### PR TITLE
Test fixtures for Feedback should be regenerated.

### DIFF
--- a/apps/feedback/fixtures/test_feedback_fixture.json
+++ b/apps/feedback/fixtures/test_feedback_fixture.json
@@ -1,1 +1,87 @@
-[{"pk": 1, "model": "auth.user", "fields": {"username": "sigurd", "first_name": "", "last_name": "", "is_active": true, "is_superuser": true, "is_staff": true, "last_login": "2013-02-08T23:29:39.022", "groups": [], "user_permissions": [], "password": "pbkdf2_sha256$10000$VSsLcOfRkSyF$QHsyzvJrRmgl8erkRI1QDKm3aiGZMKhnhORpXfFDxN0=", "email": "a@a.com", "date_joined": "2013-02-08T23:29:18.180"}}, {"pk": 1, "model": "feedback.feedbackrelation", "fields": {"answered": [], "feedback": 1, "content_type": 6, "object_id": 1}}, {"pk": 1, "model": "feedback.feedback", "fields": {"description": "Test tilbakemelding", "author": 1}}, {"pk": 1, "model": "feedback.fieldofstudyquestion", "fields": {"feedback": 1, "order": 1}}, {"pk": 1, "model": "feedback.textquestion", "fields": {"label": "Er tester bra?", "feedback": 1, "order": 10}}, {"pk": 2, "model": "feedback.textquestion", "fields": {"label": "Kan vi teste mer?", "feedback": 1, "order": 11}}, {"pk": 1, "model": "feedback.ratingquestion", "fields": {"label": "Vurder testen i poeng", "feedback": 1, "order": 20}}, {"pk": 2, "model": "feedback.ratingquestion", "fields": {"label": "Hva synes du om appen?", "feedback": 1, "order": 21}}]
+[
+    {
+        "pk": 1, 
+        "model": "auth.user", 
+        "fields": {
+            "username": "sigurd", 
+            "first_name": "", 
+            "last_name": "", 
+            "is_active": true, 
+            "is_superuser": true, 
+            "is_staff": true, 
+            "last_login": "2013-02-08T23:29:39.022", 
+            "groups": [], 
+            "user_permissions": [], 
+            "password": "pbkdf2_sha256$10000$VSsLcOfRkSyF$QHsyzvJrRmgl8erkRI1QDKm3aiGZMKhnhORpXfFDxN0=", 
+            "email": "a@a.com", 
+            "date_joined": "2013-02-08T23:29:18.180"
+        }
+    }, 
+    {
+        "pk": 1, 
+        "model": "feedback.feedbackrelation", 
+        "fields": {
+            "answered": [], 
+            "feedback": 1, 
+            "content_type": [
+                "auth", 
+                "user"
+            ], 
+            "object_id": 1
+        }
+    }, 
+    {
+        "pk": 1, 
+        "model": "feedback.feedback", 
+        "fields": {
+            "description": "Test tilbakemelding", 
+            "author": [
+                "sigurd"
+            ]
+        }
+    }, 
+    {
+        "pk": 1, 
+        "model": "feedback.fieldofstudyquestion", 
+        "fields": {
+            "feedback": 1, 
+            "order": 1
+        }
+    }, 
+    {
+        "pk": 1, 
+        "model": "feedback.textquestion", 
+        "fields": {
+            "label": "Er tester bra?", 
+            "feedback": 1, 
+            "order": 10
+        }
+    }, 
+    {
+        "pk": 2, 
+        "model": "feedback.textquestion", 
+        "fields": {
+            "label": "Kan vi teste mer?", 
+            "feedback": 1, 
+            "order": 11
+        }
+    }, 
+    {
+        "pk": 1, 
+        "model": "feedback.ratingquestion", 
+        "fields": {
+            "label": "Vurder testen i poeng", 
+            "feedback": 1, 
+            "order": 20
+        }
+    }, 
+    {
+        "pk": 2, 
+        "model": "feedback.ratingquestion", 
+        "fields": {
+            "label": "Hva synes du om appen?", 
+            "feedback": 1, 
+            "order": 21
+        }
+    }
+]


### PR DESCRIPTION
Serialization of Generic Relations are dangerous and might break the tests in the **close** future.

Regenerate the fixture `apps/feedback/fixtures/test_*` with the --natural parameter.

[1]https://docs.djangoproject.com/en/dev/ref/django-admin/#django-admin-option---natural
