### PR TITLE
Revert "removed nose, now running with standard django unit tests"

### DIFF
--- a/apps/article/tests.py
+++ b/apps/article/tests.py
@@ -5,8 +5,9 @@ from django.test import TestCase
 
 from apps.article.models import Article
 
+
 class ArticleTests(TestCase):
-    
+
     def setUp(self):
         self.logger = logging.getLogger(__name__)
         self.article = G(Article, heading="test_heading")

--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -7,13 +7,13 @@ PROJECT_SETTINGS_DIRECTORY = os.path.dirname(globals()['__file__'])
 # Root directory. Contains manage.py
 PROJECT_ROOT_DIRECTORY = os.path.join(PROJECT_SETTINGS_DIRECTORY, '../..')
 
-#TEST_RUNNER = "django_nose.NoseTestSuiteRunner"
-#NOSE_ARGS = ['--with-coverage', '--cover-package=apps']
+TEST_RUNNER = "django_nose.NoseTestSuiteRunner"
+NOSE_ARGS = ['--with-coverage', '--cover-package=apps']
 
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 
-#TEST_RUNNER = "django_nose.NoseTestSuiteRunner"
+TEST_RUNNER = "django_nose.NoseTestSuiteRunner"
 
 ADMINS = (
     ('dotKom', 'dotkom@online.ntnu.no'),
@@ -96,7 +96,7 @@ GRAPPELLI_ADMIN_TITLE = 'Onlineweb'
 
 INSTALLED_APPS = (
     # Third party dependencies
-#    'django_nose',
+    'django_nose',
     'south',
     'grappelli',
     'filebrowser',

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,8 @@ django-nose==1.0
 factory-boy==1.1.3
 fuzzywuzzy==0.1
 lettuce==0.2.10
-#nose==1.1.2
-#nose-cov==1.5
+nose==1.1.2
+nose-cov==1.5
 sure==1.0.6
 unittest2==0.5.1
 


### PR DESCRIPTION
Tesing av alle extensions feiler med standard django unit tests

det som feiler:
 filebrowser
 django_extensions
 django_auth_profile

Å kjøre noserunner er kanskje ikke optimalt?

Conflicts:
    apps/article/tests.py
