### PR TITLE
Article require image

### DIFF
--- a/apps/article/models.py
+++ b/apps/article/models.py
@@ -16,8 +16,8 @@ class Article(models.Model):
     ingress = models.TextField(_(u"ingress"))
     content = models.TextField(_(u"content"))
     image = FileBrowseField(_(u"bilde"), 
-        max_length=200, directory=IMAGE_FOLDER, blank=False,
-        extensions=IMAGE_EXTENSIONS, null=False)
+        max_length=200, directory=IMAGE_FOLDER,
+        extensions=IMAGE_EXTENSIONS, null=True)
     video_id = models.CharField(_("vimeo id"), max_length=200, blank=True)
     created_date = models.DateTimeField(_(u"opprettet-dato"), auto_now_add=True, editable=False)
     changed_date = models.DateTimeField(_(u"sist endret"), editable=False, auto_now=True)


### PR DESCRIPTION
Image is now required when creating an article. This was achieved by removing the blank=True attribute of the image-field as blank=False is standard.  
