### PR TITLE
Bumped django_dynamic_fixtures from version 1.6.4 to 1.6.5

### DIFF
--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -170,6 +170,10 @@ MESSAGE_TAGS = {messages.DEBUG: 'alert-debug',
                 messages.ERROR: 'alert-error'}
 
 
+# Not really sure what this does.
+# Has something to do with django-dynamic-fixture bumped from 1.6.4 to 1.6.5 in order to run a syncdb with mysql/postgres (OptimusCrime)
+IMPORT_DDF_MODELS = False
+
 # Remember to keep 'local' last, so it can override any setting.
 for settings_module in ['filebrowser', 'local']:  # local last
     if not os.path.exists(os.path.join(PROJECT_SETTINGS_DIRECTORY,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-grappelli==2.4.5         # Admin template set
 django-chunks                   # Chunks, or reusable key:content for templates.
 django-crispy-forms==1.2.3      # nice forms
 django-extensions==1.0.3        # nice extra commands for debugging, etc
-django-dynamic-fixture==1.6.4   # Dynamic fixtures for models
+django-dynamic-fixture==1.6.5   # Dynamic fixtures for models
 django-simple-captcha==0.3.7    # Simple captcha
 
 #test tools


### PR DESCRIPTION
Running ow4 under postgres was not possible with django_dynamic_fixtures version 1.6.4.

Not really sure why this is fixed as the changelog does not mention any bugfixes concerning this. However, it's working now.

Also added an entry in the settings. Not sure what it does but the site itself is unchanged when setting it to False.
