### PR TITLE
Removed a section in core.less

### DIFF
--- a/static/less/core.less
+++ b/static/less/core.less
@@ -80,16 +80,7 @@ span.dates {
             }
         }
     }
-    
-/* Careeropportunities title goes left */
-    #careeropportunities img, h4, p  {
-        display: block;
-        margin-left: auto;
-        margin-right: auto;
-        text-align: center;
-    }
 }
-
 
 /* Globals
 -------------------------------------------------- */


### PR DESCRIPTION
It seemed to have no function and was sort of out of place in the file. Removed because it implied text-align: center; to all p-tags in mobile viewing and thus fucked up formatting of articles, front page and probably other things. 

@lizter should make sure I didn't miss any intended use of the section before pulling as he authored that part of the file in the first place. 
