### PR TITLE
Making Grappelli admin title link back to onlineweb root

### DIFF
--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -92,7 +92,7 @@ TEMPLATE_DIRS = (
 )
 
 # Grappelli settings
-GRAPPELLI_ADMIN_TITLE = 'Onlineweb'
+GRAPPELLI_ADMIN_TITLE = '<a href="/">Onlineweb</a>'
 
 INSTALLED_APPS = (
     # Third party dependencies


### PR DESCRIPTION
Adding link back to / from Grappelli admin title.
