### PR TITLE
Fixed non-sticky footer on low-height content and high-res

### DIFF
--- a/files/static/less/core.less
+++ b/files/static/less/core.less
@@ -23,6 +23,7 @@
 
 html {
     overflow-x: hidden;
+    background: #333;
 }
 
 body {


### PR DESCRIPTION
Fixes #211 
Footer color now extends infinite on low-height content and high-res screens.
