### PR TITLE
Improved flow in managing rulebundles in events

### DIFF
--- a/apps/events/admin.py
+++ b/apps/events/admin.py
@@ -58,7 +58,8 @@ class AttendanceEventInline(admin.StackedInline):
     model = AttendanceEvent
     max_num = 1
     extra = 0
-
+    filter_horizontal = ('rule_bundles',)
+    
 
 class EventAdmin(admin.ModelAdmin):
     inlines = (AttendanceEventInline, FeedbackRelationInline, CompanyInline)


### PR DESCRIPTION
Small fix that improves managing rulebundles in a attendance event. Lets you uncheck added rulebundles
