### PR TITLE
Added a slight hack to avoid a jQuery browser specific bug

### DIFF
--- a/templates/events/index.html
+++ b/templates/events/index.html
@@ -125,6 +125,12 @@
         filters.query = $(this).val();
         filters.search();
       });
+      
+      // This is a slight hack to avoid a difficult bug in jQuery where some browsers tend to preserve checkbox states
+      // without them being domready.	
+      $(document).ready(function () {
+        $('#future').prop('checked', true); 
+      });
 
       $('#future').on('click', function () {
         filters.future = !filters.future;


### PR DESCRIPTION
Some browsers tend to preserve checkbox states on navigate back. Found some bug reports stating that the checkbox states were not domready and would be asserted to checked, even though they were not.

This fix forces future filter to be forced on domready and thus works on navback.

Fixes #345 
