### PR TITLE
Removed Pillow from requirements. Upgraded django-simple-captcha to 0.4....

### DIFF
--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -123,6 +123,9 @@ TEMPLATE_DIRS = (
 PIZZA_GROUP = 'dotkom'
 PIZZA_ADMIN_GROUP = 'pizzaadmin'
 
+# Captcha settings
+CAPTCHA_NOISE_FUNCTIONS = None
+
 # Grappelli settings
 GRAPPELLI_ADMIN_TITLE = '<a href="/">Onlineweb</a>'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Django==1.5.4
 South==0.7.5                    # DB migration tool. 
-Pillow==2.0.0                   # pillow
 django-tastypie==0.9.15         # API
 mimeparse==0.1.3
 python-dateutil==1.5
@@ -17,7 +16,7 @@ django-chunks                   # Chunks, or reusable key:content for templates.
 django-crispy-forms==1.4.0      # nice forms
 django-extensions==1.0.3        # nice extra commands for debugging, etc
 django-dynamic-fixture==1.6.5   # Dynamic fixtures for models
-django-simple-captcha==0.3.7    # Simple captcha
+django-simple-captcha==0.4.0    # Simple captcha
 django_compressor==1.3
 django-watson==1.1.2
 APScheduler==2.1.1              # Scheduler

--- a/vagrantbootstrap.sh
+++ b/vagrantbootstrap.sh
@@ -82,6 +82,11 @@ function install_onlineweb_requirements() {
     workon onlineweb
     cd /vagrant
     progress pip install -r requirements.txt
+    echo "uninstalling PIP and Pillow to fix dependency crashes"
+    progress pip uninstall PIL -y
+    progress pip uninstall Pillow -y
+    echo "installing Pillow 2.0.0"
+    progress pip install Pillow==2.0.0
 }
 
 function install_lessc() {


### PR DESCRIPTION
...0. Edited vagrantbootstrap.sh

Fixes #378 #383 

The reason for these issues are the new django-wiki requirement, which installs PIL after Pillow, with no jpeg and png decoders, thereby making rendering of those image types impossible. The fix for this is to uninstall PIL and Pillow and reinstalling Pillow.

Captcha now displays normal text.
Removed Pillow from requirements.txt.

Provisioning script vagrantbootstrap.sh now installs requirements as usual, but removes PIL and Pillow after install.
It then reinstalls Pillow 2.0.0, which compiles with jpeg and png decoders.

For people not running vagrant:
After running pip install -r requirements, you have to run pip uninstall PIL, pip uninstall Pillow, pip install Pillow==2.0.0

Upgraded django-simple-captcha to 0.4.0
