### PR TITLE
Add CSS rules to prevent dotted outlines on links in Firefox.

### DIFF
--- a/files/static/less/eventwidget.less
+++ b/files/static/less/eventwidget.less
@@ -130,14 +130,5 @@ section#events {
             color: #666;
         }
     }
-
-
-    @media (max-width: 991px) {
-        ul.event-list:nth-child(1) {
-            li:last-child {
-                border-bottom: 1px solid #e0e0e0;
-            }
-        }
-    }
 }
 


### PR DESCRIPTION
Fixes #467 
