### PR TITLE
Removed marks API endpoints.

### DIFF
--- a/apps/api/v0/urls.py
+++ b/apps/api/v0/urls.py
@@ -26,10 +26,10 @@ v0_api.register(ArticleResource())
 v0_api.register(ArticleLatestResource())
 
 # marks
-v0_api.register(MarkResource())
-v0_api.register(EntryResource())
-v0_api.register(MyMarksResource())
-v0_api.register(MyActiveMarksResource())
+#v0_api.register(MarkResource())
+#v0_api.register(EntryResource())
+#v0_api.register(MyMarksResource())
+#v0_api.register(MyActiveMarksResource())
 
 # offline
 v0_api.register(IssueResource())


### PR DESCRIPTION
Marks has no need to be an endpoint in the current version of the api.

We just remove all the endpoints, but the code is still there, in case we want to use this in the future.
