### PR TITLE
Fixed required length of fields in events

### DIFF
--- a/apps/events/admin.py
+++ b/apps/events/admin.py
@@ -91,9 +91,7 @@ class EventAdmin(admin.ModelAdmin):
         form = super(EventAdmin, self).get_form(request, obj, **kwargs)
         form.base_fields['ingress_short'].validators=[validators.MinLengthValidator(50)]
         form.base_fields['ingress'].validators=[validators.MinLengthValidator(75)]
-        form.base_fields['description'].validators=[
-                                                    validators.MinLengthValidator(140),
-                                                    ]
+        form.base_fields['description'].validators=[validators.MinLengthValidator(140)]
         return form
 
 admin.site.register(Event, EventAdmin)


### PR DESCRIPTION
New lengths are 50, 75 and 140 for short ingress, ingress and content respectively
