### PR TITLE
Setting BooleanField default value to False

### DIFF
--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -480,7 +480,7 @@ class Attendee(models.Model):
     user = models.ForeignKey(User)
 
     timestamp = models.DateTimeField(auto_now_add=True, editable=False)
-    attended = models.BooleanField(_(u'var tilstede'))
+    attended = models.BooleanField(_(u'var tilstede'), default=False)
 
     def __unicode__(self):
         return self.user.get_full_name()


### PR DESCRIPTION
This was changed in Django 1.6 to default to None instead of False
