### PR TITLE
Fix cookies expiring when closing the browser

### DIFF
--- a/apps/authentication/forms.py
+++ b/apps/authentication/forms.py
@@ -36,7 +36,6 @@ class LoginForm(forms.Form):
             return False
         if self.is_valid():
             auth.login(request, self.user)
-            request.session.set_expiry(0)
             return True
         return False
 

--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -52,6 +52,9 @@ USE_TZ = True
 DATETIME_FORMAT = 'N j, Y, H:i'
 SECRET_KEY = 'override-this-in-local.py'
 
+# Session cookie expires after one year
+SESSION_COOKIE_AGE = 31540000
+
 # Override this in local if you need to :)
 BASE_URL = 'https://online.ntnu.no'
 


### PR DESCRIPTION
Will now expire after one year. Fixes #706
