### PR TITLE
Mark rules acception restrictions one-way-ticket

### DIFF
--- a/apps/authentication/models.py
+++ b/apps/authentication/models.py
@@ -273,5 +273,11 @@ class Position(models.Model):
         verbose_name_plural = _(u'posisjoner')
         ordering = (u'user',)
 
+# Static method for resetting all users mark rules accepted field to false due to changes in mark rules
+def reset_marks_acceptance():
+    for user in OnlineUser.objects.all():
+        user.mark_rules = False
+        user.save()
+
 # Register OnlineUser in watson index for searching
 watson.register(OnlineUser)

--- a/apps/profiles/views.py
+++ b/apps/profiles/views.py
@@ -208,9 +208,8 @@ def update_mark_rules(request):
                 request.user.mark_rules = True
                 request.user.save()
             else:
-                return_status = json.dumps({'message': _(u"Du har valgt å ikke akseptere prikkereglene.")})
-                request.user.mark_rules = False
-                request.user.save()
+                return_status = json.dumps({'message': _(u"Du kan ikke endre din godkjenning av prikkereglene.")})
+		return HttpResponse(status=403, content=return_status)
 
             return HttpResponse(status=212, content=return_status)
         return HttpResponse(status=405)

--- a/files/static/js/profiles.js
+++ b/files/static/js/profiles.js
@@ -73,16 +73,14 @@ $(document).ready(function() {
 
         if(!checked) {
             $(".marks").removeClass("off").addClass("on");
-            updateMarkRules(true);
-        }
-        else {
-            $(".marks").removeClass("on").addClass("off");
-            updateMarkRules(false);
+            updateMarkRules();
         }
     }
 
     $(".marks").mouseup(function(e) {
-        performMarkRulesClick();
+	if (!($("#marks-checkbox").is(':checked'))) {
+            performMarkRulesClick();
+        }
     });
 
     $("#marks-checkbox").click(function(e){
@@ -90,16 +88,17 @@ $(document).ready(function() {
         e.preventDefault();
     });
 
-    var updateMarkRules = function(accepted) {
+    var updateMarkRules = function() {
         var utils = new Utils();
 
         $.ajax({
             method: 'POST',
             url: 'update_mark_rules/',
-            data: { 'rules_accepted': accepted },
+            data: { 'rules_accepted': true },
             success: function(res) {
                 res = jQuery.parseJSON(res);
                 utils.setStatusMessage(res['message'], 'alert-success');
+                $(".marks").attr('disabled', true);
             },
             error: function() {
                 utils.setStatusMessage('En uventet error ble oppdaget. Kontakt dotkom@online.ntnu.no for assistanse.', 'alert-danger');

--- a/templates/profiles/marks.html
+++ b/templates/profiles/marks.html
@@ -6,8 +6,9 @@
 <div class="row-space"></div>
 <div class="row">
     <div class="col-md-12">
-        <button class="marks {% ifequal mark_rules_accepted True %}on{% else %}off{% endifequal %}">
-            <input id="marks-checkbox" type="checkbox" {% ifequal mark_rules_accepted True %}checked="checked"{% endifequal %}>
+	<p><strong>NB!</strong> Godkjennig av prikkereglene er endelig, med mindre endringer i reglene forekommer.</p>
+        <button class="marks {% ifequal mark_rules_accepted True %}on{% else %}off{% endifequal %}" {% ifequal mark_rules_accepted True %}disabled{% endifequal %}>
+            <input id="marks-checkbox" type="checkbox" {% ifequal mark_rules_accepted True %}checked{% endifequal %}>
         </button>
     </div>
 </div>


### PR DESCRIPTION
Marks can now only be set once. Also added static method for resetting marks on all users in auth.models for future dashboard use ( apps.authentication.models.reset_marks_acceptance() )

Fixes #675 
