### PR TITLE
Remove simplejson in favor of built-in json

### DIFF
--- a/apps/feedback/views.py
+++ b/apps/feedback/views.py
@@ -8,10 +8,11 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required
-from django.utils import simplejson
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import ugettext_lazy as _
 from django.utils.safestring import SafeString
+
+import json
 
 from apps.feedback.models import FeedbackRelation, FieldOfStudyAnswer, RATING_CHOICES, TextAnswer, RegisterToken
 from apps.feedback.forms import create_answer_forms
@@ -117,7 +118,7 @@ def get_chart_data(request, applabel, appmodel, object_id, feedback_id):
     answer_collection['replies']['titles'] = rating_titles
     answer_collection['replies']['fos'] = answer_count.items()
    
-    return HttpResponse(simplejson.dumps(answer_collection), mimetype='application/json')
+    return HttpResponse(json.dumps(answer_collection), mimetype='application/json')
 
 
 @staff_member_required

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ markdown2==2.2.0                # textarea text formatting
 psycopg2                        # Postgres adapter
 pytz                            # Timezone lib. Obsolete?
 gunicorn==18.0
-simplejson==3.3.1
 icalendar==3.6.1
 
 # third party deps

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,12 +1,12 @@
 # -*- coding: utf8 -*-
 from datetime import datetime, date
-import simplejson
+import json
 
 from django.db.models.query import QuerySet
 from django.db import models
 
 
-class JsonHelper(simplejson.JSONEncoder):
+class JsonHelper(json.JSONEncoder):
 
     def default(self, obj):
         if isinstance(obj, datetime):
@@ -21,4 +21,4 @@ class JsonHelper(simplejson.JSONEncoder):
         elif isinstance(obj, QuerySet):
             return list(obj)
 
-        return simplejson.JSONEncoder.default(self, obj)
+        return json.JSONEncoder.default(self, obj)


### PR DESCRIPTION
Fixes #668 

We're still going to get some deprecation warnings until both sorl-thumbnail and django-compressor release a new version. 
