### PR TITLE
Add .editorconfig to project with some default values

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-indent_style = tab
+indent_style = space
 end_of_line = lf
 indent_size = 4
 charset = utf-8


### PR DESCRIPTION
... with some not-very-controversial values. Fixes #807 

'indent_style = tab' and 'indent_size = 4' since the majority of the code base uses it. 
