### PR TITLE
Added CS:S game-server to resources

### DIFF
--- a/templates/resourcecenter/index.html
+++ b/templates/resourcecenter/index.html
@@ -93,7 +93,6 @@ Ressurssenter - Online
 						eller koble til <a href="steam://connect/css.online.ntnu.no:27015">direkte.</a>
 					</p>
 				</div>
-				</div>
 			</div>
 		</div>
 		<div class="row">


### PR DESCRIPTION
Changed the "spillservere" resource to reflect the new CS:S game-server, and reworded the general intro of the resource because you cannot actually see "Hovedbygget" in the new minecraft server.
