### PR TITLE
Display registration end date after regisration has opened

### DIFF
--- a/templates/events/details.html
+++ b/templates/events/details.html
@@ -98,13 +98,23 @@
                                         {% endif %}
                                     </div>
                                     <div class="col-xs-12 col-sm-4 col-md-4">
-                                        <div class="event-hero-title">Påmeldingsstart</div>
-                                        <div class="event-hero-large-text">
+                                         {% if attendance_event.registration_start > now %}
+                                            <div class="event-hero-title">Påmeldingsstart</div>
                                             <div class="event-hero-large-text">
-                                                <span class="break">{{ attendance_event.registration_start|date:"H.i" }}</span>
-                                                <span class="date-small">{{ attendance_event.registration_start|date:"d. M Y" }}</span>
+                                                <div class="event-hero-large-text">
+                                                    <span class="break">{{ attendance_event.registration_start|date:"H.i" }}</span>
+                                                    <span class="date-small">{{ attendance_event.registration_start|date:"d. M Y" }}</span>
+                                                </div>
                                             </div>
-                                        </div>
+                                        {% else %}
+                                            <div class="event-hero-title">Påmeldingsslutt</div>
+                                            <div class="event-hero-large-text">
+                                                <div class="event-hero-large-text">
+                                                    <span class="break">{{ attendance_event.registration_end|date:"H.i" }}</span>
+                                                    <span class="date-small">{{ attendance_event.registration_end|date:"d. M Y" }}</span>
+                                                </div>
+                                            </div>
+                                        {% endif %}
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Changes "påmeldingsstart" to "påmeldingsslutt" and registration end dates, after registration start date has passed.
Fixes #871 
