### PR TITLE
Genfors - Add 10 sec cache on stats queries and randomize votes in secret mode

### DIFF
--- a/apps/genfors/views.py
+++ b/apps/genfors/views.py
@@ -489,14 +489,15 @@ def api_user(request):
                         genfors["question"]["votes"] = [[unicode(v.voter.anonymousvoter), v.answer] for v in votes]
                     elif q.question_type == 1:
                         genfors["question"]["votes"] = [[unicode(v.voter.anonymousvoter), v.answer.description] if v.answer else [unicode(v.voter.anonymousvoter), "Blankt"] for v in votes]
+                    
+                    # Shuffle the order of votes so you cannot infer who cast what vote when there are few voters left
+                    random.shuffle(genfors['question']['votes'])
+
                 else:
                     if q.question_type == 0:
                         genfors["question"]["votes"] = [[unicode(v.voter.registeredvoter), v.answer] for v in votes]
                     elif q.question_type == 1:
                         genfors["question"]["votes"] = [[unicode(v.voter.registeredvoter), v.answer.description] if v.answer else [unicode(v.voter.registeredvoter), "Blankt"] for v in votes]
-
-                # Shuffle the order of votes so you cannot infer who cast what vote when there are few voters left
-                random.shuffle(genfors['question']['votes'])
         else:
             genfors["question"] = None
 

--- a/files/static/js/genfors.js
+++ b/files/static/js/genfors.js
@@ -129,5 +129,5 @@ Genfors = (function () {
 
 $(document).ready(function () {
     Genfors.vote.bind_buttons();
-    setInterval(Genfors.update, 15000);
+    setInterval(Genfors.update, 10000);
 });


### PR DESCRIPTION
Fixes #827 

Also adds 10 second per view cache on the user api, which should greatly reduce server load as more and more votes get cast.
