### PR TITLE
Change Wiki nav link to /wiki/

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -39,7 +39,7 @@
                   <li><a href="{% url 'events_index' %}">Arkiv</a></li>
                   <li><a href="{% url 'careeropportunity_index' %}">Karrieremuligheter</a></li>
                   <li><a href="{% url 'resourcecenter_index' %}">Ressurser</a></li>
-                  <li><a href="https://wiki.online.ntnu.no/projects/online/wiki">Wiki</a></li>
+                  <li><a href="/wiki/">Wiki</a></li>
                 </ul>
 
                 <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
Just change from wiki.online.ntnu.no to /wiki/. No need to let google keep on seeing wiki.online.ntnu.no when we have permanent redirects in place for that subdomain.
