### PR TITLE
Fix issue where e-mail fields would float into eachother

### DIFF
--- a/files/static/less/profiles.less
+++ b/files/static/less/profiles.less
@@ -185,6 +185,11 @@ textarea {
   }
 }
 
+.email-row div p {
+  position: relative;
+  top: 6px;
+}
+
 #mail-settings {
   div.emails {
     div.row {

--- a/templates/profiles/mail_settings.html
+++ b/templates/profiles/mail_settings.html
@@ -9,8 +9,8 @@
     <div class="col-xs-12 col-sm-12 col-md-10">
         {% for email in user.get_emails %}
         <div class="row email-row">
-            <div class="col-sm-8 col-md-8">
-                <span class="email">{{ email }}</span>
+            <div class="col-xs-4 col-sm-8 col-md-8">
+                <p>{{ email }}</p>
             </div>
             <div class="col-sm-4 col-md-4">
                 <div class="btn-group pull-right">


### PR DESCRIPTION
On mobile devices, e-mail fields would float into eachother.
The text of e-mail fields are now also verticaly aligned.
Fixes #617 
