### PR TITLE
Aligned sponsor logo properly

### DIFF
--- a/files/static/less/navbar.less
+++ b/files/static/less/navbar.less
@@ -146,7 +146,7 @@ svg, rect {
         color: #fff;
         font-size: 9px;
         opacity: 0.3;
-        padding: 3px 0 0 13px;
+        padding: 3px 0 0 16px;
         position: relative;
         right: -5px;
     }


### PR DESCRIPTION
Aligns sponsor logo with the text under.
before/after
![image](https://cloud.githubusercontent.com/assets/3536134/5845204/63dfa412-a1ba-11e4-8d20-2e72124382c6.png)
