### PR TITLE
Add django-sekizai css/js blocks to the base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,5 @@
 {% load compress %}
+{% load sekizai_tags %}
 <!DOCTYPE html>
 <html>
 <head>
@@ -13,6 +14,7 @@
         <link rel="stylesheet" type="text/less" href="{{ STATIC_URL }}less/core.less">
         {% endcompress %}
     {% endblock %}
+    {% render_block "css" %}
     {% block apple-webapp %}{% endblock %}
 </head>
 <body>
@@ -199,6 +201,8 @@
         <script src="{{ STATIC_URL }}js/libs/konami.js"></script>
         <script src="{{ STATIC_URL }}js/christmas.js"></script>
     {% endblock %}
+
+    {% render_block "js" %}
 
     {% if GOOGLE_ANALYTICS_KEY %}
         <script type="text/javascript">

--- a/templates/wiki/base.html
+++ b/templates/wiki/base.html
@@ -11,15 +11,12 @@
 
 {% block js %}
     {{ block.super }}
-    <script type="text/javascript" src="/static/wiki/js/editor.js"></script>
-    <script type="text/javascript" src="/static/wiki/markitup/frontend.init.js"></script>
-    <script type="text/javascript" src="/static/wiki/markitup/jquery.markitup.js"></script>
-    <script type="text/javascript" src="/static/wiki/markitup/sets/frontend/set.js"></script>
+    {% compress js %}
+    <script src="{{ STATIC_URL }}wiki/js/core.js"></script>
+    {% endcompress %}
 {% endblock %}
 
 {% block styles %}
-    <link rel="stylesheet" media="all" href="/static/wiki/markitup/skins/simple/style.css" />
-    <link rel="stylesheet" media="all" href="/static/wiki/markitup/sets/frontend/style.css" />
     {{ block.super }}
     {% compress css %}
         <link rel="stylesheet" type="text/less" href="{{ STATIC_URL }}less/wiki.less" />


### PR DESCRIPTION
This way we will always include the necessary django-wiki static files. See #1032 for some more info. 

Fixes #1032
Fixes #990
