### PR TITLE
Use past tense when date is in past

### DIFF
--- a/templates/events/details.html
+++ b/templates/events/details.html
@@ -168,9 +168,14 @@
 
 
                 {% if attendance_event %}
-                    <p class="help-text" style="margin-top:20px">
-                    Avmeldingsfristen {% if attendance_event.unattend_deadline > now %} er {% else %} var {% endif %} 
-                    {{ attendance_event.unattend_deadline|date:"H.i d. M Y" }}</p>
+                    <p class="help-text" style="margin-top:20px">Avmeldingsfristen 
+                        {% if attendance_event.unattend_deadline > now %}
+                            er
+                        {% else %}
+                            var
+                        {% endif %}
+                        {{ attendance_event.unattend_deadline|date:"H.i d. M Y" }}
+                    </p>
                 {% endif %}
             </div>
 
@@ -179,7 +184,14 @@
                     <div class="col-md-12">
                         <div class="event-access">
                             <p class="access-title">
-                            Dette arrangementet {% if attendance_event.registration_end > now %}er{% else %}var{% endif %} åpent for</p>
+                                Dette arrangementet
+                                {% if attendance_event.registration_end > now %}
+                                    er
+                                {% else %}
+                                    var
+                                {% endif %}
+                                åpent for
+                            </p>
                             <div class="rules">
 
                                 {% if attendance_event.guest_attendance %}


### PR DESCRIPTION
Changes "er" to "var" everywhere when the event registration date has passed, or event unregistration date has passed.
