### PR TITLE
Removed uneeded wiki padding-top

### DIFF
--- a/files/static/less/wiki.less
+++ b/files/static/less/wiki.less
@@ -10,7 +10,6 @@
         z-index: 1050;
     }
 
-    padding: 87px 0 0;
     .page-header {
         margin-top: 0px;
     }


### PR DESCRIPTION
This is also fucking up the padding on https://online.ntnu.no/wiki/ (padding above 'Wiki' link), but this is actually caused by an issue in django-wiki. 
