### PR TITLE
Fix highlighting of menu elements when viewing subpages

### DIFF
--- a/files/static/js/init.js
+++ b/files/static/js/init.js
@@ -133,7 +133,12 @@ $(function() {
 
     /* Menu element change
     --------------------------------------------------------------------------------- */
-    $(".mn-nav a[href='"+window.location.pathname+"']").parent().addClass('active');
+    var paths = window.location.pathname.split('/');
+    var activeTab = paths[1];
+    // Making sure that events don't highlight the archive menu
+    if(activeTab !== 'events' || paths.length === 3) {
+        $(".mn-nav a[href='/"+activeTab+"/']").parent().addClass('active');
+    }
 
     switch (window.location.pathname) {
         case "/article/archive":


### PR DESCRIPTION
I don't particularly like the events check, but afaik it's the only subpage that has no relevance to the menu element it would appear under. 
