### PR TITLE
Use date.today as default for started_date

### DIFF
--- a/apps/authentication/migrations/0003_auto_20150311_2105.py
+++ b/apps/authentication/migrations/0003_auto_20150311_2105.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('authentication', '0002_auto_20150304_2211'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='onlineuser',
+            name='started_date',
+            field=models.DateField(default=datetime.date.today, verbose_name='startet studie'),
+            preserve_default=True,
+        ),
+    ]

--- a/apps/authentication/models.py
+++ b/apps/authentication/models.py
@@ -88,7 +88,7 @@ class OnlineUser(AbstractUser):
     
     # Online related fields
     field_of_study = models.SmallIntegerField(_(u"studieretning"), choices=FIELD_OF_STUDY_CHOICES, default=0)
-    started_date = models.DateField(_(u"startet studie"), default=timezone.now().date)
+    started_date = models.DateField(_(u"startet studie"), default=datetime.date.today)
     compiled = models.BooleanField(_(u"kompilert"), default=False)
 
     # Infomail


### PR DESCRIPTION
Django can't serialize timezone().now().date so let's use date.today instead
