### PR TITLE
Remove unused port forward from Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,7 +36,6 @@ Vagrant.configure('2') do |config|
             onlineweb_config.vm.box_url = 'http://files.vagrantup.com/precise32.box'
             
             onlineweb_config.vm.network :forwarded_port, guest: 8000, host: 8001
-            onlineweb_config.vm.network :forwarded_port, guest: 80, host: 8080
             onlineweb_config.vm.network :forwarded_port, guest: 443, host: 8443
 
             onlineweb_config.ssh.forward_agent = true


### PR DESCRIPTION
This has caused problems for me, and I see no reason for forwarding this port when we're always doing `runserver 0.0.0.0:8001` anyways. (Why :8001 is beyond me :confused:)
