### PR TITLE
Load firstof from future to avoid XSS attacks on Django 1.7

### DIFF
--- a/templates/profiles/users.html
+++ b/templates/profiles/users.html
@@ -2,6 +2,7 @@
 {% load gravatar_url_resolver %}
 {% load crispy_forms_tags %}
 {% load compress %}
+{% load firstof from future %}
 
 
 {% block styles %}

--- a/templates/profiles/view_profile.html
+++ b/templates/profiles/view_profile.html
@@ -2,6 +2,8 @@
 {% load gravatar_url_resolver %}
 {% load crispy_forms_tags %}
 {% load compress %}
+{% load firstof from future %}
+
 {% block styles %}
     {{ block.super }}
     {% compress css %}


### PR DESCRIPTION
> Hei dotKom!
> 
> På grunn av for dårlig sanitering av input på Onlineweb kan en ondsinnet bruker få en annen bruker til å kjøre kode i sin nettleser. Vedlagt er et proof-of-concept som legger til en e-postadresse i profilen til offeret. Videre kunne jeg ha lagt inn at e-postadressen som blir lagt til også blir satt som primær, da ville angriperen kunne tilbakestilt passordet og tatt over brukeren. Eventuelt kan sikkerhetshullet utnyttes til å melde av brukere på arrangementer.
> 
> Sikkerhetshullet fungerer slik at angriperen taster inn følgende i feltene på "Personlig informasjon" i sin egen profil:
> Nickname: _/w=window;o="onload";eval(address.innerHTML)'
> Telefonnummer: <img src onerror='/_
> Adresse: csrfSafeMethod=function(){};w[o]=function(){$.post("/profile/email/",{new_email:"slem@bruker.no"})}
> 
> Det neste steget i angrepet er å få offeret/ofrene til å besøke angriperens profil. Dette kan gjøres med en redirect fra en annen side eller lignende. Angrepet er bygget opp av flere saniteringsfeil.
> 
> Proof-of-concept: Ved å besøke min bruker vil koden over kjøres. Etter at profilen er besøkt vil dere se at "slem@bruker.no" er lagt til i listen over dine e-poster.
> 
> Med vennlig hilsen,
> Michael McMillan
