### PR TITLE
Strip '.' from tag names to fix error

### DIFF
--- a/apps/article/admin.py
+++ b/apps/article/admin.py
@@ -18,6 +18,7 @@ class TagAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         obj.changed_by = request.user
         if not change:
+            obj.name = obj.name.replace('.', '')
             obj.created_by = request.user
         obj.save()
 


### PR DESCRIPTION
Fixes error where articles crashed if tag name had punctuation. 
Fix #1052 
