### PR TITLE
Fixed #1058

### DIFF
--- a/templates/events/search.html
+++ b/templates/events/search.html
@@ -41,13 +41,14 @@
 
       <div class="meta">
         {% if event.is_attendance_event %}
+          {% ifequal event.attendance_event.number_of_seats_taken event.attendance_event.max_capacity %}
+		  <div class="col-md-3">
+		    <p>Venteliste: {{ event.attendance_event.number_on_waitlist }} </p>
+		  </div>
+		  {% else %}
           <div class="col-md-3">
             <p>Påmeldte: {{ event.attendance_event.number_of_seats_taken }} / {{ event.attendance_event.max_capacity }}</p>
           </div>
-          {% ifequal event.attendance_event.number_of_seats_taken event.attendance_event.max_capacity %}
-            <div class="col-md-3">
-              <p>Venteliste: {{ event.attendance_event.number_on_waitlist }} </p>
-            </div>
           {% endifequal %}
           <div class="col-md-3">
             <p>Sted: {{ event.location }}</p>


### PR DESCRIPTION
Replaced "Påmeldinger" with "Venteliste" when the event is full. The place column is still showing because I think some people are using it, and now the issue is solved, so why not.
