### PR TITLE
Fixes bio field width on profile-view

### DIFF
--- a/templates/profiles/view_profile.html
+++ b/templates/profiles/view_profile.html
@@ -120,7 +120,7 @@
                             </div>
                         {% endif %}
                         </div>
-                        <div class="col-md-4" id="bio">
+                        <div class="col-md-12" id="bio">
                             <b>Bio</b><br />
                             {% if user_profile.bio %}
                                 {{ user_profile.bio|striptags }}


### PR DESCRIPTION
Fixes #1229 

Small fix to width of bio field in profile view, now uses full width as opposed to a third of it.
