### PR TITLE
Add help and link plugins for django-wiki

### DIFF
--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -260,7 +260,6 @@ INSTALLED_APPS = (
     #Wiki
     'wiki',
     'wiki.plugins.attachments',
-    'wiki.plugins.notifications',
     'wiki.plugins.images',
     'wiki.plugins.macros',
     'wiki.plugins.help',


### PR DESCRIPTION
Help is just a simple overview of markdown.
Link is a helper plugin for creating wiki links. ex: `[Article](wiki:/article)`

Removed wiki notifications.
