### PR TITLE
POC for Django-taggit (on ResponsiveImage).

### DIFF
--- a/apps/gallery/dashboard/forms.py
+++ b/apps/gallery/dashboard/forms.py
@@ -15,5 +15,10 @@ class ResponsiveImageForm(forms.ModelForm):
         model = ResponsiveImage
         fields = ['name', 'description', 'tags']
         widgets = {
-            'tags': TagWidget(attrs={'placeholder': u'Eksempel: kontoret, kjelleren, åre'})
+            'tags': TagWidget(attrs={
+                'placeholder': u'Eksempel: kontoret, kjelleren, åre',
+            })
+        }
+        labels = {
+            'tags': u'Tags'
         }

--- a/apps/gallery/dashboard/forms.py
+++ b/apps/gallery/dashboard/forms.py
@@ -4,6 +4,8 @@
 
 from django import forms
 
+from taggit.forms import TagWidget
+
 from apps.gallery.models import ResponsiveImage
 
 
@@ -11,4 +13,7 @@ class ResponsiveImageForm(forms.ModelForm):
 
     class Meta(object):
         model = ResponsiveImage
-        fields = ['name', 'description']
+        fields = ['name', 'description', 'tags']
+        widgets = {
+            'tags': TagWidget(attrs={'placeholder': u'Eksempel: kontoret, kjelleren, åre'})
+        }

--- a/apps/gallery/dashboard/views.py
+++ b/apps/gallery/dashboard/views.py
@@ -6,9 +6,12 @@ from logging import getLogger
 
 from django.core.urlresolvers import reverse
 from django.contrib import messages
+from django.contrib.contenttypes.models import ContentType
 from django.http import HttpResponseBadRequest, HttpResponseNotAllowed
 from django.shortcuts import redirect
 from django.views.generic import DetailView, UpdateView, ListView, TemplateView
+
+from taggit.models import TaggedItem
 
 
 from apps.dashboard.tools import DashboardPermissionMixin
@@ -55,6 +58,9 @@ class GalleryIndex(DashboardPermissionMixin, ListView):
 
         # Add query filters and some statistics on disk usage
         context['years'] = years
+        context['tags'] = [tag.tag.name for tag in TaggedItem.objects.filter(
+            content_type=ContentType.objects.get_for_model(ResponsiveImage)
+        ).order_by('tag__name')]
         context['disk_usage'] = humanize_size(total_disk_usage)
 
         return context

--- a/apps/gallery/forms.py
+++ b/apps/gallery/forms.py
@@ -34,8 +34,7 @@ def _get_correct_file_name(uploaded_file):
 
     file_name, file_extension = os.path.splitext(uploaded_file.name)
 
-    # PIL can actually not recognize that JPG is a JPEG, fuck all the things and hours of debugging PIL source code to find this out
-    if file_extension.upper() == ".JPG":
-        file_extension = ".JPEG"
+    if file_extension.lower() == ".jpg":
+        file_extension = ".jpeg"
 
     return "{0}{1}".format(file_name, file_extension)

--- a/apps/gallery/migrations/0009_responsiveimage_tags.py
+++ b/apps/gallery/migrations/0009_responsiveimage_tags.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import taggit.managers
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taggit', '0002_auto_20150616_2121'),
+        ('gallery', '0008_auto_20151024_1845'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='responsiveimage',
+            name='tags',
+            field=taggit.managers.TaggableManager(to='taggit.Tag', through='taggit.TaggedItem', help_text='A comma-separated list of tags.', verbose_name='Tags'),
+        ),
+    ]

--- a/apps/gallery/migrations/0010_auto_20151031_0348.py
+++ b/apps/gallery/migrations/0010_auto_20151031_0348.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import taggit.managers
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gallery', '0009_responsiveimage_tags'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='responsiveimage',
+            name='tags',
+            field=taggit.managers.TaggableManager(to='taggit.Tag', through='taggit.TaggedItem', help_text=b'En komma eller mellomrom-separert liste med tags.', verbose_name='Tags'),
+        ),
+    ]

--- a/apps/gallery/models.py
+++ b/apps/gallery/models.py
@@ -10,6 +10,8 @@ from django.db import models
 from django.db.models.signals import post_delete
 from django.utils.translation import ugettext_lazy as _
 
+from taggit.managers import TaggableManager
+
 from apps.gallery import settings as gallery_settings
 from utils.helpers import humanize_size
 
@@ -71,6 +73,8 @@ class ResponsiveImage(models.Model):
     image_sm = models.ImageField(u'SM Bilde', upload_to=gallery_settings.RESPONSIVE_IMAGES_PATH)
     image_xs = models.ImageField(u'XS Bilde', upload_to=gallery_settings.RESPONSIVE_IMAGES_PATH)
     thumbnail = models.ImageField(u'Thumbnail', upload_to=gallery_settings.RESPONSIVE_THUMBNAIL_PATH)
+
+    tags = TaggableManager()
 
     def __str__(self):
         """

--- a/apps/gallery/models.py
+++ b/apps/gallery/models.py
@@ -74,7 +74,7 @@ class ResponsiveImage(models.Model):
     image_xs = models.ImageField(u'XS Bilde', upload_to=gallery_settings.RESPONSIVE_IMAGES_PATH)
     thumbnail = models.ImageField(u'Thumbnail', upload_to=gallery_settings.RESPONSIVE_THUMBNAIL_PATH)
 
-    tags = TaggableManager()
+    tags = TaggableManager(help_text="En komma eller mellomrom-separert liste med tags.")
 
     def __str__(self):
         """

--- a/apps/gallery/serializers.py
+++ b/apps/gallery/serializers.py
@@ -3,11 +3,14 @@
 # Created by 'myth' on 10/18/15
 
 from rest_framework import serializers
+from taggit_serializer.serializers import TagListSerializerField, TaggitSerializer
 
 from apps.gallery.models import ResponsiveImage
 
 
-class ResponsiveImageSerializer(serializers.ModelSerializer):1
+class ResponsiveImageSerializer(TaggitSerializer, serializers.ModelSerializer):
+
+    tags = TagListSerializerField()
 
     class Meta(object):
         model = ResponsiveImage

--- a/apps/gallery/serializers.py
+++ b/apps/gallery/serializers.py
@@ -7,11 +7,11 @@ from rest_framework import serializers
 from apps.gallery.models import ResponsiveImage
 
 
-class ResponsiveImageSerializer(serializers.ModelSerializer):
+class ResponsiveImageSerializer(serializers.ModelSerializer):1
 
     class Meta(object):
         model = ResponsiveImage
         fields = (
             'id', 'name', 'timestamp', 'description', 'thumb',
-            'original', 'wide', 'lg', 'md', 'sm', 'xs'
+            'original', 'wide', 'lg', 'md', 'sm', 'xs', 'tags'
         )

--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -205,7 +205,11 @@ def search(request):
 
     # Field filters are normally AND'ed together. Q objects circumvent this, treating each field result like a set.
     # This allows us to use set operators like | (union), & (intersect) and ~ (negation)
-    matches = ResponsiveImage.objects.filter(Q(name__icontains=query) | Q(description__icontains=query))[:10]
+    matches = ResponsiveImage.objects.filter(
+        Q(name__icontains=query) |
+        Q(description__icontains=query) |
+        Q(tags__name__in=query.split(' '))
+    ).distinct()[:10]
 
     results = {
         'total': len(matches),
@@ -262,6 +266,10 @@ class ResponsiveImageViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin,
 
         if query:
             # Restrict results based off of search
-            queryset = queryset.filter(Q(name__icontains=query) | Q(description__icontains=query))
+            queryset = queryset.filter(
+                Q(name__icontains=query) |
+                Q(description__icontains=query) |
+                Q(tags__name__in=query.split())
+            ).distinct()
 
         return queryset

--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -220,7 +220,8 @@ def search(request):
             'sm': settings.MEDIA_URL + str(image.image_sm),
             'md': settings.MEDIA_URL + str(image.image_md),
             'lg': settings.MEDIA_URL + str(image.image_lg),
-            'timestamp': image.timestamp.strftime('%Y-%m-%d %H:%M:%S')
+            'timestamp': image.timestamp.strftime('%Y-%m-%d %H:%M:%S'),
+            'tags': [str(tag) for tag in image.tags.all()]
         } for image in matches]
     }
 

--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -13,6 +13,7 @@ from django.http import JsonResponse, HttpResponse
 from guardian.decorators import permission_required
 from rest_framework import mixins, viewsets
 from rest_framework.permissions import AllowAny
+from taggit.utils import parse_tags
 
 from apps.gallery import util
 from apps.gallery.models import UnhandledImage, ResponsiveImage
@@ -135,6 +136,7 @@ def crop_image(request):
             image = get_object_or_404(UnhandledImage, pk=crop_data['id'])
             image_name = crop_data['name']
             image_description = crop_data['description']
+            image_tags = crop_data['tags']
             responsive_image_path = util.save_responsive_image(image, crop_data)
 
             # Error / Status collection is performed in the utils create_responsive_images function
@@ -160,6 +162,9 @@ def crop_image(request):
                 thumbnail=thumbnail
             )
             resp_image.save()
+            # Unpack and add any potential tags
+            if image_tags:
+                resp_image.tags.add(*parse_tags(image_tags))
 
             log.debug(
                 '%s cropped and saved ResponsiveImage %d (%s)' % (

--- a/apps/gallery/widgets.py
+++ b/apps/gallery/widgets.py
@@ -3,7 +3,7 @@
 # Created by 'myth' on 10/14/15
 
 from django.conf import settings
-from django.forms import HiddenInput
+from django.forms import HiddenInput, TextInput
 from django.forms.utils import flatatt, format_html, force_text
 
 from apps.gallery.models import ResponsiveImage
@@ -66,3 +66,15 @@ class SingleImageInput(HiddenInput):
             )
 
         return format_html(WIDGET_STRING, flatatt(final_attrs), img_thumb)
+
+
+class TagInputField(TextInput):
+    """
+    Adds some extras to a TextInputField to support space or comma separated tagging
+    """
+
+    def __init__(self, attrs=None):
+        super(TagInputField, self).__init__(attrs=attrs)
+
+    def render(self, name, value, attrs=None):
+        return super(TagInputField, self).render(name, value, attrs=attrs)

--- a/files/static/js/dashboard/gallery.js
+++ b/files/static/js/dashboard/gallery.js
@@ -7,9 +7,10 @@ var GalleryDashboard = (function ($, tools) {
     /* Private fields */
 
     var SEARCH_ENDPOINT = '/api/v1/images/'
-    var search_field, search_button, result_table, years
+    var search_field, search_button, result_table, years, tags
 
     years = $('.dashboard-gallery-year')
+    tags = $('.dashboard-gallery-tag')
     search_field = $('#dashboard-gallery-search-query')
     search_button = $('#dashboard-gallery-search-button')
     result_table = $('#dashboard-gallery-table')
@@ -56,6 +57,11 @@ var GalleryDashboard = (function ($, tools) {
             years.on('click', function (e) {
                 e.preventDefault()
                 GalleryDashboard.filter($(this).text())
+            })
+
+            tags.on('click', function (e) {
+                e.preventDefault();
+                GalleryDashboard.search($(this).text())
             })
         },
 

--- a/files/static/js/gallery.js
+++ b/files/static/js/gallery.js
@@ -321,8 +321,10 @@ var Gallery = (function ($, tools) {
         var cropData = image.cropper("getData");
         var image_name = $('#image-edit-name');
         var image_description = $('#image-edit-description');
+        var image_tags = $('#image-edit-tags');
         cropData.name = image_name.val();
         cropData.description = image_description.val();
+        cropData.tags = image_tags.val();
 
         if (cropData.name.length < 2) {
             alert('Du må gi bildet et navn!');

--- a/files/static/less/gallery.less
+++ b/files/static/less/gallery.less
@@ -121,6 +121,12 @@ div#datavalues > div.input-group > span.input-group-addon:last-child {
     font-size: medium;
 }
 
+.dashboard-gallery-tag {
+    display: inline-block;
+    margin-top: 10px;
+    margin-bottom: 5px;
+}
+
 /* IMAGE WIDGET STUFF */
 
 #image-selection-wrapper {

--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -143,6 +143,9 @@ GRAPPELLI_ADMIN_TITLE = '<a href="/">Onlineweb</a>'
 ANONYMOUS_USER_ID = -1
 GUARDIAN_RENDER_403 = True
 
+# Django-Taggit settings
+TAGGIT_CASE_INSENSITIVE = True
+
 # List of usergroups that should be listed under "Finn brukere" in user profile
 USER_SEARCH_GROUPS = [
     16,  # appKom

--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -206,6 +206,7 @@ INSTALLED_APPS = (
     'stripe',
     'rest_framework',
     'django_filters',
+    'taggit',
 
     # Django apps
     'django.contrib.admin',

--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -210,6 +210,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'django_filters',
     'taggit',
+    'taggit_serializer',
 
     # Django apps
     'django.contrib.admin',

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ django-watson==1.1.8            # Indexed model search lib
 django-reversion==1.9.3         # Model version history with middleware hooks to all post_save signals
 django-guardian==1.3            # Per Object permissions framework
 django-taggit==0.17.3           # Generic multi-model tagging library
-django-taggit-serializer=0.1.4  # REST Framework serializers for Django-taggit
+django-taggit-serializer==0.1.5 # REST Framework serializers for Django-taggit
 APScheduler==2.1.1              # Scheduler
 feedme==1.8.5
 git+https://github.com/dotKom/redwine.git@1.2.2#egg=redwine==1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ django-watson==1.1.8            # Indexed model search lib
 django-reversion==1.9.3         # Model version history with middleware hooks to all post_save signals
 django-guardian==1.3            # Per Object permissions framework
 django-taggit==0.17.3           # Generic multi-model tagging library
+django-taggit-serializer=0.1.4  # REST Framework serializers for Django-taggit
 APScheduler==2.1.1              # Scheduler
 feedme==1.8.5
 git+https://github.com/dotKom/redwine.git@1.2.2#egg=redwine==1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ django_compressor==1.4          # Compiles less and minifies js
 django-watson==1.1.8            # Indexed model search lib
 django-reversion==1.9.3         # Model version history with middleware hooks to all post_save signals
 django-guardian==1.3            # Per Object permissions framework
+django-taggit==0.17.3           # Generic multi-model tagging library
 APScheduler==2.1.1              # Scheduler
 feedme==1.8.5
 git+https://github.com/dotKom/redwine.git@1.2.2#egg=redwine==1.2.2

--- a/templates/gallery/dashboard/index.html
+++ b/templates/gallery/dashboard/index.html
@@ -28,6 +28,8 @@ Bilder
             <span class="badge badge-info pull-right">Diskforbruk: {{ disk_usage }}</span>
         </p>
     </div>
+</div>
+<div class="row">
     <div class="col-md-12 col-lg-6">
         <div class="input-group">
             <span class="input-group-addon">Søk</span>
@@ -45,6 +47,13 @@ Bilder
                 <a href="#" class="btn btn-info dashboard-gallery-year">{{ year }}</a>
             {% endfor %}
         </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        {% for tag in tags %}
+        <a href="#" class="label label-warning dashboard-gallery-tag">{{ tag }}</a>
+        {% endfor %}
     </div>
 </div>
 <br />

--- a/templates/gallery/edit.html
+++ b/templates/gallery/edit.html
@@ -42,6 +42,10 @@
                                     <label for="image-edit-description">Beskrivelse</label>
                                     <textarea id="image-edit-description" placeholder="Skriv inn en beskrivelse av bildet her..." class="form-control" rows="6"></textarea>
                                 </div>
+                                <div class="form-group">
+                                    <label for="image-edit-tags">Tags</label>
+                                    <input id="image-edit-tags" placeholder="Eksempel: kontoret, kjelleren, åre" class="form-control">
+                                </div>
                             </div>
                             <div class="col-md-4">
                                                                 <div id="datavalues" class="row row-space">


### PR DESCRIPTION
This PR implements Django-taggit, accompanied by django-taggit-serializer which provides mixins and a serializer for REST framework.

This serves as a test/demo for the generic tagging options that django-taggit provides. It supports similar objects, which not only can return all content types, but also as a list ordered based on degree of similarity between two similarly tagged objects.

Hopefully this is a viable option for #1324 