### PR TITLE
Dashboard gallery detail view permission fix

### DIFF
--- a/apps/gallery/dashboard/views.py
+++ b/apps/gallery/dashboard/views.py
@@ -74,6 +74,7 @@ class GalleryDetail(DashboardPermissionMixin, UpdateView):
     """
 
     permission_required = 'gallery.change_responsiveimage'
+    accept_global_perms = True
     template_name = 'gallery/dashboard/detail.html'
     model = ResponsiveImage
     context_object_name = 'image'


### PR DESCRIPTION
Let responsiveimage dashboard detailview fetch model permissions before objectpermissions. This workaround addresses a bug in django-guardian preventing permissionrequired mixin to work with updateview.