### PR TITLE
Article revamp

### DIFF
--- a/apps/api/v0/article.py
+++ b/apps/api/v0/article.py
@@ -10,7 +10,7 @@ from tastypie.resources import ModelResource
 
 from apps.api.v0.image import ImageResource
 from apps.api.v0.authentication import UserResource
-from apps.article.models import Article, ArticleTag, Tag
+from apps.article.models import Article
 
 
 class ArticleResource(ModelResource):
@@ -66,10 +66,10 @@ class ArticleResource(ModelResource):
             # Not filtering on year, check if filtering on slug (tag) or return default query
             if request_tag is not None:
                 # Filtering on slug
-                slug_query = Tag.objects.filter(slug=request_tag)
-                slug_connect = ArticleTag.objects.filter(tag=slug_query).values('article_id')
                 queryset = Article.objects.filter(
-                    id__in=slug_connect, published_date__lte=timezone.now()).order_by('-published_date')
+                    tags__name__in=[request_tag],
+                    published_date__lte=timezone.now()
+                ).order_by('-published_date')
             else:
                 # No filtering at all, return default query
                 queryset = Article.objects.filter(published_date__lte=timezone.now()).order_by('-published_date')

--- a/apps/article/admin.py
+++ b/apps/article/admin.py
@@ -1,30 +1,10 @@
 from django.contrib import admin
-from apps.article.models import Article, Tag, ArticleTag
+from apps.article.models import Article
 
 from reversion.admin import VersionAdmin
 
 
-class ArticleTagAdmin(VersionAdmin):
-    model = ArticleTag
-
-
-class ArticleTagInline(admin.TabularInline):
-    model = ArticleTag
-    max_num = 99
-    extra = 0
-
-
-class TagAdmin(VersionAdmin):
-    def save_model(self, request, obj, form, change):
-        obj.changed_by = request.user
-        if not change:
-            obj.name = obj.name.replace('.', '')
-            obj.created_by = request.user
-        obj.save()
-
-
 class ArticleAdmin(VersionAdmin):
-    inlines = (ArticleTagInline,)
     list_display = ("heading", "created_by", "changed_by")
 
     # set the created and changed by fields
@@ -42,4 +22,3 @@ class ArticleAdmin(VersionAdmin):
             instances.save()
 
 admin.site.register(Article, ArticleAdmin)
-admin.site.register(Tag, TagAdmin)

--- a/apps/article/dashboard/forms.py
+++ b/apps/article/dashboard/forms.py
@@ -1,26 +1,14 @@
 # -*- encoding: utf-8 -*-
 from django import forms
 
-from apps.article.models import Tag, Article
+from apps.article.models import Article
 from apps.dashboard.widgets import DatetimePickerInput, multiple_widget_generator
 from apps.gallery.widgets import SingleImageInput
 
-
-class TagForm(forms.ModelForm):
-
-    class Meta(object):
-        model = Tag
-        fields = ['name', 'slug']
+from taggit.forms import TagWidget
 
 
 class ArticleForm(forms.ModelForm):
-
-    tags = forms.ModelMultipleChoiceField(
-        queryset=Tag.objects.all().order_by('name'),
-        label=u'Tags',
-        help_text=u'Legg til kategori',
-        required=False
-    )
 
     class Meta(object):
         """
@@ -28,7 +16,17 @@ class ArticleForm(forms.ModelForm):
         """
 
         model = Article
-        exclude = ['old_image']
+        fields = [
+            'heading',
+            'ingress_short',
+            'ingress',
+            'content',
+            'image',
+            'published_date',
+            'authors',
+            'tags',
+            'featured'
+        ]
 
         # Fields should be a mapping between field name and an attribute dictionary
         img_fields = [('image', {'id': 'responsive-image-id'})]
@@ -40,3 +38,7 @@ class ArticleForm(forms.ModelForm):
 
         # Multiple widget generator merges results from regular widget_generator into a single widget dict
         widgets = multiple_widget_generator(widgetlist)
+        widgets.update({'tags': TagWidget(attrs={'placeholder': 'Eksempel: åre, online, kjelleren'})})
+        labels = {
+            'tags': u'Tags'
+        }

--- a/apps/article/dashboard/urls.py
+++ b/apps/article/dashboard/urls.py
@@ -8,8 +8,4 @@ urlpatterns = patterns(
     url(r'^new/$', 'article_create', name='dashboard_article_create'),
     url(r'^(?P<article_id>\d+)/$', 'article_detail', name='dashboard_article_detail'),
     url(r'^(?P<article_id>\d+)/edit/$', 'article_edit', name='dashboard_article_edit'),
-
-    url(r'^tag/$', 'tag_index', name='dashboard_tag_index'),
-    url(r'^tag/new/$', 'tag_create', name='dashboard_tag_create'),
-    url(r'^tag/(?P<tag_id>\d+)/$', 'tag_edit', name='dashboard_tag_edit'),
 )

--- a/apps/article/dashboard/views.py
+++ b/apps/article/dashboard/views.py
@@ -1,11 +1,14 @@
 # -*- encoding: utf-8 -*-
 
+from collections import Counter
 from logging import getLogger
 
+from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import render, get_object_or_404, redirect
 from django.contrib import messages
 
 from guardian.decorators import permission_required
+from taggit.models import TaggedItem
 
 from apps.article.models import Article
 from apps.article.dashboard.forms import ArticleForm
@@ -20,6 +23,10 @@ def article_index(request):
     context['articles'] = Article.objects.all().order_by('-published_date')
     context['years'] = sorted(list(set(a.published_date.year for a in context['articles'])), reverse=True)
     context['pages'] = range(1, context['articles'].count() / 10 + 2)
+
+    # Fetch 30 most popular tags from the Django-taggit registry, using a Counter
+    queryset = TaggedItem.objects.filter(content_type=ContentType.objects.get_for_model(Article))
+    context['tags'] = Counter(map(lambda item: item.tag, queryset)).most_common(30)
 
     return render(request, 'article/dashboard/article_index.html', context)
 

--- a/apps/article/dashboard/views.py
+++ b/apps/article/dashboard/views.py
@@ -2,14 +2,13 @@
 
 from logging import getLogger
 
-from django.http import JsonResponse
 from django.shortcuts import render, get_object_or_404, redirect
 from django.contrib import messages
 
 from guardian.decorators import permission_required
 
-from apps.article.models import Article, Tag, ArticleTag
-from apps.article.dashboard.forms import TagForm, ArticleForm
+from apps.article.models import Article
+from apps.article.dashboard.forms import ArticleForm
 from apps.dashboard.tools import check_access_or_403, get_base_context
 
 
@@ -38,10 +37,7 @@ def article_create(request):
             instance.changed_by = request.user
             instance.created_by = request.user
             instance.save()
-
-            tag_list = Tag.objects.filter(id__in=map(int, request.POST.getlist('tags')))
-            for tag in tag_list:
-                ArticleTag.objects.create(article=instance, tag=tag)
+            form.save_m2m()
 
             messages.success(request, u'Artikkelen ble opprettet.')
             return redirect(article_detail, article_id=instance.pk)
@@ -59,11 +55,9 @@ def article_detail(request, article_id):
     check_access_or_403(request)
 
     article = get_object_or_404(Article, pk=article_id)
-    tags = ArticleTag.objects.filter(article=article)
 
     context = get_base_context(request)
     context['article'] = article
-    context['tags'] = tags
 
     return render(request, 'article/dashboard/article_detail.html', context)
 
@@ -74,10 +68,7 @@ def article_edit(request, article_id):
 
     article = get_object_or_404(Article, pk=article_id)
 
-    form = ArticleForm(
-        instance=article,
-        initial={'tags': [t.tag.pk for t in ArticleTag.objects.filter(article=article)]}
-    )
+    form = ArticleForm(instance=article)
 
     if request.method == 'POST':
         if 'action' in request.POST and request.POST['action'] == 'delete':
@@ -95,20 +86,9 @@ def article_edit(request, article_id):
             instance = form.save(commit=False)
             instance.changed_by = request.user
             instance.save()
-
-            # Prepare for Tags M2M handling
-            form_tags = map(int, request.POST.getlist('tags'))
-            existing_tags = ArticleTag.objects.filter(article=instance)
-
-            # Clear previous tags and update with tags from form if we have a change
-            if set(t.tag.pk for t in existing_tags) & set(form_tags) != form_tags:
-                getLogger(__name__).debug('Article tags state changed, new set is %s' % repr(form_tags))
-                ArticleTag.objects.filter(article=instance).delete()
-                for tag in Tag.objects.filter(pk__in=map(int, request.POST.getlist('tags'))):
-                    ArticleTag(article=instance, tag=tag).save()
+            form.save_m2m()
 
             messages.success(request, u'Artikkelen ble lagret.')
-
             getLogger(__name__).info('%s edited article %d (%s)' % (request.user, instance.id, instance.heading))
 
             return redirect(article_index)
@@ -120,70 +100,3 @@ def article_edit(request, article_id):
     context['edit'] = True
 
     return render(request, 'article/dashboard/article_create.html', context)
-
-
-@permission_required('article.view_tag')
-def tag_index(request):
-    check_access_or_403(request)
-
-    context = get_base_context(request)
-    context['tags'] = Tag.objects.all()
-
-    return render(request, 'article/dashboard/tag_index.html', context)
-
-
-@permission_required('article.add_tag')
-def tag_create(request):
-    check_access_or_403(request)
-
-    form = TagForm()
-
-    if request.method == 'POST':
-        form = TagForm(request.POST)
-        if form.is_valid():
-            instance = form.save()
-
-            getLogger(__name__).info('%s created tag %s' % (request.user, instance.name))
-
-            if request.is_ajax():
-                return JsonResponse(data={
-                    'id': instance.id,
-                    'name': instance.name,
-                    'slug': instance.slug
-                })
-            messages.success(request, u'Tag ble opprettet.')
-            return redirect(tag_index)
-        else:
-            messages.error(request, u'Noen av de påkrevde feltene inneholder feil.')
-
-    context = get_base_context(request)
-    context['form'] = form
-
-    return render(request, 'article/dashboard/tag_create.html', context)
-
-
-@permission_required('article.change_tag')
-def tag_edit(request, tag_id):
-    check_access_or_403(request)
-
-    tag = get_object_or_404(Tag, pk=tag_id)
-
-    form = TagForm(instance=tag)
-
-    if request.method == 'POST':
-        form = TagForm(request.POST)
-        if form.is_valid():
-            instance = form.save()
-
-            getLogger(__name__).info('%s updated tag %s' % (request.user, instance.name))
-
-            messages.success(request, u'Tag ble opprettet.')
-            return redirect(tag_index)
-        else:
-            messages.error(request, u'Noen av de påkrevde feltene inneholder feil.')
-
-    context = get_base_context(request)
-    context['form'] = form
-    context['edit'] = True
-
-    return render(request, 'article/dashboard/tag_create.html', context)

--- a/apps/article/migrations/0009_article_tags.py
+++ b/apps/article/migrations/0009_article_tags.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import taggit.managers
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taggit', '0002_auto_20150616_2121'),
+        ('article', '0008_auto_20151029_2238'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='article',
+            name='tags',
+            field=taggit.managers.TaggableManager(to='taggit.Tag', through='taggit.TaggedItem', blank=True, help_text='A comma-separated list of tags.', verbose_name='Tags'),
+        ),
+    ]

--- a/apps/article/migrations/0010_auto_20151101_0522.py
+++ b/apps/article/migrations/0010_auto_20151101_0522.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('article', '0009_article_tags'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='articletag',
+            unique_together=set([]),
+        ),
+        migrations.RemoveField(
+            model_name='articletag',
+            name='article',
+        ),
+        migrations.RemoveField(
+            model_name='articletag',
+            name='tag',
+        ),
+        migrations.RemoveField(
+            model_name='article',
+            name='old_image',
+        ),
+        migrations.RemoveField(
+            model_name='article',
+            name='photographers',
+        ),
+        migrations.DeleteModel(
+            name='ArticleTag',
+        ),
+        migrations.DeleteModel(
+            name='Tag',
+        ),
+    ]

--- a/apps/article/models.py
+++ b/apps/article/models.py
@@ -1,18 +1,19 @@
 # -*- coding: utf-8 -*-
 
 import re
+from unidecode import unidecode
 
 from django.conf import settings
 from django.db import models
 from django.db.models import permalink, SET_NULL
 from django.template.defaultfilters import slugify
-from unidecode import unidecode
 from django.utils.translation import ugettext as _
+
+from taggit.managers import TaggableManager
 import reversion
 import watson
 
 from apps.gallery.models import ResponsiveImage
-from filebrowser.fields import FileBrowseField
 
 
 User = settings.AUTH_USER_MODEL
@@ -26,11 +27,6 @@ class Article(models.Model):
     ingress_short = models.CharField(_(u"kort ingress"), max_length=100)
     ingress = models.TextField(_(u"ingress"))
     content = models.TextField(_(u"content"))
-    old_image = FileBrowseField(
-        _(u"bilde"),
-        max_length=200, directory=IMAGE_FOLDER,
-        extensions=IMAGE_EXTENSIONS, null=True
-    )
     image = models.ForeignKey(ResponsiveImage, null=True, default=None, blank=True, on_delete=SET_NULL)
     video = models.CharField(_("vimeo id"), max_length=200, blank=True)
     created_date = models.DateTimeField(_(u"opprettet-dato"), auto_now_add=True, editable=False)
@@ -46,8 +42,9 @@ class Article(models.Model):
     changed_by = models.ForeignKey(
         User, null=False, verbose_name=_(u"endret av"), related_name="changed_by", editable=False
     )
-    photographers = models.CharField(_(u'fotograf(er)'), max_length=200, blank=True)
     featured = models.BooleanField(_(u"featured artikkel"), default=False)
+
+    tags = TaggableManager(blank=True)
 
     def __unicode__(self):
         return self.heading
@@ -59,28 +56,9 @@ class Article(models.Model):
     def slug(self):
         return slugify(unidecode(self.heading))
 
-    @property
-    def tags(self):
-        at = ArticleTag.objects.filter(article=self.id)
-        tags = []
-        for a in at:
-            tags.append(a.tag)
-        return tags
-
-    @property
-    def tagstring(self):
-        tag_names = []
-        for tag in self.tags:
-            tag_names.append(tag.name)
-        return u', '.join(tag_names)
-
     @permalink
     def get_absolute_url(self):
         return 'article_details', None, {'article_id': self.id, 'article_slug': self.slug}
-
-    def images(self):
-        from apps.article.utils import find_image_versions
-        return find_image_versions(self)
 
     class Meta(object):
         verbose_name = _(u"artikkel")
@@ -93,46 +71,3 @@ class Article(models.Model):
 
 reversion.register(Article)
 watson.register(Article)
-
-
-class Tag(models.Model):
-    name = models.CharField(_(u"navn"), max_length=50)
-    slug = models.CharField(_(u"kort navn"), max_length=30)
-
-    @property
-    def frequency(self):
-        at = ArticleTag.objects.filter(tag=self.id)
-        count = 0
-        for a in at:
-            count += 1
-        return count
-
-    @permalink
-    def get_absolute_url(self):
-        return 'view_article_tag', None, {'name': self.name, 'slug': self.slug}
-
-    def __unicode__(self):
-        return self.name
-
-    class Meta(object):
-        permissions = (
-            ('view_tag', 'View Tag'),
-        )
-
-
-reversion.register(Tag)
-
-
-class ArticleTag(models.Model):
-    article = models.ForeignKey(Article, verbose_name=_(u"artikkel"), related_name='article_tags')
-    tag = models.ForeignKey(Tag, verbose_name=_(u"tag"), related_name='article_tags')
-
-    class Meta(object):
-        unique_together = ('article', 'tag')
-        verbose_name = _(u"tag")
-        verbose_name_plural = _(u"tags")
-        permissions = (
-            ('view_articletag', 'View ArticleTag'),
-        )
-
-reversion.register(ArticleTag)

--- a/apps/article/serializers.py
+++ b/apps/article/serializers.py
@@ -27,7 +27,6 @@ class ArticleSerializer(TaggitSerializer, serializers.ModelSerializer):
             'id',
             'ingress',
             'ingress_short',
-            'photographers',
             'published_date',
             'slug',
             'tags',

--- a/apps/article/serializers.py
+++ b/apps/article/serializers.py
@@ -1,13 +1,16 @@
 from rest_framework import serializers
 
-from apps.article.models import Article, Tag
+from apps.article.models import Article
 from apps.authentication.serializers import UserSerializer
 from apps.gallery.serializers import ResponsiveImageSerializer
 
+from taggit_serializer.serializers import TaggitSerializer, TagListSerializerField
 
-class ArticleSerializer(serializers.ModelSerializer):
+
+class ArticleSerializer(TaggitSerializer, serializers.ModelSerializer):
     created_by = UserSerializer()
     image = ResponsiveImageSerializer()
+    tags = TagListSerializerField()
     absolute_url = serializers.CharField(source='get_absolute_url', read_only=True)
 
     class Meta(object):
@@ -27,14 +30,7 @@ class ArticleSerializer(serializers.ModelSerializer):
             'photographers',
             'published_date',
             'slug',
+            'tags',
             'video',
-            'image',
-            'article_tags',
+            'image'
         )
-
-
-class TagSerializer(serializers.ModelSerializer):
-
-    class Meta(object):
-        model = Tag
-        fields = ('name', 'short_name')

--- a/apps/article/urls.py
+++ b/apps/article/urls.py
@@ -8,9 +8,9 @@ from apps.article import views
 
 urlpatterns = patterns(
     'apps.article.views',
-    url(r'^archive$', 'archive', name='article_archive'),
-    url(r'^(?P<article_id>\d+)/(?P<article_slug>[a-zA-Z0-9_-]+)$', 'details', name='article_details'),
-    url(r'^tag/(?P<name>[^\.]+)/(?P<slug>[^\.]+)', 'archive_tag', name='view_article_tag'),
+    url(r'^archive/$', 'archive', name='article_archive'),
+    url(r'^(?P<article_id>\d+)/(?P<article_slug>[a-zA-Z0-9_-]+)/$', 'details', name='article_details'),
+    url(r'^tag/(?P<name>[^\.]+)/(?P<slug>[^\.]+)/', 'archive_tag', name='view_article_tag'),
     url(r'^year/(?P<year>\d+)/$', 'archive_year', name='article_archive_year'),
     url(r'^year/(?P<year>\d+)/month/(?P<month>[^\.]+)/$', 'archive_month', name='article_archive_month'),
 )

--- a/apps/article/urls.py
+++ b/apps/article/urls.py
@@ -15,7 +15,5 @@ urlpatterns = patterns(
     url(r'^year/(?P<year>\d+)/month/(?P<month>[^\.]+)/$', 'archive_month', name='article_archive_month'),
 )
 
-# API v1
-
 router = SharedAPIRootRouter()
 router.register(r'articles', views.ArticleViewSet)

--- a/apps/feedback/migrations/0006_auto_20151101_0522.py
+++ b/apps/feedback/migrations/0006_auto_20151101_0522.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('feedback', '0005_merge'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='multiplechoicequestion',
+            options={'verbose_name': 'Flervalgsp\xf8rsm\xe5l', 'verbose_name_plural': 'Flervalgsp\xf8rsm\xe5l', 'permissions': (('view_multiplechoicequestion', 'View MultipleChoiceQuestion'),)},
+        ),
+    ]

--- a/apps/gallery/dashboard/forms.py
+++ b/apps/gallery/dashboard/forms.py
@@ -13,11 +13,12 @@ class ResponsiveImageForm(forms.ModelForm):
 
     class Meta(object):
         model = ResponsiveImage
-        fields = ['name', 'description', 'tags']
+        fields = ['name', 'description', 'photographer', 'tags']
         widgets = {
             'tags': TagWidget(attrs={
                 'placeholder': u'Eksempel: kontoret, kjelleren, åre',
-            })
+            }),
+            'photographer': forms.TextInput(attrs={'placeholder': u'Eventuell(e) fotograf(er)...'})
         }
         labels = {
             'tags': u'Tags'

--- a/apps/gallery/dashboard/views.py
+++ b/apps/gallery/dashboard/views.py
@@ -153,6 +153,7 @@ class GalleryDelete(DashboardPermissionMixin, DetailView):
     """
 
     permission_required = 'gallery.delete_responsiveimage'
+    accept_global_perms = True
     model = ResponsiveImage
 
     def get(self, request, *args, **kwargs):
@@ -195,6 +196,7 @@ class GalleryUnhandledDelete(DashboardPermissionMixin, DetailView):
     """
 
     permission_required = 'gallery.delete_unhandledimage'
+    accept_global_perms = True
     model = UnhandledImage
 
     def get(self, request, *args, **kwargs):

--- a/apps/gallery/migrations/0011_responsiveimage_photographer.py
+++ b/apps/gallery/migrations/0011_responsiveimage_photographer.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gallery', '0010_auto_20151031_0348'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='responsiveimage',
+            name='photographer',
+            field=models.CharField(default=b'', max_length=100, verbose_name='Fotograf', blank=True),
+        ),
+    ]

--- a/apps/gallery/models.py
+++ b/apps/gallery/models.py
@@ -53,9 +53,9 @@ class UnhandledImage(models.Model):
 def unhandled_image_delete(sender, instance, **kwargs):
     # Pass false so FileField doesn't save the model.
     if instance.image:
-        instance.image.delete()
+        instance.image.delete(False)
     if instance.thumbnail:
-        instance.thumbnail.delete()
+        instance.thumbnail.delete(False)
 
 # Connect post_delete event with
 post_delete.connect(receiver=unhandled_image_delete, dispatch_uid=uuid.uuid1(), sender=UnhandledImage)
@@ -73,7 +73,7 @@ class ResponsiveImage(models.Model):
     image_sm = models.ImageField(u'SM Bilde', upload_to=gallery_settings.RESPONSIVE_IMAGES_PATH)
     image_xs = models.ImageField(u'XS Bilde', upload_to=gallery_settings.RESPONSIVE_IMAGES_PATH)
     thumbnail = models.ImageField(u'Thumbnail', upload_to=gallery_settings.RESPONSIVE_THUMBNAIL_PATH)
-
+    photographer = models.CharField(u'Fotograf', max_length=100, null=False, blank=True, default='')
     tags = TaggableManager(help_text="En komma eller mellomrom-separert liste med tags.")
 
     def __str__(self):
@@ -208,19 +208,19 @@ def responsive_image_delete(sender, instance, **kwargs):
 
     # Pass false so FileField doesn't save the model.
     if instance.image_original:
-        instance.image_original.delete()
+        instance.image_original.delete(False)
     if instance.image_wide:
-        instance.image_wide.delete()
+        instance.image_wide.delete(False)
     if instance.image_lg:
-        instance.image_lg.delete()
+        instance.image_lg.delete(False)
     if instance.image_md:
-        instance.image_md.delete()
+        instance.image_md.delete(False)
     if instance.image_sm:
-        instance.image_sm.delete()
+        instance.image_sm.delete(False)
     if instance.image_xs:
-        instance.image_xs.delete()
+        instance.image_xs.delete(False)
     if instance.thumbnail:
-        instance.thumbnail.delete()
+        instance.thumbnail.delete(False)
 
     # Automatically delete all related objects that for some insane reason had a ref to the
     # same image. This is bat country. Really only happens if there has been an exception

--- a/apps/gallery/serializers.py
+++ b/apps/gallery/serializers.py
@@ -16,5 +16,6 @@ class ResponsiveImageSerializer(TaggitSerializer, serializers.ModelSerializer):
         model = ResponsiveImage
         fields = (
             'id', 'name', 'timestamp', 'description', 'thumb',
-            'original', 'wide', 'lg', 'md', 'sm', 'xs', 'tags'
+            'original', 'wide', 'lg', 'md', 'sm', 'xs', 'tags',
+            'photographer'
         )

--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -137,6 +137,7 @@ def crop_image(request):
             image_name = crop_data['name']
             image_description = crop_data['description']
             image_tags = crop_data['tags']
+            image_photographer = crop_data['photographer']
             responsive_image_path = util.save_responsive_image(image, crop_data)
 
             # Error / Status collection is performed in the utils create_responsive_images function
@@ -153,6 +154,7 @@ def crop_image(request):
             resp_image = ResponsiveImage(
                 name=image_name,
                 description=image_description,
+                photographer=image_photographer,
                 image_original=original_media,
                 image_lg=lg_media,
                 image_md=md_media,
@@ -217,6 +219,7 @@ def search(request):
             'name': image.name,
             'description': image.description,
             'id': image.id,
+            'photographer': image.photographer,
             'original': settings.MEDIA_URL + str(image.image_original),
             'thumbnail': settings.MEDIA_URL + str(image.thumbnail),
             'wide': settings.MEDIA_URL + str(image.image_wide),

--- a/files/static/js/Article-archive.js
+++ b/files/static/js/Article-archive.js
@@ -267,7 +267,7 @@ function ArticleArchive (Utils) {
                         output += '      <a href="'+articles[i].id+'/'+articles[i].slug+'"><h3>'+articles[i].heading+'</h3></a>';
                         output += '      <p>'+articles[i].ingress_short+'</p>';
                         output += '      <div class="meta"><div class="row"><div class="col-md-12">';
-                        output += '        <p><strong>Publisert av: </strong>' + articles[i].authors + '</p>';
+                        output += '        <p><strong>Skrevet av: </strong>' + articles[i].authors + '</p>';
                         output += '      </div></div></div>';
                         output += '    </div><!-- end col-md-8 -->';
                         output += '  </div><!-- end row -->';

--- a/files/static/js/dashboard/article.js
+++ b/files/static/js/dashboard/article.js
@@ -7,7 +7,7 @@ var Article = (function ($, tools) {
 
     var SEARCH_ENDPOINT = '/api/v1/articles/'
 
-    var page, query, searchButton, results, paginator, years;
+    var page, query, searchButton, results, paginator, years, tags;
 
     /**
      * Generic API helper function that only takes on an URI
@@ -35,7 +35,7 @@ var Article = (function ($, tools) {
             searchButton = $('#dashboard-article-search-button')
             results = $('#dashboard-article-table')
             years = $('.dashboard-article-year')
-            tagform = $('#dashboard-article-inline-tag-form')
+            tags = $('.dashboard-article-tag')
 
             // Bind click listener for search button
             searchButton.on('click', function (e) {
@@ -56,23 +56,10 @@ var Article = (function ($, tools) {
                 Article.filter($(this).text())
             })
 
-            // Intercept inline tag form posting and update tags list
-            $('#article-inline-tag-submit').on('click', function (e) {
-                e.preventDefault()
-                $.ajax({
-                    method: 'POST',
-                    url: '/dashboard/article/tag/new/',
-                    data: tagform.serialize(),
-                    success: function (data) {
-                        $('#article-inline-tag-error').hide()
-                        $('#id_tags').append('<option value="' + data.id + '">' + data.name + '</option>')
-                        $('#article-tag-name').val('')
-                        $('#article-tag-slug').val('')
-                    },
-                    error: function (xhr, statusText, thrownError) {
-                        $('#article-inline-tag-error').text('Klarte ikke legge til ny tag: ' + statusText).show()
-                    }
-                })
+            // Bind click listener to tags filter buttons
+            tags.on('click', function (e) {
+                e.preventDefault();
+                Article.tags($(this).text())
             })
         },
 
@@ -84,6 +71,10 @@ var Article = (function ($, tools) {
             doRequest(SEARCH_ENDPOINT + '?year=' + year)
         },
 
+        tags: function (tag) {
+            doRequest(SEARCH_ENDPOINT + '?tags=' + tag)
+        },
+
         table: {
             draw: function (items) {
                 var html = ''
@@ -93,7 +84,7 @@ var Article = (function ($, tools) {
 
                     html += '<tr>'
                     html += '<td><a href="' + item.id + '">' + item.heading + '</a></td>'
-                    html += '<td>' + item.author.first_name + ' ' + item.author.last_name + '</td>'
+                    html += '<td>' + item.authors + '</td>'
                     html += '<td>' + t.format('YYYY-MM-DD HH:MM:SS') + '</td>'
                     html += '<td><a href="/dashboard/article/' + item.id + '/edit/">'
                     html += '<i class="fa fa-edit fa-lg"></i></a></td></tr>'

--- a/files/static/js/gallery.js
+++ b/files/static/js/gallery.js
@@ -322,9 +322,11 @@ var Gallery = (function ($, tools) {
         var image_name = $('#image-edit-name');
         var image_description = $('#image-edit-description');
         var image_tags = $('#image-edit-tags');
+        var image_photographer = $('#image-edit-photographer');
         cropData.name = image_name.val();
         cropData.description = image_description.val();
-        cropData.tags = image_tags.val();
+        cropData.tags = image_tags.val() || '';
+        cropData.photographer = image_photographer.val() || '';
 
         if (cropData.name.length < 2) {
             alert('Du må gi bildet et navn!');

--- a/files/static/less/dashboard/articles.less
+++ b/files/static/less/dashboard/articles.less
@@ -1,0 +1,4 @@
+.dashboard-article-tag {
+  display: inline-block;
+  margin-top: 10px;
+}

--- a/files/static/less/dashboard/main.less
+++ b/files/static/less/dashboard/main.less
@@ -276,7 +276,7 @@ body.fixed .wrapper {
 }
 /* All images should be responsive */
 img {
-  max-width: 100%important;
+  max-width: 100% !important;
 }
 /* 10px padding and margins */
 .pad {
@@ -465,4 +465,4 @@ img {
  *
  */
 
-.datepicker { z-index: 1151 !imporatant; }
+.datepicker { z-index: 1151; }

--- a/templates/article/archive.html
+++ b/templates/article/archive.html
@@ -37,8 +37,8 @@
             <div class="col-xs-12 col-sm-12 col-md-3 pull-right" id="filterbox">
                 <h3>Tags</h3>
                 <div class="tag-cloud" id="article_archive_tagcloud">
-                    {% for tag in tags %}
-                        <span><a href="{{ tag.get_absolute_url }}" class="tag">{{ tag }}</a></span>
+                    {% for tag, count in tags %}
+                        <span><a href="{% url 'view_article_tag' tag.name tag.slug %}" class="tag">{{ tag }}</a></span>
                     {% endfor %}
                 </div>
                 <h3>Filter</h3>

--- a/templates/article/dashboard/article_create.html
+++ b/templates/article/dashboard/article_create.html
@@ -62,35 +62,8 @@ Artikler
             <button class="btn btn-success" type="submit">
                 <i class="fa fa-save fa-lg"></i> Lagre
             </button>
-            </form>
-            <br />
-            <form action="{% url 'dashboard_tag_create' %}" method="POST" id="dashboard-article-inline-tag-form">
-                {% csrf_token %}
-                <h4>Legg til ny Tag</h4>
-                <div class="alert alert-danger" style="display:none" id="article-inline-tag-error"></div>
-                <div class="row">
-                    <div class="col-md-5">
-                        <div class="form-group">
-                            <label for="article-tag-name">Navn</label>
-                            <input name="name" placeholder="Fullt navn" id="article-tag-name" class="form-control" />
-                        </div>
-                    </div>
-                    <div class="col-md-5">
-                        <div class="form-group">
-                            <label for="article-tag-slug">Slug</label>
-                            <input name="slug" placeholder="Kort navn" id="article-tag-slug" class="form-control" />
-                        </div>
-                    </div>
-                    <div class="col-md-2">
-                        <div class="form-group">
-                            <label>Lagre</label><br />
-                            <a class="btn btn-primary" href="#" id="article-inline-tag-submit">
-                                <i class="fa fa-plus fa-lg"></i>
-                            </a>
-                        </div>
-                    </div>
-                </div>
-            </form>
+        </form>
+        <br />
         {% include 'gallery/formwidget.html' %}
     </div>
 </div>

--- a/templates/article/dashboard/article_detail.html
+++ b/templates/article/dashboard/article_detail.html
@@ -79,7 +79,7 @@ Artikler
                     </p>
                     <h3>Tags</h3>
                     {% for tag in article.tags.all %}
-                        <a href="#" class="btn btn-default">{{ tag }}</a>
+                        <a href="/article/tag/{{ tag.name }}/{{ tag.slug }}" class="btn btn-default">{{ tag }}</a>
                     {% endfor %}
                 </div>
             </div>

--- a/templates/article/dashboard/article_detail.html
+++ b/templates/article/dashboard/article_detail.html
@@ -66,7 +66,7 @@ Artikler
                             <dt>Navn</dt>
                             <dd>{{ article.image.name|striptags }}</dd>
                             <dt>Fotograf(er)</dt>
-                            <dd>{{ article.photographers|striptags }}</dd>
+                            <dd>{{ article.image.photographer|striptags }}</dd>
                             <dt>Vimeo ID</dt>
                             <dd>
                                 {% if article.vimeo %}
@@ -78,8 +78,8 @@ Artikler
                         </dl>
                     </p>
                     <h3>Tags</h3>
-                    {% for tag in tags %}
-                        <a href="{{ tag.tag.absolute_url }}" class="btn btn-default">{{ tag.tag.name }}</a>
+                    {% for tag in article.tags.all %}
+                        <a href="#" class="btn btn-default">{{ tag }}</a>
                     {% endfor %}
                 </div>
             </div>

--- a/templates/article/dashboard/article_index.html
+++ b/templates/article/dashboard/article_index.html
@@ -14,6 +14,13 @@ Artikler
     <script src="{{ STATIC_URL }}js/dashboard/article.js" type="text/javascript"></script>
 {% endblock %}
 
+{% block styles %}
+    {{ block.super }}
+    {% compress css %}
+    <link rel="stylesheet" type="text/less" href="{{ STATIC_URL }}less/dashboard/articles.less">
+    {% endcompress %}
+{% endblock %}
+
 {% block breadcrumbs %}
     <li>Artikler</li>
 {% endblock %}
@@ -42,6 +49,13 @@ Artikler
         </div>
     </div>
 </div>
+<div class="row">
+    <div class="col-md-12">
+        {% for tag, count in tags %}
+        <a href="#" class="label label-warning dashboard-article-tag">{{ tag }}</a>
+        {% endfor %}
+    </div>
+</div>
 <br />
 <div class="row">
     <div class="col-md-12">
@@ -63,7 +77,7 @@ Artikler
                     {% for article in articles %}
                         <tr>
                             <td><a href="{% url 'dashboard_article_detail' article.pk %}">{{ article }}</a></td>
-                            <td>{{ article.created_by }}</td>
+                            <td>{{ article.authors }}</td>
                             <td>{{ article.published_date|date:'Y-m-d H:i:s' }}</td>
                             <td>
                                 <a href="{% url 'dashboard_article_edit' article.pk %}">

--- a/templates/article/details.html
+++ b/templates/article/details.html
@@ -24,7 +24,7 @@
                            <div>
                                <img width="100%" src="{{ article.image.wide }}" alt="{{ article.heading }}"/>
                                <div class="col-md-12 photograph-detail-meta">
-                                   <span class="meta-caption">{% if article.photographers %} Fotograf</span> {{ article.photographers|striptags|markdown }} {% endif %}
+                                   <span class="meta-caption">{% if article.image.photographer %} Fotograf</span> {{ article.image.photographer|striptags|markdown }} {% endif %}
                                </div>
                            </div>
                        </div>
@@ -123,7 +123,7 @@
                         </div>
                         <div class="tag-cloud">
                             {% if article.tags %}
-                                {% for tag in article.tags %}
+                                {% for tag in article.tags.all %}
                                     <a href="{% url 'view_article_tag' tag.name tag.slug %}"><span class="tag">{{ tag }}</span></a>
                                 {% endfor %}
                             {% else %}

--- a/templates/dashboard_base.html
+++ b/templates/dashboard_base.html
@@ -69,16 +69,6 @@
                                     <i class="fa fa-angle-double-right orange"></i> Oversikt
                                 </a>
                             </li>
-                            <li>
-                                <a href="{% url 'dashboard_tag_create' %}">
-                                    <i class="fa fa-angle-double-right orange"></i> Ny tag
-                                </a>
-                            </li>
-                            <li>
-                                <a href="{% url 'dashboard_tag_index' %}">
-                                    <i class="fa fa-angle-double-right orange"></i> Tags
-                                </a>
-                            </li>
                         </ul>
                     </li>
                     {% endif %}

--- a/templates/gallery/dashboard/detail.html
+++ b/templates/gallery/dashboard/detail.html
@@ -55,7 +55,7 @@ Bilder
                         <a href="{{ image.original }}">
                             <img class="responsive-image" src="{{ image.xs }}" alt title="{{ image.name|striptags }}" />
                         </a>
-                        <p><small></small></p>
+                        <p></p>
                         <dl class="dl-horizontal">
                             <dt>Diskforbruk</dt>
                             <dd>{{ image.sizeof_total }}</dd>

--- a/templates/gallery/edit.html
+++ b/templates/gallery/edit.html
@@ -43,6 +43,10 @@
                                     <textarea id="image-edit-description" placeholder="Skriv inn en beskrivelse av bildet her..." class="form-control" rows="6"></textarea>
                                 </div>
                                 <div class="form-group">
+                                    <label for="image-edit-photographer">Fotograf</label>
+                                    <input id="image-edit-photographer" type="text" class="form-control" placeholder="Kan stå blank...">
+                                </div>
+                                <div class="form-group">
                                     <label for="image-edit-tags">Tags</label>
                                     <input id="image-edit-tags" placeholder="Eksempel: kontoret, kjelleren, åre" class="form-control">
                                 </div>


### PR DESCRIPTION
Articles have been revamped significantly.
The Tag and ArticleTag models are now deleted and gone with the wind.

Instead Django-Taggit has taken its place, and provides a much easier API, as well as being inter-model searchable. This fixes #1324 

Photographers have been moved from article to responsiveimage. This fixes #1319 

Both the old and new API have been updated. Templates, dashboard, article detail, archive, and tags filtering and views have been refactored to use the new tagging engine.