### PR TITLE
Article tag slug reverse lookup bug for multi word tags with special chars

### DIFF
--- a/apps/article/urls.py
+++ b/apps/article/urls.py
@@ -10,7 +10,7 @@ urlpatterns = patterns(
     'apps.article.views',
     url(r'^archive/$', 'archive', name='article_archive'),
     url(r'^(?P<article_id>\d+)/(?P<article_slug>[a-zA-Z0-9_-]+)/$', 'details', name='article_details'),
-    url(r'^tag/(?P<name>[^\.]+)/(?P<slug>[^\.]+)/', 'archive_tag', name='view_article_tag'),
+    url(r'^tag/(?P<slug>[^\.]+)/', 'archive_tag', name='view_article_tag'),
     url(r'^year/(?P<year>\d+)/$', 'archive_year', name='article_archive_year'),
     url(r'^year/(?P<year>\d+)/month/(?P<month>[^\.]+)/$', 'archive_month', name='article_archive_month'),
 )

--- a/apps/article/views.py
+++ b/apps/article/views.py
@@ -3,6 +3,7 @@
 from collections import Counter
 
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
 from django.utils import timezone
 from django.shortcuts import render, get_object_or_404
 
@@ -134,7 +135,7 @@ class ArticleViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.
         query = self.request.query_params.get('query', None)
 
         if tags:
-            queryset = queryset.filter(tags__name__in=[tags])
+            queryset = queryset.filter(Q(tags__name__in=[tags]) | Q(tags__slug__in=[tags]))
 
         if year:
             if month:

--- a/templates/article/archive.html
+++ b/templates/article/archive.html
@@ -38,7 +38,7 @@
                 <h3>Tags</h3>
                 <div class="tag-cloud" id="article_archive_tagcloud">
                     {% for tag, count in tags %}
-                        <span><a href="{% url 'view_article_tag' tag.name tag.slug %}" class="tag">{{ tag }}</a></span>
+                        <span><a href="{% url 'view_article_tag' tag.slug %}" class="tag">{{ tag }}</a></span>
                     {% endfor %}
                 </div>
                 <h3>Filter</h3>

--- a/templates/article/dashboard/article_detail.html
+++ b/templates/article/dashboard/article_detail.html
@@ -79,7 +79,7 @@ Artikler
                     </p>
                     <h3>Tags</h3>
                     {% for tag in article.tags.all %}
-                        <a href="/article/tag/{{ tag.name }}/{{ tag.slug }}" class="btn btn-default">{{ tag }}</a>
+                        <a href="/article/tag/{{ tag.slug }}/" class="btn btn-default">{{ tag }}</a>
                     {% endfor %}
                 </div>
             </div>


### PR DESCRIPTION
Fix a bug in slug and name resolving for tags. Removed dual reverse lookup args. Using slug only.