### PR TITLE
Filter only against articles, not any object

### DIFF
--- a/apps/article/views.py
+++ b/apps/article/views.py
@@ -107,7 +107,7 @@ def details(request, article_id, article_slug):
     else:
         article.is_changed = False
 
-    related_articles = article.tags.similar_objects()[:4]
+    related_articles = Article.objects.filter(tags__in=article.tags.all()).distinct()[:4]
 
     return render(request, 'article/details.html', {'article': article, 'related_articles': related_articles})
 


### PR DESCRIPTION
When finding similar articles, only look for articles, not [any related object](https://django-taggit.readthedocs.org/en/latest/api.html#TaggableManager.similar_objects).