### PR TITLE
Bump django extensions and add requests security for frigg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ django-filebrowser==3.5.4 		# File uploading
 django-grappelli==2.6.3         # Admin template set
 git+git://github.com/clintecker/django-chunks.git@0.2# Chunks, or reusable key:content for templates.
 django-crispy-forms==1.4.0      # nice forms
-django-extensions==1.5.2        # nice extra commands for debugging, etc
+django-extensions==1.5.9        # nice extra commands for debugging, etc
 django-dynamic-fixture==1.8.1   # Dynamic fixtures for models
 django-recaptcha==1.0.4         # Google ReCaptcha
 django-oauth-toolkit==0.8.1     # OAuth2 authentication support
@@ -48,6 +48,9 @@ nose-cov==1.6
 teamcity-messages==1.16
 flake8==2.4.1
 pepper8>=1.0.4                  # Transforms flake8 output to HTML report + TC messages
+
+# Frigg
+requests[security]==2.8.0
 
 # Wiki
 git+https://github.com/django-wiki/django-wiki.git@e28776af87580740fb67488329c86dd58313d531#egg=wiki==0.1.dev1


### PR DESCRIPTION
Since we use `django>=1.8.0,<1.9.0` as a requirement we automatically get the newest django version if there's a new one. While not everyone installs requirements every time they start to work on the project, our deployment script will.

If there's going to be a release today, this patch is required as Django 1.8.6 (released yesterday) disallows south migrations in the same directory as django migrations, something django_extensions does in v. 1.5.6 (pointed out by @frecar in #1251 and #1281).

This patch bumps django extensions to a version where this is not a problem any more (v 1.5.9), and it adds some requirements for frigg tests. (while both the aforementioned PRs have included these requirements bumps, these requirements should be in develop ASAP and not having to wait for those feature branches to be merged.)