### PR TITLE
Add some filter fields so DRF is happy when rendering filter toolbox

### DIFF
--- a/apps/gallery/views.py
+++ b/apps/gallery/views.py
@@ -247,6 +247,7 @@ class ResponsiveImageViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin,
     queryset = ResponsiveImage.objects.filter().order_by('-timestamp')
     serializer_class = ResponsiveImageSerializer
     permission_classes = (AllowAny,)
+    filter_fields = ('id', 'name', 'timestamp')
 
     def get_queryset(self):
         queryset = self.queryset

--- a/apps/offline/views.py
+++ b/apps/offline/views.py
@@ -29,3 +29,4 @@ class OfflineIssueViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mi
     queryset = Issue.objects.all()
     serializer_class = OfflineIssueSerializer
     permission_classes = (AllowAny,)
+    filter_fields = ('id', 'issue', 'release_date', 'title')


### PR DESCRIPTION
Fixes the stacktraces from `/api/v1/offline/` and `/api/v1/images/`.

This does only happen if someone tries to render the HTML version of the page. Frontpage uses json-version of page so it's okay atm.