### PR TITLE
Save Stripe ID for webshop purchases, more informative receipt emails

### DIFF
--- a/apps/payment/views.py
+++ b/apps/payment/views.py
@@ -89,29 +89,27 @@ def payment_info(request):
     raise Http404("Request not supported")
 
 
-
 @login_required
 def webshop_info(request):
     if request.is_ajax():
         data = dict()
 
-        #TODO fix get order_line
+        # TODO fix get order_line
         order_line = OrderLine.objects.filter(user=request.user, paid=False).first()
 
         if order_line:
-            data['stripe_public_key'] = settings.STRIPE_PUBLIC_KEYS[1] #Prokom
+            data['stripe_public_key'] = settings.STRIPE_PUBLIC_KEYS[1]  # Prokom
             data['email'] = request.user.email
             data['order_line_id'] = order_line.pk
             data['price'] = int(order_line.subtotal() * 100)
 
             return HttpResponse(json.dumps(data), content_type="application/json")
 
-    raise Http404("Request not supported");
+    raise Http404("Request not supported")
 
 
 @login_required
 def webshop_pay(request):
-    logger = logging.getLogger(__name__)
 
     if request.is_ajax():
         if request.method == "POST":
@@ -123,19 +121,19 @@ def webshop_pay(request):
 
             order_line = OrderLine.objects.get(pk=order_line_id)
 
-            #Check if the user has added or removed items since reloading the checkout page
+            # Check if the user has added or removed items since reloading the checkout page
             if int(order_line.subtotal() * 100) != amount:
                 messages.error(request, u"Det har skjedd endringer på bestillingen. Prøv igjen")
                 return HttpResponse("Invalid input", content_type="text/plain", status=500)
 
             try:
-                stripe.api_key = settings.STRIPE_PRIVATE_KEYS[1] #Prokom
+                stripe.api_key = settings.STRIPE_PRIVATE_KEYS[1]  # Prokom
 
                 charge = stripe.Charge.create(
-                  amount=amount,
-                  currency="nok",
-                  card=token,
-                  description="Web shop purchase - " + request.user.email
+                    amount=amount,
+                    currency="nok",
+                    card=token,
+                    description="Web shop purchase - " + request.user.email
                 )
 
                 order_line.pay()
@@ -150,8 +148,8 @@ def webshop_pay(request):
                 messages.error(request, str(e))
                 return HttpResponse(str(e), content_type="text/plain", status=500) 
 
+    raise Http404("Request not supported")
 
-    raise Http404("Request not supported");
 
 @login_required
 def payment_refund(request, payment_relation_id):

--- a/apps/payment/views.py
+++ b/apps/payment/views.py
@@ -126,7 +126,7 @@ def webshop_pay(request):
             #Check if the user has added or removed items since reloading the checkout page
             if int(order_line.subtotal() * 100) != amount:
                 messages.error(request, u"Det har skjedd endringer på bestillingen. Prøv igjen")
-                return HttpResponse("Invalid input", content_type="text/plain", status=500) 
+                return HttpResponse("Invalid input", content_type="text/plain", status=500)
 
             try:
                 stripe.api_key = settings.STRIPE_PRIVATE_KEYS[1] #Prokom

--- a/apps/webshop/admin.py
+++ b/apps/webshop/admin.py
@@ -20,6 +20,16 @@ class ProductAdmin(admin.ModelAdmin):
     prepopulated_fields = {"slug": ("name",)}
 
 
+class OrderInline(admin.TabularInline):
+    model = Order
+    extra = 1
+
+
+class OrderLineAdmin(admin.ModelAdmin):
+    model = OrderLine
+    inlines = [OrderInline,]
+
+
 class OrderAdmin(admin.ModelAdmin):
     model = Order
 
@@ -27,4 +37,4 @@ class OrderAdmin(admin.ModelAdmin):
 admin.site.register(Category, CategoryAdmin)
 admin.site.register(Product, ProductAdmin)
 admin.site.register(Order, OrderAdmin)
-admin.site.register(OrderLine)
+admin.site.register(OrderLine, OrderLineAdmin)

--- a/apps/webshop/dashboard/views.py
+++ b/apps/webshop/dashboard/views.py
@@ -1,13 +1,10 @@
-from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
-from django.shortcuts import render, get_object_or_404, redirect
-from django.http import HttpResponseBadRequest, HttpResponse, JsonResponse
-from django.views.generic import TemplateView, DetailView, RedirectView, UpdateView, CreateView, DeleteView
+from django.shortcuts import get_object_or_404
+from django.views.generic import TemplateView, DetailView, UpdateView, CreateView, DeleteView
 
-from apps.dashboard.tools import DashboardMixin, DashboardPermissionMixin
+from apps.dashboard.tools import DashboardPermissionMixin
 from apps.gallery.models import ResponsiveImage
-from apps.webshop.dashboard.forms import CategoryForm, ProductForm
 from apps.webshop.models import Category, Product
 
 from taggit.models import TaggedItem
@@ -32,10 +29,12 @@ class Categories(DashboardPermissionMixin, TemplateView):
         context['categories'] = Category.objects.all().prefetch_related('products')
         return context
 
+
 class CategoryView(DashboardPermissionMixin, DetailView):
     model = Category
     template_name = 'webshop/dashboard/category.html'
     permission_required = 'webshop.view_category'
+
 
 class CategoryCreate(DashboardPermissionMixin, CreateView):
     model = Category
@@ -50,6 +49,7 @@ class CategoryCreate(DashboardPermissionMixin, CreateView):
     def get_success_url(self):
         return reverse('dashboard-webshop:categories')
 
+
 class CategoryUpdate(DashboardPermissionMixin, UpdateView):
     model = Category
     fields = ['name', 'slug']
@@ -60,6 +60,7 @@ class CategoryUpdate(DashboardPermissionMixin, UpdateView):
     def get_success_url(self):
         return reverse('dashboard-webshop:category', kwargs={'slug': self.object.slug})
 
+
 class CategoryDelete(DashboardPermissionMixin, DeleteView):
     model = Category
     template_name = 'webshop/dashboard/delete.html'
@@ -68,10 +69,12 @@ class CategoryDelete(DashboardPermissionMixin, DeleteView):
     def get_success_url(self):
         return reverse('dashboard-webshop:categories')
 
+
 class ProductView(DashboardPermissionMixin, DetailView):
     model = Product
     template_name = 'webshop/dashboard/product.html'
     permission_required = 'webshop.view_product'
+
 
 class ProductCreate(DashboardPermissionMixin, CreateView):
     model = Product
@@ -98,6 +101,7 @@ class ProductCreate(DashboardPermissionMixin, CreateView):
     def get_success_url(self):
         return reverse('dashboard-webshop:category', kwargs={'slug': self.kwargs.get('category_slug')})
 
+
 class ProductUpdate(DashboardPermissionMixin, UpdateView):
     model = Product
     fields = ['name', 'slug', 'short', 'description', 'price', 'stock']
@@ -112,6 +116,7 @@ class ProductUpdate(DashboardPermissionMixin, UpdateView):
 
     def get_success_url(self):
         return reverse('dashboard-webshop:product', kwargs={'slug': self.object.slug})
+
 
 class ProductDelete(DashboardPermissionMixin, DeleteView):
     model = Product

--- a/apps/webshop/migrations/0002_orderline_stripe_id.py
+++ b/apps/webshop/migrations/0002_orderline_stripe_id.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webshop', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='orderline',
+            name='stripe_id',
+            field=models.CharField(max_length=50, null=True, blank=True),
+        ),
+    ]

--- a/apps/webshop/models.py
+++ b/apps/webshop/models.py
@@ -95,6 +95,7 @@ class OrderLine(models.Model):
     user = models.ForeignKey(User)
     datetime = models.DateTimeField(auto_now_add=True)
     paid = models.BooleanField(default=False)
+    stripe_id = models.CharField(max_length=50, null=True, blank=True)
 
     def count_orders(self):
         return sum((order.quantity for order in self.orders.all()))

--- a/apps/webshop/models.py
+++ b/apps/webshop/models.py
@@ -57,6 +57,7 @@ class Category(models.Model):
         verbose_name = 'Kategori'
         verbose_name_plural = 'Kategorier'
 
+
 class ProductSize(models.Model):
     product = models.ForeignKey(Product)
     size = models.CharField(u'Størrelse', max_length=25)


### PR DESCRIPTION
Basically I wanted to add the stripe charge id so a customer has some reference to easily match a given transaction (using the uid rather than filtering on user...) if there are any questions, or for a refund. This information should be saved on our servers for easy retrieval, rather than we having to query Stripe to get this information.

Tbh, it's a really important fix and it should be released ASAP, unless anyone have any problems with the implementation.

I also included a simple list of what was purchased.