### PR TITLE
Run group syncer on groups post-save hooks

### DIFF
--- a/apps/authentication/appconfig.py
+++ b/apps/authentication/appconfig.py
@@ -4,3 +4,9 @@ from django.apps import AppConfig
 class AuthenticationConfig(AppConfig):
     name = 'apps.authentication'
     verbose_name = 'Authentication for OW4'
+
+    def ready(self):
+        super(AuthenticationConfig, self).ready()
+        # The following stops pycharm from nagging about unused import statement
+        # noinspection PyUnresolvedReferences
+        import apps.authentication.signals

--- a/apps/authentication/signals.py
+++ b/apps/authentication/signals.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from django.conf import settings
+from django.contrib.auth.models import Group
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from apps.authentication.tasks import SynchronizeGroups
+
+
+@receiver(post_save, sender=Group)
+def trigger_group_syncer(sender, instance, created, **kwargs):
+    """
+    :param sender: The model that triggered this hook
+    :param instance: The model instance triggering this hook
+    :param created: True if the instance was created, False if the instance was updated
+
+    Calls the SynchronizeGroups Task if a group is updated. (Not if it's the initial creation of a group)
+    """
+
+    if created:
+        # If a new instance is created, we do not need to trigger group sync.
+        pass
+    else:
+        SynchronizeGroups.run()

--- a/apps/authentication/tasks.py
+++ b/apps/authentication/tasks.py
@@ -15,9 +15,14 @@ class SynchronizeGroups(Task):
     @staticmethod
     def run():
         logger = logging.getLogger('syncer')
-        locale.setlocale(locale.LC_ALL, 'en_US.utf8')
 
-        SynchronizeGroups.do_sync(logger)
+        if not hasattr(settings, "GROUP_SYNCER"):
+            # Make sure to only run the group syncer if we have the settings for it
+            logger.info("GROUP_SYNCER setting not set, not syncing groups")
+        else:
+            locale.setlocale(locale.LC_ALL, 'en_US.utf8')
+
+            SynchronizeGroups.do_sync(logger)
 
     @staticmethod
     def do_sync(logger):
@@ -108,6 +113,3 @@ class SynchronizeGroups(Task):
                         ' because they were not in the source group(s).'
                     )
 
-
-# Register scheduler
-schedule.register(SynchronizeGroups, day_of_week='mon-sun', minute='*/15')


### PR DESCRIPTION
Resolves #1191.

While the aforementioned issue is right in the fact that the syncer spams the logs, it should "spam" the logs - if it has something to spam it with. 

This PR makes the group syncer run whenever there are changes to a group, rather than every 15 minutes.

