### PR TITLE
Featured events by registration start

### DIFF
--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -39,8 +39,10 @@ class EventOrderedByRegistration(models.Manager):
     Order events by registration start if registration start is within 7 days of today.
     """
     def get_queryset(self):
-        week_back = timezone.now() - timedelta(days=7)
-        week_in_future = timezone.now() + timedelta(days=7)
+        DELTA_FUTURE = settings.OW4_SETTINGS.get('events').get('OW4_EVENTS_FEATURED_DAYS_FUTURE')
+        DELTA_PAST = settings.OW4_SETTINGS.get('events').get('OW4_EVENTS_FEATURED_DAYS_PAST')
+        week_back = timezone.now() - timedelta(days=DELTA_PAST)
+        week_in_future = timezone.now() + timedelta(days=DELTA_FUTURE)
 
         return super(EventOrderedByRegistration, self).get_queryset().\
             annotate(registration_filtered=Case(

--- a/apps/events/tests.py
+++ b/apps/events/tests.py
@@ -383,6 +383,59 @@ class EventTest(TestCase):
                         "Any user should be able to see unrestricted events")
 
 
+class EventOrderedByRegistrationTestCase(TestCase):
+    def test_registration_no_push_forward(self):
+        """
+        Tests that an AttendanceEvent with registration date far in the future is sorted by its event end date,
+        like any other event.
+        """
+        today = timezone.now()
+        month_ahead = today + datetime.timedelta(days=30)
+        month_ahead_plus_five = month_ahead + datetime.timedelta(days=5)
+        normal_event = G(Event, event_start=month_ahead, event_end=month_ahead)
+        pushed_event = G(Event, event_start=month_ahead_plus_five, event_end=month_ahead_plus_five)
+        G(AttendanceEvent, registration_start=month_ahead_plus_five, registration_end=month_ahead_plus_five,
+          event=pushed_event)
+
+        expected_order = [normal_event, pushed_event]
+
+        self.assertEqual(list(Event.by_registration.all()), expected_order)
+
+    def test_registration_start_pushed_forward(self):
+        """
+        Tests that an AttendanceEvent with registration date within the "featured delta" (+/- 7 days from today)
+        will be pushed ahead in the event list, thus sorted by registration start rather than event end.
+        """
+        today = timezone.now()
+        three_days_ahead = today + datetime.timedelta(days=3)
+        month_ahead = today + datetime.timedelta(days=30)
+        month_ahead_plus_five = month_ahead + datetime.timedelta(days=5)
+        normal_event = G(Event, event_start=month_ahead, event_end=month_ahead)
+        pushed_event = G(Event, event_start=month_ahead_plus_five, event_end=month_ahead_plus_five)
+        G(AttendanceEvent, registration_start=three_days_ahead, registration_end=three_days_ahead, event=pushed_event)
+
+        expected_order = [pushed_event, normal_event]
+
+        self.assertEqual(list(Event.by_registration.all()), expected_order)
+
+    def test_registration_past_push_forward(self):
+        """
+        Tests that an AttendanceEvent with a registration date in the past, outside the "featured delta" (+/- 7 days)
+        will be sorted by the event's end date.
+        """
+        today = timezone.now()
+        month_ahead = today + datetime.timedelta(days=30)
+        month_ahead_plus_five = month_ahead + datetime.timedelta(days=5)
+        month_back = today - datetime.timedelta(days=30)
+        normal_event = G(Event, event_start=month_ahead, event_end=month_ahead)
+        pushed_event = G(Event, event_start=month_ahead_plus_five, event_end=month_ahead_plus_five)
+        G(AttendanceEvent, registration_start=month_back, registration_end=month_back, event=pushed_event)
+
+        expected_order = [normal_event, pushed_event]
+
+        self.assertEqual(list(Event.by_registration.all()), expected_order)
+
+
 class EventsURLTestCase(TestCase):
     def test_events_index_empty(self):
         url = reverse('events_index')

--- a/apps/events/tests.py
+++ b/apps/events/tests.py
@@ -3,9 +3,10 @@
 import datetime
 import logging
 
+from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from django_dynamic_fixture import G
 from rest_framework import status
@@ -384,6 +385,12 @@ class EventTest(TestCase):
 
 
 class EventOrderedByRegistrationTestCase(TestCase):
+    def setUp(self):
+        self.FEATURED_TIMEDELTA_SETTINGS = settings
+        # Override settings so that the tests will work even if we update the default delta
+        self.FEATURED_TIMEDELTA_SETTINGS.OW4_SETTINGS['events']['OW4_EVENTS_FEATURED_DAYS_FUTURE'] = 7
+        self.FEATURED_TIMEDELTA_SETTINGS.OW4_SETTINGS['events']['OW4_EVENTS_FEATURED_DAYS_PAST'] = 7
+
     def test_registration_no_push_forward(self):
         """
         Tests that an AttendanceEvent with registration date far in the future is sorted by its event end date,
@@ -399,7 +406,8 @@ class EventOrderedByRegistrationTestCase(TestCase):
 
         expected_order = [normal_event, pushed_event]
 
-        self.assertEqual(list(Event.by_registration.all()), expected_order)
+        with override_settings(settings=self.FEATURED_TIMEDELTA_SETTINGS):
+            self.assertEqual(list(Event.by_registration.all()), expected_order)
 
     def test_registration_start_pushed_forward(self):
         """
@@ -416,7 +424,8 @@ class EventOrderedByRegistrationTestCase(TestCase):
 
         expected_order = [pushed_event, normal_event]
 
-        self.assertEqual(list(Event.by_registration.all()), expected_order)
+        with override_settings(settings=self.FEATURED_TIMEDELTA_SETTINGS):
+            self.assertEqual(list(Event.by_registration.all()), expected_order)
 
     def test_registration_past_push_forward(self):
         """
@@ -433,7 +442,8 @@ class EventOrderedByRegistrationTestCase(TestCase):
 
         expected_order = [normal_event, pushed_event]
 
-        self.assertEqual(list(Event.by_registration.all()), expected_order)
+        with override_settings(settings=self.FEATURED_TIMEDELTA_SETTINGS):
+            self.assertEqual(list(Event.by_registration.all()), expected_order)
 
 
 class EventsURLTestCase(TestCase):

--- a/apps/events/tests.py
+++ b/apps/events/tests.py
@@ -32,7 +32,7 @@ class EventTest(TestCase):
 
     def setUp(self):
         self.event = G(Event, title='Sjakkturnering')
-        self.attendance_event = G(AttendanceEvent, event=self.event)
+        self.attendance_event = G(AttendanceEvent, event=self.event, max_capacity=2)
         self.user = G(User, username='ola123', ntnu_username='ola123ntnu', first_name="ola", last_name="nordmann")
         self.attendee = G(Attendee, event=self.attendance_event, user=self.user)
         self.logger = logging.getLogger(__name__)

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -300,11 +300,15 @@ class EventViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.Li
     permission_classes = (AllowAny,)
     filter_class = EventDateFilter
     filter_fields = ('event_start', 'event_end', 'id',)
-    ordering_fields = ('event_start', 'event_end', 'id',)
-    ordering = ('id',)
+    ordering_fields = ('event_start', 'event_end', 'id', 'registration_filtered',)
+    ordering = ('id', 'registration_filtered',)
 
     def get_queryset(self):
-        return Event.objects.filter(
+        """
+        :return: Queryset filtered by these requirements:
+        - event has NO group restriction OR user having access to restricted event
+        """
+        return Event.by_registration.filter(
             Q(group_restriction__isnull=True) | Q(group_restriction__groups__in=self.request.user.groups.all())).\
             distinct()
 

--- a/files/static/js/EventWidget.js
+++ b/files/static/js/EventWidget.js
@@ -9,7 +9,7 @@ function EventWidget (Utils){
         var now = moment();
 
         Utils.makeApiRequest({
-            'url':'/api/v1/events/?event_end__gte=' + now.format('YYYY-MM-DD') + '&ordering=event_start&format=json',
+            'url':'/api/v1/events/?event_end__gte=' + now.format('YYYY-MM-DD') + '&ordering=registration_filtered&format=json',
             'method' : 'GET',
             'data': {},
             success: function (data) {

--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -398,6 +398,13 @@ REST_FRAMEWORK = {
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r'^/api/v1/.*$' # Enables CORS on /api/v1/ endpoints only
 
+OW4_SETTINGS = {
+   'events': {
+       'FEATURED_DAYS_FUTURE': os.getenv('OW4_EVENTS_FEATURED_DAYS_FUTURE', 7),
+       'FEATURED_DAYS_PAST': os.getenv('OW4_EVENTS_FEATURED_DAYS_PAST', 7),
+   }
+}
+
 # Remember to keep 'local' last, so it can override any setting.
 for settings_module in ['filebrowser', 'django_wiki', 'local']:  # local last
     if not os.path.exists(os.path.join(PROJECT_SETTINGS_DIRECTORY,


### PR DESCRIPTION
Fixes #1285.

Committed code is well documented with the changes.

This new manager will order events by registration start if it's an attendance event and attendance_event.registration_start is within a time delta of 7 days.