### PR TITLE
Fixes provisioning bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ node_modules/*
 .tox
 coverage
 coverage.xml
+setuptools-*.zip

--- a/vagrantbootstrap.sh
+++ b/vagrantbootstrap.sh
@@ -109,6 +109,7 @@ function prepare_and_run_onlineweb() {
 
 init
 update_packages
+install_curl
 add_custom_repos
 update_packages
 install_packages

--- a/vagrantbootstrap.sh
+++ b/vagrantbootstrap.sh
@@ -61,7 +61,7 @@ function install_packages() {
     echo "installing packages"
     progress sudo apt-get install -y \
         python-dev python-setuptools python-virtualenv vim \
-        tmux screen git-core curl build-essential openssl \
+        tmux screen git-core build-essential openssl \
         libjpeg8 libjpeg8-dev zlib-bin libtiff4-dev libfreetype6 libfreetype6-dev libpq-dev libssl-dev\
         python-psycopg2 imagemagick \
         nodejs # from custom ppa:chris-lea/node.js

--- a/vagrantbootstrap.sh
+++ b/vagrantbootstrap.sh
@@ -41,10 +41,10 @@ function progress() {
     fi
 }
 
+
 function add_custom_repos() {
     echo "adding custom repositories for nodejs"
-    progress sudo apt-get install -y python-software-properties
-    progress sudo add-apt-repository -y ppa:chris-lea/node.js
+    progress curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
 }
 
 function update_packages() {

--- a/vagrantbootstrap.sh
+++ b/vagrantbootstrap.sh
@@ -64,7 +64,8 @@ function install_packages() {
         tmux screen git-core build-essential openssl \
         libjpeg8 libjpeg8-dev zlib-bin libtiff4-dev libfreetype6 libfreetype6-dev libpq-dev libssl-dev\
         python-psycopg2 imagemagick \
-        nodejs # from custom ppa:chris-lea/node.js
+        nodejs \
+        libffi-dev
 }
 
 function setup_virtualenv() {

--- a/vagrantbootstrap.sh
+++ b/vagrantbootstrap.sh
@@ -52,6 +52,11 @@ function update_packages() {
     progress sudo apt-get update
 }
 
+function install_curl() {
+    echo "installing curl"
+    progress sudo apt-get install curl
+}
+
 function install_packages() {
     echo "installing packages"
     progress sudo apt-get install -y \

--- a/vagrantbootstrap.sh
+++ b/vagrantbootstrap.sh
@@ -99,7 +99,7 @@ function prepare_and_run_onlineweb() {
     cd /vagrant
     cp onlineweb4/settings/example-local.py onlineweb4/settings/local.py
     echo "creating tables"
-    progress python manage.py syncdb
+    progress python manage.py migrate
     if $RUNSERVER
     then
         echo "starting dev server"


### PR DESCRIPTION
This PR bumps nodejs to 4.x LTS version, and installs libffi-dev

In current state the system won't provision correctly. Too old node version causes errors like (see [gist](https://gist.github.com/tmn/f5529f727a723a90f004)): 

```
cryptiles@2.0.5: wanted: {"node":">=0.10.40"} (current: {"node":"0.10.37","npm":"1.4.28"})
boom@2.10.1: wanted: {"node":">=0.10.40"} (current: {"node":"0.10.37","npm":"1.4.28"})
hoek@2.16.3: wanted: {"node":">=0.10.40"} (current: {"node":"0.10.37","npm":"1.4.28"})
```


And missing **libffi-dev** causes errors on `cryptography` when `Running setup.py install for cryptography` (see [gist](https://gist.github.com/tmn/0c347d7cc36d1ed165e8)).