### PR TITLE
Fix displaying extras in dashboard events

### DIFF
--- a/templates/events/dashboard/details.html
+++ b/templates/events/dashboard/details.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 
 {% block title %}
-{{ event }} - Dashboard - Online 
+{{ event }} - Dashboard - Online
 {% endblock title %}
 
 {% block page-header %}
@@ -20,7 +20,7 @@ Arrangementsdetaljer
 {% endblock %}
 
 {% block breadcrumbs %}
-    <li><a href="{% url 'dashboard_events_index' %}">Events</a></li> 
+    <li><a href="{% url 'dashboard_events_index' %}">Events</a></li>
     <li>{{ event }}</li>
 {% endblock %}
 
@@ -37,17 +37,17 @@ Arrangementsdetaljer
         <div class="panel panel-default">
             <div class="panel-body">
                 <ul id="dashboard-tabs" class="nav nav-tabs">
-                    <li role="presentation" class="hidden {% if active_tab == 'attendance' %} active{% endif %}">
+                    <li role="presentation" class="hidden {% if active_tab == 'details' %} active{% endif %}">
                         <a data-section="details" href="{% url 'dashboard_event_details_active' event.id 'details' %}">Detaljer</a>
                     </li>
                     <li role="presentation" class="hidden{% if active_tab == 'attendance' %} active{% endif %}">
                         <a data-section="attendance" href="{% url 'dashboard_event_details_active' event.id 'attendance' %}">Påmelding</a>
                     </li>
                     {% if event.is_attendance_event %}
-                    <li role="presentation" class="{% if active_tab == 'attendance' %} active{% endif %}">
+                    <li role="presentation" class="{% if active_tab == 'attendees' %} active{% endif %}">
                         <a data-section="attendees" href="{% url 'dashboard_event_details_active' event.id 'attendees' %}">Påmeldte</a>
                     </li>
-                    <li role="presentation" class="hidden{% if active_tab == 'attendance' %} active{% endif %}">
+                    <li role="presentation" class="hidden{% if active_tab == 'reservation' %} active{% endif %}">
                         <a data-section="reservation" href="{% url 'dashboard_event_details_active' event.id 'reservation' %}">Reservasjon</a>
                     </li>
                     {% endif %}

--- a/templates/events/dashboard/index.html
+++ b/templates/events/dashboard/index.html
@@ -2,7 +2,7 @@
 {% load compress %}
 
 {% block title %}
-Event index - Dashboard - Online 
+Event index - Dashboard - Online
 {% endblock title %}
 
 {% block page-header %}
@@ -24,7 +24,7 @@ Arrangementsoversikt
 {% endblock js %}
 
 {% block breadcrumbs %}
-    <li>Events</li> 
+    <li>Events</li>
 {% endblock %}
 
 {% block content %}
@@ -47,7 +47,7 @@ Arrangementsoversikt
                     <tbody>
                     {% for event in events %}
                         <tr>
-                            <td><a href="{% url 'dashboard_event_details' event.id %}">{{ event }}</a></td>
+                            <td><a href="{% url 'dashboard_event_change_attendees' event.id %}">{{ event }}</a></td>
                             <td>
                                 {% if event.is_attendance_event %}
                                     {{ event.attendance_event.number_of_seats_taken }}/{{ event.attendance_event.max_capacity }}


### PR DESCRIPTION
This actually just sends the user directly to the attendees page until we add more tabs. 
The related views needs to be rewritten to proper support tab switching with context like extras. 