### PR TITLE
Dashboard events fix

### DIFF
--- a/apps/events/dashboard/utils.py
+++ b/apps/events/dashboard/utils.py
@@ -18,12 +18,14 @@ def event_ajax_handler(event, request):
     if action == 'attended':
         attendee = _get_attendee(request.POST['attendee_id'])
         if not attendee:
-            return u'Fant ingen påmeldte med oppgitt ID (%s).' % request.POST['attendee_id']
+            return {'message': u'Fant ingen påmeldte med oppgitt ID (%s).' % request.POST['attendee_id'],
+                    'status': 400}
         return handle_attended(attendee)
     elif action == 'paid':
         attendee = _get_attendee(request.POST['attendee_id'])
         if not attendee:
-            return u'Fant ingen påmeldte med oppgitt ID (%s).' % request.POST['attendee_id']
+            return {'message': u'Fant ingen påmeldte med oppgitt ID (%s).' % request.POST['attendee_id'],
+                    'status': 400}
         return handle_paid(attendee)
     elif action == 'add_attendee':
         return handle_add_attendee(event, request.POST['user_id'])

--- a/apps/events/dashboard/utils.py
+++ b/apps/events/dashboard/utils.py
@@ -42,6 +42,8 @@ def handle_attended(attendee):
     attendee.attended = not attendee.attended
     attendee.save()
 
+    return {'message': 'OK', 'status': 200}
+
 
 def handle_paid(attendee):
     """
@@ -51,6 +53,8 @@ def handle_paid(attendee):
     """
     attendee.paid = not attendee.paid
     attendee.save()
+
+    return {'message': 'OK', 'status': 200}
 
 
 def handle_add_attendee(event, user_id):

--- a/apps/events/dashboard/views.py
+++ b/apps/events/dashboard/views.py
@@ -187,7 +187,7 @@ def event_change_attendees(request, event_id, active_tab='attendees'):
             # Temp fix since event_ajax_handler can return either a dict with proper data
             # or just a string with an error message
             resp = event_ajax_handler(event, request)
-            if not isinstance(dict, resp):
+            if not isinstance(resp, dict):
                 return HttpResponse(_(unicode(resp)), status=400)
             else:
                 return JsonResponse(resp)

--- a/apps/events/dashboard/views.py
+++ b/apps/events/dashboard/views.py
@@ -184,13 +184,7 @@ def event_change_attendees(request, event_id, active_tab='attendees'):
             if not event.is_attendance_event:
                 return HttpResponse(_(u'Dette er ikke et påmeldingsarrangement.'), status=400)
 
-            # Temp fix since event_ajax_handler can return either a dict with proper data
-            # or just a string with an error message
-            resp = event_ajax_handler(event, request)
-            if not isinstance(resp, dict):
-                return HttpResponse(_(unicode(resp)), status=400)
-            else:
-                return JsonResponse(resp)
+            return JsonResponse(event_ajax_handler(event, request))
 
     # NON AJAX
     context = get_base_context(request)

--- a/apps/events/dashboard/views.py
+++ b/apps/events/dashboard/views.py
@@ -184,7 +184,13 @@ def event_change_attendees(request, event_id, active_tab='attendees'):
             if not event.is_attendance_event:
                 return HttpResponse(_(u'Dette er ikke et påmeldingsarrangement.'), status=400)
 
-            return JsonResponse(event_ajax_handler(event, request))
+            # Temp fix since event_ajax_handler can return either a dict with proper data
+            # or just a string with an error message
+            resp = event_ajax_handler(event, request)
+            if not isinstance(dict, resp):
+                return HttpResponse(_(unicode(resp)), status=400)
+            else:
+                return JsonResponse(resp)
 
     # NON AJAX
     context = get_base_context(request)


### PR DESCRIPTION
Temporary fix for dashboard events ajax responses for attended and paid statuses.
This should really be fixed in `apps/events/dashboard/utils.py` where the functions return both `None`, `unicode` or `dict`. All should be a proper dict with status and message to prevent the need for runtime object introspection.