### PR TITLE
Group sync

### DIFF
--- a/apps/authentication/signals.py
+++ b/apps/authentication/signals.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import logging
+import uuid
+
 from apps.authentication.tasks import SynchronizeGroups
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
@@ -6,10 +9,12 @@ from django.db.models.signals import m2m_changed, post_save
 from django.dispatch import receiver
 
 User = get_user_model()
+logger = logging.getLogger('syncer.%s' % __name__)
+sync_uuid = uuid.uuid1()
 
 
 @receiver(post_save, sender=Group)
-def trigger_group_syncer(sender, instance, created=False, **kwargs):
+def trigger_group_syncer(sender, created=False, **kwargs):
     """
     :param sender: The model that triggered this hook
     :param instance: The model instance triggering this hook
@@ -17,11 +22,25 @@ def trigger_group_syncer(sender, instance, created=False, **kwargs):
 
     Calls the SynchronizeGroups Task if a group is updated. (Not if it's the initial creation of a group)
     """
+    global sync_uuid
 
     if created:
         # If a new instance is created, we do not need to trigger group sync.
         pass
     else:
-        SynchronizeGroups.run()
+        # If sync is triggered by adding a user to group or a group to a user
+        # then we need to detach the signal hook listening to m2m changes on
+        # those models as they will trigger a recursive call to this method.
+        if sender == User.groups.through:
+            logger.debug('Disconnect m2m_changed signal hook with uuid %s before synchronizing groups' % sync_uuid)
+            if m2m_changed.disconnect(sender=sender, dispatch_uid=sync_uuid):
+                logger.debug('Signal with uuid %s disconnected' % sync_uuid)
+                SynchronizeGroups.run()
 
-m2m_changed.connect(trigger_group_syncer, sender=User.groups.through)
+            sync_uuid = uuid.uuid1()
+            logger.debug('m2m_changed signal hook reconnected with uuid: %s' % sync_uuid)
+            m2m_changed.connect(receiver=trigger_group_syncer, dispatch_uid=sync_uuid, sender=User.groups.through)
+        else:
+            SynchronizeGroups.run()
+
+m2m_changed.connect(trigger_group_syncer, dispatch_uid=sync_uuid, sender=User.groups.through)

--- a/apps/authentication/tasks.py
+++ b/apps/authentication/tasks.py
@@ -25,21 +25,18 @@ class SynchronizeGroups(Task):
     @staticmethod
     def do_sync(logger):
         # Loop all the syncs
-        for sync in settings.GROUP_SYNCER:
-            # Log that syncer we are running
-            logger.info('Started: ' + sync.get('name'))
+        for job in settings.GROUP_SYNCER:
+            # Log that jober we are running
+            logger.info('Started: ' + job.get('name'))
 
-            SynchronizeGroups.add_users(sync, logger)
-            SynchronizeGroups.remove_users(sync, logger)
+            SynchronizeGroups.add_users(job, logger)
+            SynchronizeGroups.remove_users(job, logger)
 
     @staticmethod
     def add_users(sync, logger):
 
         # FORWARD SYNC
         # Syncing users from source groups to destination groups
-
-        # Store number of synced users
-        synced = 0
 
         # Get all users in the source groups
         users_in_source = User.objects.filter(
@@ -63,22 +60,11 @@ class SynchronizeGroups(Task):
                         destination_group_object.user_set.add(user)
                         logger.info('%s added to group %s' % (user, destination_group_object.name))
 
-                        # Increase syncs
-                        synced += 1
-
-            # Check if any changes were made and if there was, log it
-            if synced > 0:
-                logger.info('%s user(s) were synced to correct destination group(s).' % synced)
-                pass
-
     @staticmethod
     def remove_users(sync, logger):
 
         # BACKWARDS SYNC
         # Removing users from destination group(s) if they are not in the source group(s)
-
-        # Store number of synced users
-        synced = 0
 
         # Get all users in the destination groups
         users_in_destination = User.objects.filter(
@@ -110,13 +96,4 @@ class SynchronizeGroups(Task):
                             # This group is a destination group, remove it from the user
                             destination_group = Group.objects.filter(id=user_group.id).first()
                             destination_group.user_set.remove(user)
-                            logger.info('%s removed from group %s' % (user, destination_group_object.name))
-
-                            # Increase syncs
-                            synced += 1
-
-            # Check if any changes were made and if there was, log it
-            if synced > 0:
-                logger.info('%s user(s) were removed from the destination group(s) '
-                            'because they were not in the source group(s).' % synced
-                            )
+                            logger.info('%s removed from group %s' % (user, destination_group.name))

--- a/apps/authentication/tasks.py
+++ b/apps/authentication/tasks.py
@@ -26,7 +26,7 @@ class SynchronizeGroups(Task):
     def do_sync(logger):
         # Loop all the syncs
         for job in settings.GROUP_SYNCER:
-            # Log that jober we are running
+            # Log what job we are running
             logger.info('Started: ' + job.get('name'))
 
             SynchronizeGroups.add_users(job, logger)

--- a/apps/authentication/tasks.py
+++ b/apps/authentication/tasks.py
@@ -12,7 +12,7 @@ class SynchronizeGroups(Task):
 
     @staticmethod
     def run():
-        logger = logging.getLogger('syncer')
+        logger = logging.getLogger('syncer.%s' % __name__)
 
         if not hasattr(settings, "GROUP_SYNCER"):
             # Make sure to only run the group syncer if we have the settings for it
@@ -29,9 +29,11 @@ class SynchronizeGroups(Task):
             # Log that syncer we are running
             logger.info('Started: ' + sync.get('name'))
 
+            SynchronizeGroups.add_users(sync, logger)
+            SynchronizeGroups.remove_users(sync, logger)
+
     @staticmethod
-    def add_users(sync):
-        logger = logging.getLogger(__name__)
+    def add_users(sync, logger):
 
         # FORWARD SYNC
         # Syncing users from source groups to destination groups
@@ -59,17 +61,18 @@ class SynchronizeGroups(Task):
                     if destination_group_object not in user_groups:
                         # User is not in the current destination group, add
                         destination_group_object.user_set.add(user)
+                        logger.info('%s added to group %s' % (user, destination_group_object.name))
 
                         # Increase syncs
                         synced += 1
 
             # Check if any changes were made and if there was, log it
             if synced > 0:
-                logger.info(str(synced) + ' user(s) were synced to correct destination group(s).')
+                logger.info('%s user(s) were synced to correct destination group(s).' % synced)
+                pass
 
     @staticmethod
-    def remove_users(sync):
-        logger = logging.getLogger(__name__)
+    def remove_users(sync, logger):
 
         # BACKWARDS SYNC
         # Removing users from destination group(s) if they are not in the source group(s)
@@ -107,14 +110,13 @@ class SynchronizeGroups(Task):
                             # This group is a destination group, remove it from the user
                             destination_group = Group.objects.filter(id=user_group.id).first()
                             destination_group.user_set.remove(user)
+                            logger.info('%s removed from group %s' % (user, destination_group_object.name))
 
                             # Increase syncs
                             synced += 1
 
             # Check if any changes were made and if there was, log it
             if synced > 0:
-                logger.info(
-                    str(synced) +
-                    ' user(s) were removed from the destination group(s) ' +
-                    ' because they were not in the source group(s).'
-                )
+                logger.info('%s user(s) were removed from the destination group(s) '
+                            'because they were not in the source group(s).' % synced
+                            )


### PR DESCRIPTION
Disconnects signal hooks as to avoid infinite recursive calls when adding or removing users to syncable groups.