### PR TITLE
Add config for py.test to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,8 @@ skip=.tox,onlineweb4/settings/__init__.py
 default_section=THIRDPARTY
 known_first_party=apps
 
+[pytest]
+DJANGO_SETTINGS_MODULE=onlineweb4.settings
+norecursedirs=.* env* tmp*
+python_files=tests.py
+


### PR DESCRIPTION
Add a config for running `py.test` as test runner to the setup.cfg script. 

This is an alternative to `python manage.py test` which currently spits out a bunch of coverage-data, which IMO is unnecessary during developing. This won't break anything, but it'll add some simplicity to (at least my) testing. 

`py.test` will run tests, just like `python manage test` does, but with a bit different output, and without coverage (except explicitly declared, using `--cover=apps`.

Example output:
```
 ❯ py.test                                                                                [00:52:01]
======================================== test session starts ========================================
platform darwin -- Python 3.5.1, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
django settings: onlineweb4.settings (from ini file)
rootdir: /Users/sklirg/projects/github/onlineweb4, inifile: setup.cfg
plugins: cov-2.2.0, django-2.9.1, flake8-0.2, isort-0.1.0
collected 92 items

apps/approval/tests.py ...
apps/article/tests.py .
apps/authentication/tests.py ................
apps/autoconfig/tests.py ..
apps/careeropportunity/tests.py .
apps/companyprofile/tests.py .
apps/events/tests.py ........................
apps/feedback/tests.py .................
apps/marks/tests.py .........
apps/offline/tests.py ..
apps/payment/tests.py ..............
apps/profiles/tests.py .
apps/resourcecenter/tests.py .

==================================== 92 passed in 63.70 seconds =====================================
```