### PR TITLE
Article cache fix

### DIFF
--- a/apps/article/views.py
+++ b/apps/article/views.py
@@ -85,7 +85,7 @@ class ArticleViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.
     filter_fields = ('tags',)
 
     def get_queryset(self):
-        queryset = self.queryset
+        queryset = self.queryset.all()
         month = self.request.query_params.get('month', None)
         year = self.request.query_params.get('year', None)
         tags = self.request.query_params.get('tags', None)

--- a/apps/article/views.py
+++ b/apps/article/views.py
@@ -2,7 +2,6 @@
 
 from collections import Counter
 
-import watson
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, render
@@ -10,6 +9,7 @@ from django.utils import timezone
 from rest_framework import mixins, viewsets
 from rest_framework.permissions import AllowAny
 from taggit.models import TaggedItem
+from watson import search as watson
 
 from apps.article.models import Article
 from apps.article.serializers import ArticleSerializer


### PR DESCRIPTION
Should re-evaluate the queryset for each time it's retrieved, which should invalidate Django's internal caching and therefore get new articles. 

Fix not verified as the only place possible to reproduce the problem is in production.

---

Watson fix as described [here](https://github.com/etianen/django-watson/blob/master/CHANGELOG.markdown#120---03122015).