### PR TITLE
User registration jobmail fix

### DIFF
--- a/apps/authentication/views.py
+++ b/apps/authentication/views.py
@@ -141,7 +141,6 @@ def verify(request, token):
             # Check if Online-member, and set Infomail to True is he/she is
             if user.is_member:
                 user.infomail = True
-                user.jobmail = True
 
         user_activated = False
         if not user.is_active:

--- a/apps/authentication/views.py
+++ b/apps/authentication/views.py
@@ -153,8 +153,12 @@ def verify(request, token):
 
         if user_activated:
             log.info('New user %s was activated' % user)
-            messages.success(request, _('Bruker %s ble aktivert. Du kan nå logge inn.') % user.username)
-            return redirect('auth_login')
+            user.backend = "django.contrib.auth.backends.ModelBackend"
+            auth.login(request, user)
+            messages.success(request, _(
+                'Bruker %s ble aktivert. Du er nå logget inn. '
+                'Kikk rundt på "Min Side" for å oppdatere profilinnstillinger.') % user.username)
+            return redirect('profiles')
         else:
             log.info('New email %s was verified for user %s' % (email, user))
             messages.success(request, _('Eposten %s er nå verifisert.') % email)

--- a/templates/profiles/email.html
+++ b/templates/profiles/email.html
@@ -85,8 +85,8 @@
 </div>
 <div class="row">
     <div class="col-xs-12 col-sm-12 col-md-10">
-        <h3>Oppdragsmail</h3>
-        <p>Her kan du velge å få info om diverse oppdrag og småjobber reltart til informatikkstudiet.</p>
+        <h3>Muligheter</h3>
+        <p>Her kan du velge å få informasjon om diverse arrangement, oppdrag og småjobber reltart til informatikkstudiet.</p>
     </div>
 </div>
 <div class="row">
@@ -107,7 +107,7 @@ This is related to issue #595
 <div class="row-space"></div>
 <div class="row">
     <div class="col-xs-12 col-sm-12 col-md-8">
-        <h3>Listealternativer</h3>        
+        <h3>Listealternativer</h3>
     </div>
 </div>
 <div class="row">


### PR DESCRIPTION
Fixes #1335 by not updating the jobmail-field upon activation of user profiles. 

Because we want to promote this feature, we redirect users to their profile page after registration, where they can update their settings and opt-in (or out) of services they want.