### PR TITLE
Fix 1604: Add weekdays to Splash calendar

### DIFF
--- a/files/static/css/splash/main.css
+++ b/files/static/css/splash/main.css
@@ -285,7 +285,7 @@ article.cal {
   text-align: center;
   display: block;
   color: #ff7800;
-
+  margin-top: -6px;
 }
 .cal-left ul li span span {
   font-size: 38px;

--- a/templates/splash/base.html
+++ b/templates/splash/base.html
@@ -92,7 +92,7 @@
           {% for events in splash_year.events %}
             {% with events|first as firstElement %}
             <li class="" data-date="{{ firstElement.start_time.month }}{{ firstElement.start_time.day }}">
-              <span>{{ firstElement.start_time|date:"F" }}<span>{{ firstElement.start_time.day }}</span>
+              <span>{{ firstElement.start_time|date:"l" }}<span>{{ firstElement.start_time.day }}</span>{{ firstElement.start_time|date:"F" }}</span>
 
               <article>
                 {% for event in events %}
@@ -148,7 +148,7 @@
         <h3>Bedrifter</h3>
         <p>Er du bedrift på jakt etter bedriftspresentasjon eller kurs? Klikk <a href="#" onclick="open_window('#bedrifter'); return false;">her</a> for mer informasjon.</p>
       </div>
-      
+
 
       <div class="right" id="social">
 


### PR DESCRIPTION
![screenshot 2016-07-25 09 58 23](https://cloud.githubusercontent.com/assets/5422571/17094258/6cf724d0-524e-11e6-9964-3908b41886fb.png)

Would be nice if someone with a bit more CSS skills than me could verify that the `margin-top: -6px` isn't the worlds worst hack.