### PR TITLE
Update min length limit in event fields

### DIFF
--- a/apps/events/admin.py
+++ b/apps/events/admin.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from django.contrib import admin, messages
-from django.core import validators
 from django.utils.translation import ugettext as _
 from reversion.admin import VersionAdmin
 

--- a/apps/events/admin.py
+++ b/apps/events/admin.py
@@ -158,9 +158,9 @@ class EventAdmin(VersionAdmin):
 
     def get_form(self, request, obj=None, **kwargs):
         form = super(EventAdmin, self).get_form(request, obj, **kwargs)
-        form.base_fields['ingress_short'].validators = [validators.MinLengthValidator(50)]
-        form.base_fields['ingress'].validators = [validators.MinLengthValidator(75)]
-        form.base_fields['description'].validators = [validators.MinLengthValidator(140)]
+        form.base_fields['ingress_short'].validators = [validators.MinLengthValidator(25)]
+        form.base_fields['ingress'].validators = [validators.MinLengthValidator(25)]
+        form.base_fields['description'].validators = [validators.MinLengthValidator(45)]
         return form
 
 

--- a/apps/events/admin.py
+++ b/apps/events/admin.py
@@ -156,13 +156,6 @@ class EventAdmin(VersionAdmin):
             instance.save()
         formset.save_m2m()
 
-    def get_form(self, request, obj=None, **kwargs):
-        form = super(EventAdmin, self).get_form(request, obj, **kwargs)
-        form.base_fields['ingress_short'].validators = [validators.MinLengthValidator(25)]
-        form.base_fields['ingress'].validators = [validators.MinLengthValidator(25)]
-        form.base_fields['description'].validators = [validators.MinLengthValidator(45)]
-        return form
-
 
 class ReserveeInline(admin.TabularInline):
     model = Reservee

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -7,6 +7,7 @@ from functools import reduce
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
+from django.core import validators
 from django.db import models
 from django.db.models import Case, Q, Value, When
 from django.template.defaultfilters import slugify
@@ -79,9 +80,10 @@ class Event(models.Model):
     event_start = models.DateTimeField(_('start-dato'))
     event_end = models.DateTimeField(_('slutt-dato'))
     location = models.CharField(_('lokasjon'), max_length=100)
-    ingress_short = models.CharField(_("kort ingress"), max_length=150)
-    ingress = models.TextField(_('ingress'))
-    description = models.TextField(_('beskrivelse'))
+    ingress_short = models.CharField(_("kort ingress"), max_length=150,
+                                     validators=[validators.MinLengthValidator(25)])
+    ingress = models.TextField(_('ingress'), validators=[validators.MinLengthValidator(25)])
+    description = models.TextField(_('beskrivelse'), validators=[validators.MinLengthValidator(45)])
     image = FileBrowseField(_("bilde"), max_length=200,
                             directory=IMAGE_FOLDER, extensions=IMAGE_EXTENSIONS, null=True, blank=True)
     event_type = models.SmallIntegerField(_('type'), choices=TYPE_CHOICES, null=False)


### PR DESCRIPTION
I've set min length of short and normal ingress to 25, and description to 45. Because:

- A very valid ingress could be as short as:
  - Gjør deg klar til X-Fest!
  - Velkommen til kurs med ELV
  - Velkommen til bedriftspresentasjon med NIX

Often you don't have the description ready for an event. And a valid description could be:
- Mer informasjon kommer når [event] nærmer seg!

The form could enforce everyone to write something about the co-organizers etc. But the issue is more "the look on the front page" than the content of the page. How to present an event without much content (waiting for information etc.) could be discussed as a routine for the working committees, but I don't think the system should enforce it.

This PR fixes #1578