### PR TITLE
Slack inviter

### DIFF
--- a/apps/slack/serializers.py
+++ b/apps/slack/serializers.py
@@ -1,0 +1,6 @@
+from rest_framework import serializers
+
+
+class SlackSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    name = serializers.CharField(max_length=200)

--- a/apps/slack/serializers.py
+++ b/apps/slack/serializers.py
@@ -3,4 +3,3 @@ from rest_framework import serializers
 
 class SlackSerializer(serializers.Serializer):
     email = serializers.EmailField()
-    name = serializers.CharField(max_length=200)

--- a/apps/slack/tests.py
+++ b/apps/slack/tests.py
@@ -72,7 +72,6 @@ class InviteViewSetTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(slack_mock.called)
-        self.assertTrue(response.json()['ok'])
 
     @patch('apps.slack.views.SlackInvite')
     def test_post_withEmailOnly_fails(self, slack_mock):
@@ -81,8 +80,7 @@ class InviteViewSetTest(APITestCase):
 
         response = self.client.post(url, {'email': email})
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(response.json()['ok'])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @patch('apps.slack.views.SlackInvite')
     def test_post_withNameOnly_fails(self, slack_mock):
@@ -91,8 +89,7 @@ class InviteViewSetTest(APITestCase):
 
         response = self.client.post(url, {'name': name})
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(response.json()['ok'])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @patch('apps.slack.views.SlackInvite.invite')
     def test_post_withInvalidEmail_fails(self, slack_mock):
@@ -103,6 +100,5 @@ class InviteViewSetTest(APITestCase):
 
         response = self.client.post(url, {'name': name, 'email': email})
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertTrue(slack_mock.called)
-        self.assertFalse(response.json()['ok'])

--- a/apps/slack/tests.py
+++ b/apps/slack/tests.py
@@ -92,11 +92,11 @@ class InviteViewSetTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @patch('apps.slack.views.SlackInvite.invite')
-    def test_post_withInvalidEmail_fails(self, slack_mock):
+    def test_post_withSlackError_fails(self, slack_mock):
         slack_mock.side_effect = SlackException('Error')
         url = reverse('slack-list')
         name = 'Name'
-        email = 'email@Invalid'
+        email = 'email@example.com'
 
         response = self.client.post(url, {'name': name, 'email': email})
 

--- a/apps/slack/tests.py
+++ b/apps/slack/tests.py
@@ -1,10 +1,12 @@
+from unittest.mock import MagicMock, patch
+
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APITestCase
-from unittest.mock import MagicMock, patch
 
 from apps.slack.utils import SlackException, SlackInvite
+
 
 class SlackInviteTest(TestCase):
     def setUp(self):
@@ -42,13 +44,14 @@ class SlackInviteTest(TestCase):
             self.slack_invite.invite("test@example.com", "Test")
 
     @patch('apps.slack.utils.requests.post')
-    def test_invite_statusCodeIsNot200_raisesException(self, post_mock):
+    def test_invite_okIsNotTrue_raisesException(self, post_mock):
         post_mock.side_effect = [
             MagicMock(status_code=200, json=lambda: {'ok': False, 'error': 'Mocked!'})
         ]
 
         with self.assertRaises(SlackException):
             self.slack_invite.invite("test@example.com", "Test")
+
 
 class InviteViewSetTest(APITestCase):
     @patch('apps.slack.views.SlackInvite')
@@ -73,7 +76,6 @@ class InviteViewSetTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(response.json()['ok'])
 
-
     @patch('apps.slack.views.SlackInvite')
     def test_post_withNameOnly_fails(self, slack_mock):
         url = reverse('slack-list')
@@ -83,7 +85,6 @@ class InviteViewSetTest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(response.json()['ok'])
-
 
     @patch('apps.slack.views.SlackInvite.invite')
     def test_post_withInvalidEmail_fails(self, slack_mock):

--- a/apps/slack/tests.py
+++ b/apps/slack/tests.py
@@ -60,6 +60,17 @@ class SlackInviteTest(TestCase):
         with self.assertRaises(SlackException):
             self.slack_invite.invite("test@example.com", "Test")
 
+    @patch('apps.slack.utils.log.error')
+    @patch('apps.slack.utils.requests.post')
+    def test_invite_invalidAuth_logsError(self, post_mock, log_mock):
+        post_mock.side_effect = [
+            MagicMock(status_code=200, json=lambda: {'ok': False, 'error': 'invalid_auth'})
+        ]
+
+        with self.assertRaises(SlackException):
+            self.slack_invite.invite("test@example.com", "Test")
+        self.assertTrue(log_mock.called)
+
 
 class InviteViewSetTest(APITestCase):
     @patch('apps.slack.views.SlackInvite')

--- a/apps/slack/tests.py
+++ b/apps/slack/tests.py
@@ -21,6 +21,14 @@ class SlackInviteTest(TestCase):
         self.assertFalse(self.slack_invite._match_email('@example.com'))
         self.assertTrue(self.slack_invite._match_email('mail@example.com'))
 
+    def test_invite_matchEmailFails_raisesException(self):
+        with self.assertRaises(SlackException):
+            self.slack_invite.invite('invalid@email', 'Name')
+
+    def test_invite_invalidName_raisesException(self):
+        with self.assertRaises(SlackException):
+            self.slack_invite.invite('valid@email.com', '')
+
     @patch('apps.slack.utils.requests.post')
     def test_invite_callsRequestsPost(self, post_mock):
         post_mock.side_effect = [

--- a/apps/slack/tests.py
+++ b/apps/slack/tests.py
@@ -1,0 +1,48 @@
+from django.test import TestCase
+from unittest.mock import MagicMock, patch
+
+from apps.slack.utils import SlackException, SlackInvite
+
+class SlackInviteTest(TestCase):
+    def setUp(self):
+        self.slack_invite = SlackInvite()
+
+    def test_url_returns_string(self):
+        self.assertIsInstance(self.slack_invite._url(), str)
+
+    def test_match_email_invalidEmail_returnsFalse(self):
+        self.assertFalse(self.slack_invite._match_email('mail.example'))
+        self.assertFalse(self.slack_invite._match_email('mail@example.'))
+        self.assertFalse(self.slack_invite._match_email('@example.com'))
+        self.assertTrue(self.slack_invite._match_email('mail@example.com'))
+
+    @patch('apps.slack.utils.requests.post')
+    def test_invite_callsRequestsPost(self, post_mock):
+        post_mock.side_effect = [
+            MagicMock(status_code=200, data={'ok': True})
+        ]
+
+        mail = "test@example.com"
+        name = "Test"
+
+        self.slack_invite.invite(mail, name)
+
+        self.assertTrue(post_mock.called)
+
+    @patch('apps.slack.utils.requests.post')
+    def test_invite_statusCodeIsNot200_raisesException(self, post_mock):
+        post_mock.side_effect = [
+            MagicMock(status_code=403)
+        ]
+
+        with self.assertRaises(SlackException):
+            self.slack_invite.invite("test@example.com", "Test")
+
+    @patch('apps.slack.utils.requests.post')
+    def test_invite_statusCodeIsNot200_raisesException(self, post_mock):
+        post_mock.side_effect = [
+            MagicMock(status_code=200, data={'ok': False, 'error': 'Mocked!'})
+        ]
+
+        with self.assertRaises(SlackException):
+            self.slack_invite.invite("test@example.com", "Test")

--- a/apps/slack/tests.py
+++ b/apps/slack/tests.py
@@ -22,7 +22,7 @@ class SlackInviteTest(TestCase):
     @patch('apps.slack.utils.requests.post')
     def test_invite_callsRequestsPost(self, post_mock):
         post_mock.side_effect = [
-            MagicMock(status_code=200, data={'ok': True})
+            MagicMock(status_code=200, json=lambda: {'ok': True})
         ]
 
         mail = "test@example.com"
@@ -44,7 +44,7 @@ class SlackInviteTest(TestCase):
     @patch('apps.slack.utils.requests.post')
     def test_invite_statusCodeIsNot200_raisesException(self, post_mock):
         post_mock.side_effect = [
-            MagicMock(status_code=200, data={'ok': False, 'error': 'Mocked!'})
+            MagicMock(status_code=200, json=lambda: {'ok': False, 'error': 'Mocked!'})
         ]
 
         with self.assertRaises(SlackException):

--- a/apps/slack/urls.py
+++ b/apps/slack/urls.py
@@ -1,0 +1,8 @@
+from apps.api.utils import SharedAPIRootRouter
+from apps.slack import views
+from apps.shop.views import InventoryViewSet
+
+urlpatterns = []
+
+router = SharedAPIRootRouter()
+router.register('slack', views.InviteViewSet, base_name='slack')

--- a/apps/slack/urls.py
+++ b/apps/slack/urls.py
@@ -1,6 +1,5 @@
 from apps.api.utils import SharedAPIRootRouter
 from apps.slack import views
-from apps.shop.views import InventoryViewSet
 
 urlpatterns = []
 

--- a/apps/slack/utils.py
+++ b/apps/slack/utils.py
@@ -1,0 +1,41 @@
+import re
+import requests
+import time
+
+class SlackException(Exception):
+    pass
+
+class SlackInvite:
+    def __init__(self):
+        self.token = ''
+        self.team_name = 'onlinentnu'
+        self.channels = ['online']
+
+    def _url(self):
+        return "https://{team}.slack.com/api/users.admin.invite?t={time}".format(
+            team=self.team_name, time=int(time.time())
+        )
+
+    def _post(self, email, name):
+        r = requests.post(self._url(), data={
+            "email": email,
+            "first_name": name,
+            "channels": self.channels,
+            "token": self.token,
+            "set_active": "true",
+            "_attempts": 1
+        })
+        if r.status_code != 200 or not isinstance(r.data, dict):
+            raise SlackException('Failed to invite user')
+        if not r.data['ok']:
+            raise SlackException(r.data['error'])
+
+    def _match_email(self, email):
+        return re.match(r'^.+@.+\..+', email)
+
+    def invite(self, email, name):
+        if not self._match_email(email):
+            raise SlackException('Invalid e-mail')
+        if name == '':
+            raise SlackException('Empty name')
+        self._post(email, name)

--- a/apps/slack/utils.py
+++ b/apps/slack/utils.py
@@ -54,5 +54,5 @@ class SlackInvite:
             log.error('Auth to Slack API failed')
         if error_text in self.ERRORS:
             return self.ERRORS[error_text]
-        log.warning('Unknown error from Slack API', error_text)
+        log.warning('Unknown error from Slack API: ' + error_text)
         return 'Ukjent feilmelding'

--- a/apps/slack/utils.py
+++ b/apps/slack/utils.py
@@ -1,10 +1,13 @@
-from django.conf import settings
 import re
-import requests
 import time
+
+import requests
+from django.conf import settings
+
 
 class SlackException(Exception):
     pass
+
 
 class SlackInvite:
     def __init__(self):

--- a/apps/slack/utils.py
+++ b/apps/slack/utils.py
@@ -38,7 +38,7 @@ class SlackInvite:
 
     def invite(self, email, name):
         if not self._match_email(email):
-            raise SlackException('Invalid e-mail')
+            raise SlackException('Ugyldig e-mail')
         if name == '':
-            raise SlackException('Empty name')
+            raise SlackException('Ugyldig navn')
         self._post(email, name)

--- a/apps/slack/utils.py
+++ b/apps/slack/utils.py
@@ -28,10 +28,9 @@ class SlackInvite:
             team=self.team_name, time=int(time.time())
         )
 
-    def _post(self, email, name):
+    def _post(self, email):
         r = requests.post(self._url(), data={
             "email": email,
-            "first_name": name,
             "token": self.token,
             "set_active": "true",
             "_attempts": 1
@@ -45,12 +44,10 @@ class SlackInvite:
     def _match_email(self, email):
         return re.match(r'^.+@.+\..+', email)
 
-    def invite(self, email, name):
+    def invite(self, email):
         if not self._match_email(email):
             raise SlackException('Ugyldig e-mail')
-        if name == '':
-            raise SlackException('Ugyldig navn')
-        self._post(email, name)
+        self._post(email)
 
     def _error_to_text(self, error_text):
         if error_text == 'invalid_auth':

--- a/apps/slack/utils.py
+++ b/apps/slack/utils.py
@@ -25,10 +25,11 @@ class SlackInvite:
             "set_active": "true",
             "_attempts": 1
         })
-        if r.status_code != 200 or not isinstance(r.data, dict):
+        if r.status_code != 200 or not isinstance(r.json(), dict):
             raise SlackException('Failed to invite user')
-        if not r.data['ok']:
-            raise SlackException(r.data['error'])
+        data = r.json()
+        if not data['ok']:
+            raise SlackException(data['error'])
 
     def _match_email(self, email):
         return re.match(r'^.+@.+\..+', email)

--- a/apps/slack/utils.py
+++ b/apps/slack/utils.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 import re
 import requests
 import time
@@ -7,9 +8,8 @@ class SlackException(Exception):
 
 class SlackInvite:
     def __init__(self):
-        self.token = ''
-        self.team_name = 'onlinentnu'
-        self.channels = ['online']
+        self.token = settings.SLACK_INVITER['token']
+        self.team_name = settings.SLACK_INVITER['team_name']
 
     def _url(self):
         return "https://{team}.slack.com/api/users.admin.invite?t={time}".format(
@@ -20,7 +20,6 @@ class SlackInvite:
         r = requests.post(self._url(), data={
             "email": email,
             "first_name": name,
-            "channels": self.channels,
             "token": self.token,
             "set_active": "true",
             "_attempts": 1

--- a/apps/slack/utils.py
+++ b/apps/slack/utils.py
@@ -1,8 +1,11 @@
+import logging
 import re
 import time
 
 import requests
 from django.conf import settings
+
+log = logging.getLogger('Slack')
 
 
 class SlackException(Exception):
@@ -10,6 +13,12 @@ class SlackException(Exception):
 
 
 class SlackInvite:
+    ERRORS = {
+        'already_invited': 'E-posten har allerede blitt invitert',
+        'invalid_auth': 'Klarte ikke sende invitasjon',
+        'invalid_email': 'Ugyldig e-mail'
+    }
+
     def __init__(self):
         self.token = settings.SLACK_INVITER['token']
         self.team_name = settings.SLACK_INVITER['team_name']
@@ -31,7 +40,7 @@ class SlackInvite:
             raise SlackException('Failed to invite user')
         data = r.json()
         if not data['ok']:
-            raise SlackException(data['error'])
+            raise SlackException(self._error_to_text(data['error']))
 
     def _match_email(self, email):
         return re.match(r'^.+@.+\..+', email)
@@ -42,3 +51,11 @@ class SlackInvite:
         if name == '':
             raise SlackException('Ugyldig navn')
         self._post(email, name)
+
+    def _error_to_text(self, error_text):
+        if error_text == 'invalid_auth':
+            log.error('Auth to Slack API failed')
+        if error_text in self.ERRORS:
+            return self.ERRORS[error_text]
+        log.warning('Unknown error from Slack API', error_text)
+        return 'Ukjent feilmelding'

--- a/apps/slack/views.py
+++ b/apps/slack/views.py
@@ -1,5 +1,6 @@
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
+from rest_framework import serializers
 
 from apps.slack.utils import SlackException, SlackInvite
 
@@ -7,19 +8,11 @@ from apps.slack.utils import SlackException, SlackInvite
 class InviteViewSet(ViewSet):
     def create(self, request, format=None):
         if not('email' in request.data and 'name' in request.data):
-            return Response({
-                'ok': False,
-                'error': 'Missing name or e-mail'
-            })
+            raise serializers.ValidationError('Missing name or e-mail')
         slack = SlackInvite()
         try:
             slack.invite(request.data['email'], request.data['name'])
         except SlackException as e:
-            return Response({
-                'ok': False,
-                'error': str(e)
-            })
+            raise serializers.ValidationError(str(e))
 
-        return Response({
-            'ok': True
-        })
+        return Response()

--- a/apps/slack/views.py
+++ b/apps/slack/views.py
@@ -3,12 +3,15 @@ from rest_framework.viewsets import ViewSet
 from rest_framework import serializers
 
 from apps.slack.utils import SlackException, SlackInvite
+from apps.slack.serializers import SlackSerializer
 
 
 class InviteViewSet(ViewSet):
+    serializer_class = SlackSerializer
+
     def create(self, request, format=None):
-        if not('email' in request.data and 'name' in request.data):
-            raise serializers.ValidationError('Missing name or e-mail')
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
         slack = SlackInvite()
         try:
             slack.invite(request.data['email'], request.data['name'])

--- a/apps/slack/views.py
+++ b/apps/slack/views.py
@@ -1,0 +1,6 @@
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+
+class InviteViewSet(ViewSet):
+    def create(self, request, format=None):
+        return Response(request.data)

--- a/apps/slack/views.py
+++ b/apps/slack/views.py
@@ -14,7 +14,7 @@ class InviteViewSet(ViewSet):
         serializer.is_valid(raise_exception=True)
         slack = SlackInvite()
         try:
-            slack.invite(request.data['email'], request.data['name'])
+            slack.invite(request.data['email'])
         except SlackException as e:
             raise serializers.ValidationError(str(e))
 

--- a/apps/slack/views.py
+++ b/apps/slack/views.py
@@ -1,9 +1,9 @@
+from rest_framework import serializers
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
-from rest_framework import serializers
 
-from apps.slack.utils import SlackException, SlackInvite
 from apps.slack.serializers import SlackSerializer
+from apps.slack.utils import SlackException, SlackInvite
 
 
 class InviteViewSet(ViewSet):

--- a/apps/slack/views.py
+++ b/apps/slack/views.py
@@ -1,6 +1,24 @@
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 
+from apps.slack.utils import SlackException, SlackInvite
+
 class InviteViewSet(ViewSet):
     def create(self, request, format=None):
-        return Response(request.data)
+        if not('email' in request.data and 'name' in request.data):
+            return Response({
+                'ok': False,
+                'error': 'Missing name or e-mail'
+            })
+        slack = SlackInvite()
+        try:
+            slack.invite(request.data['email'], request.data['name'])
+        except SlackException as e:
+            return Response({
+                'ok': False,
+                'error': str(e)
+            })
+
+        return Response({
+            'ok': True
+        })

--- a/apps/slack/views.py
+++ b/apps/slack/views.py
@@ -1,7 +1,8 @@
-from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
 
 from apps.slack.utils import SlackException, SlackInvite
+
 
 class InviteViewSet(ViewSet):
     def create(self, request, format=None):

--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -358,6 +358,14 @@ LOGGING = {
     }
 }
 
+SLACK_INVITER = {
+    # e.g. onlinentnu
+    'team_name': 'team_name_here',
+    # Token generated using OAuth2: https://api.slack.com/docs/oauth
+    # Scopes needed: client+admin
+    'token': 'xoxp-1234_fake'
+}
+
 # crispy forms settings
 CRISPY_TEMPLATE_PACK = 'bootstrap3'
 

--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -264,6 +264,7 @@ INSTALLED_APPS = (
     'apps.payment',
     'apps.posters',
     #'apps.rutinator',
+    'apps.slack',
     'apps.sso',
     'apps.splash',
     'apps.shop',

--- a/onlineweb4/urls.py
+++ b/onlineweb4/urls.py
@@ -170,6 +170,11 @@ if 'apps.rutinator' in settings.INSTALLED_APPS:
         )),
     ]
 
+if 'apps.slack' in settings.INSTALLED_APPS:
+    urlpatterns += [
+        url(r'^slack/', include('apps.slack.urls'))
+    ]
+
 if 'apps.splash' in settings.INSTALLED_APPS:
     urlpatterns += [
         url(r'^splash/',           include('apps.splash.urls')),


### PR DESCRIPTION
Slack invitation app with a simple API.
POST to `/api/v1/slack` with `email`.

This was created to enable simple signups from the splash, but we should probably add a form somewhere on the main site too.