### PR TITLE
Skip migrations when running py.test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,4 +13,5 @@ known_first_party=apps
 DJANGO_SETTINGS_MODULE=onlineweb4.settings
 norecursedirs=.* env* tmp*
 python_files=tests.py
+addopts='--nomigrations'
 


### PR DESCRIPTION
py.test inspects models directly instead which is way faster