### PR TITLE
Do not crash if google plugin can't load Maps data

### DIFF
--- a/files/static/js/init.js
+++ b/files/static/js/init.js
@@ -7,74 +7,82 @@ $(function() {
         $('.alert').fadeOut();
     }, 5000);
 
-    // Init the footer-map
-    var map = new google.maps.Map(document.getElementById("footer-map"),{
-        center: new google.maps.LatLng(63.41819751959266, 10.40592152481463),
-        zoom: 15,
-        mapTypeId: google.maps.MapTypeId.ROADMAP,
+    // Init the footer-map, but don't crash if google is not found
+    try {
+        var map = new google.maps.Map(document.getElementById("footer-map"),{
+            center: new google.maps.LatLng(63.41819751959266, 10.40592152481463),
+            zoom: 15,
+            mapTypeId: google.maps.MapTypeId.ROADMAP,
 
-        disableDefaultUI: true,
-        streetViewControl: false,
+            disableDefaultUI: true,
+            streetViewControl: false,
 
-        styles: [
-            {
-                "featureType": "all",
-                "stylers": [
-                    {
-                        "saturation": -100
-                    }
-                ]
-            },
-            {
-                "stylers": [
-                    { "hue": "#666666" },
-                    { "lightness": -30 }
-                ]
-            },
-            {
-                "featureType": "poi.school",
-                "stylers": [
-                    { "color": "#b3b3b3" }
-                ]
-            },
-            {
-                "featureType": "poi.park",
-                "stylers": [
-                    { "color": "#d2e4c4" }
-                ]
+            styles: [
+                {
+                    "featureType": "all",
+                    "stylers": [
+                        {
+                            "saturation": -100
+                        }
+                    ]
+                },
+                {
+                    "stylers": [
+                        { "hue": "#666666" },
+                        { "lightness": -30 }
+                    ]
+                },
+                {
+                    "featureType": "poi.school",
+                    "stylers": [
+                        { "color": "#b3b3b3" }
+                    ]
+                },
+                {
+                    "featureType": "poi.park",
+                    "stylers": [
+                        { "color": "#d2e4c4" }
+                    ]
 
-            },
-            {
-                "featureType": "road.local",
-                "elementType": 'all',
-                "stylers": [
-                    { "hue": '#f4f4f4' },
-                    { "lightness": 52 }
-                ]
-            },
-            {
-                "featureType": "poi.sports_complex",
-                "stylers": [
-                    { "saturation": 4 },
-                    { "weight": 0.5 },
-                    { "color": "#bad5aa" }
-                ]
-            }
-        ]
-    });
+                },
+                {
+                    "featureType": "road.local",
+                    "elementType": 'all',
+                    "stylers": [
+                        { "hue": '#f4f4f4' },
+                        { "lightness": 52 }
+                    ]
+                },
+                {
+                    "featureType": "poi.sports_complex",
+                    "stylers": [
+                        { "saturation": 4 },
+                        { "weight": 0.5 },
+                        { "color": "#bad5aa" }
+                    ]
+                }
+            ]
+        });
 
-    // Applying the marker to the map
-    var online_marker = new google.maps.Marker({
-        map: map,
-        position: new google.maps.LatLng(63.41816871425781,10.405924207023645),
-        icon: '/static/img/map-marker.png',
-        visible: true
-    });
+        // Applying the marker to the map, but only if the map has been created
+        var online_marker = new google.maps.Marker({
+            map: map,
+            position: new google.maps.LatLng(63.41816871425781,10.405924207023645),
+            icon: '/static/img/map-marker.png',
+            visible: true
+        });
+
+    }
+    catch (err){
+        console.warn("Could not load Google Maps:", err);
+    }
 
     // Reset center of the map on window-resize (using jquery-plugin to only fire the event when resizing is finished)
     // Also swap event image sources for proper resolution on mobile view
     $(window).on("debouncedresize",function(e) {
-        map.panTo(new google.maps.LatLng(63.41819751959266, 10.40592152481463));
+        if(map){
+            map.panTo(new google.maps.LatLng(63.41819751959266, 10.40592152481463));
+        }
 
         var mobile = false;
 

--- a/files/static/js/init.js
+++ b/files/static/js/init.js
@@ -1,3 +1,69 @@
+var initGoogleMaps = function() {
+    var map = new google.maps.Map(document.getElementById("footer-map"),{
+        center: new google.maps.LatLng(63.41819751959266, 10.40592152481463),
+        zoom: 15,
+        mapTypeId: google.maps.MapTypeId.ROADMAP,
+
+        disableDefaultUI: true,
+        streetViewControl: false,
+
+        styles: [
+            {
+                "featureType": "all",
+                "stylers": [
+                    {
+                        "saturation": -100
+                    }
+                ]
+            },
+            {
+                "stylers": [
+                    { "hue": "#666666" },
+                    { "lightness": -30 }
+                ]
+            },
+            {
+                "featureType": "poi.school",
+                "stylers": [
+                    { "color": "#b3b3b3" }
+                ]
+            },
+            {
+                "featureType": "poi.park",
+                "stylers": [
+                    { "color": "#d2e4c4" }
+                ]
+
+            },
+            {
+                "featureType": "road.local",
+                "elementType": 'all',
+                "stylers": [
+                    { "hue": '#f4f4f4' },
+                    { "lightness": 52 }
+                ]
+            },
+            {
+                "featureType": "poi.sports_complex",
+                "stylers": [
+                    { "saturation": 4 },
+                    { "weight": 0.5 },
+                    { "color": "#bad5aa" }
+                ]
+            }
+        ]
+    });
+
+    // Applying the marker to the map, but only if the map has been created
+    var online_marker = new google.maps.Marker({
+        map: map,
+        position: new google.maps.LatLng(63.41816871425781,10.405924207023645),
+        icon: '/static/img/map-marker.png',
+        visible: true
+    });
+    return map;
+}
+
 $(function() {
     // ??
     $('.dropdown-toggle').dropdown();
@@ -9,69 +75,7 @@ $(function() {
 
     // Init the footer-map, but don't crash if google is not found
     try {
-        var map = new google.maps.Map(document.getElementById("footer-map"),{
-            center: new google.maps.LatLng(63.41819751959266, 10.40592152481463),
-            zoom: 15,
-            mapTypeId: google.maps.MapTypeId.ROADMAP,
-
-            disableDefaultUI: true,
-            streetViewControl: false,
-
-            styles: [
-                {
-                    "featureType": "all",
-                    "stylers": [
-                        {
-                            "saturation": -100
-                        }
-                    ]
-                },
-                {
-                    "stylers": [
-                        { "hue": "#666666" },
-                        { "lightness": -30 }
-                    ]
-                },
-                {
-                    "featureType": "poi.school",
-                    "stylers": [
-                        { "color": "#b3b3b3" }
-                    ]
-                },
-                {
-                    "featureType": "poi.park",
-                    "stylers": [
-                        { "color": "#d2e4c4" }
-                    ]
-
-                },
-                {
-                    "featureType": "road.local",
-                    "elementType": 'all',
-                    "stylers": [
-                        { "hue": '#f4f4f4' },
-                        { "lightness": 52 }
-                    ]
-                },
-                {
-                    "featureType": "poi.sports_complex",
-                    "stylers": [
-                        { "saturation": 4 },
-                        { "weight": 0.5 },
-                        { "color": "#bad5aa" }
-                    ]
-                }
-            ]
-        });
-
-        // Applying the marker to the map, but only if the map has been created
-        var online_marker = new google.maps.Marker({
-            map: map,
-            position: new google.maps.LatLng(63.41816871425781,10.405924207023645),
-            icon: '/static/img/map-marker.png',
-            visible: true
-        });
-
+        var map = initGoogleMaps();
     }
     catch (err){
         console.warn("Could not load Google Maps:", err);
@@ -118,7 +122,7 @@ $(function() {
             $('.mn-nav').addClass('mn-nav-open')
                         .addClass('animation-in-process')
         }
-        
+
         setTimeout(function () {
             $('.mn-nav').removeClass('animation-in-process')
         }, 300)


### PR DESCRIPTION
Blocking google maps requests caused the init script to crash.
Added try/catch clauses around map loading code, because simply checking if the 'google' variable was undefined or not triggered the error as well.