### PR TITLE
Add warning if trying to attend events with registration.end in the past

### DIFF
--- a/apps/events/utils.py
+++ b/apps/events/utils.py
@@ -199,6 +199,7 @@ def handle_attendance_event_detail(event, user, context):
     attendee = False
     place_on_wait_list = 0
     will_be_on_wait_list = False
+    can_unattend = True
     rules = []
     user_status = False
 
@@ -214,6 +215,8 @@ def handle_attendance_event_detail(event, user, context):
 
         will_be_on_wait_list = attendance_event.will_i_be_on_wait_list
 
+        can_unattend = timezone.now() < attendance_event.registration_end
+
         user_status = event.attendance_event.is_eligible_for_signup(user)
 
         # Check if this user is on the waitlist
@@ -226,6 +229,7 @@ def handle_attendance_event_detail(event, user, context):
         'attendee': attendee,
         'user_attending': user_attending,
         'will_be_on_wait_list': will_be_on_wait_list,
+        'can_unattend': can_unattend,
         'rules': rules,
         'user_status': user_status,
         'place_on_wait_list': int(place_on_wait_list),

--- a/templates/events/details.html
+++ b/templates/events/details.html
@@ -327,6 +327,9 @@
                         </div>
                         <form action="{% url 'attend_event' event.id %}" method="POST">
                             <div class="modal-body">
+                                {% if not can_unattend %}
+                                    <div class="alert alert-warning">Avmeldingsfristen på dette arrangementet har utløpt. Det vil si at du kan ikke melde deg av dersom du først melder deg på.</div>
+                                {% endif %}
                                 {% if will_be_on_wait_list %}
                                 <p>Ved å sette deg på venteliste godtar du at du automatisk får plass om
                                     arrangementet utvides med flere plasser, eller andre påmeldte melder seg av, slik at du rykker frem i køen.


### PR DESCRIPTION
Requires #1739.

Otherwise, the bootstrap alert is probably faded out before the modal is opened.