### PR TITLE
Add date to info box

### DIFF
--- a/templates/events/details.html
+++ b/templates/events/details.html
@@ -200,7 +200,13 @@
                                                 <p class="status-text">{{ user_status.message }}</p>
                                             {% endif %}
                                         {% else %}
-                                            <p class="status-text">{{ user_status.message }}</p>
+                                            <p class="status-text">
+                                                {% if user_status.status_code == 501 %}
+                                                    Påmeldingen åpner {{ attendance_event.registration_start|date:"d. M Y H.i" }}
+                                                {% else %}
+                                                    {{ user_status.message }}
+                                                {% endif %}
+                                            </p>
                                             {% if user_status.status_code == 403 %}
                                                 <p><button type="button" class="btn btn-primary" data-toggle="modal" data-target="#user-status-modal">Mer info</button></p>
                                                 <div id="user-status-modal" class="modal fade" role="dialog">


### PR DESCRIPTION
If the signup for an event has yet to open, the orange box currently displays when signup opens. Like this:

<img width="500" alt="skarmavbild 2016-10-26 kl 21 56 37" src="https://cloud.githubusercontent.com/assets/2326278/19743443/9f9024cc-9bc9-11e6-877e-d683e448f1c5.png">

I know that the signup is listed in the info box to the left, but as an experienced Onliner your eyes will usually wander towards the orange box upon load. Currently, if the event has yet to open, you will have to start looking for the correct date in the info box to figure out when the event signup opens. I suggest altering the current message to simply stating when the event opens. This removes the need to look for the signup in the info box.

Purposed change:

<img width="495" alt="skarmavbild 2016-10-26 kl 22 13 44" src="https://cloud.githubusercontent.com/assets/2326278/19743444/9fb1c8f2-9bc9-11e6-9973-1346f5d99ee1.png">
