### PR TITLE
Add interface to see and list pending feedback schemas in profiles

### DIFF
--- a/apps/profiles/urls.py
+++ b/apps/profiles/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     # Show a specific profile.
     url(r'^view/(?P<username>[a-zA-Z0-9_-]+)/$', views.view_profile, name='profiles_view'),
 
+    url(r'^feedback-pending/$', views.feedback_pending, name='feedback_pending'),
     url(r'^edit/$', views.edit_profile, name='profile_edit'),
     url(r'^privacy/$', views.privacy, name='profile_privacy'),
     url(r'^connected_apps/$', views.connected_apps, name='profile_connected_apps'),

--- a/apps/profiles/views.py
+++ b/apps/profiles/views.py
@@ -507,6 +507,7 @@ def view_profile(request, username):
     messages.error(request, _('Du har ikke tilgang til denne profilen'))
     return redirect('profiles')
 
+
 @login_required
 def feedback_pending(request):
     return render(request, 'profiles/feedback_pending.html', {})

--- a/apps/profiles/views.py
+++ b/apps/profiles/views.py
@@ -506,3 +506,7 @@ def view_profile(request, username):
 
     messages.error(request, _('Du har ikke tilgang til denne profilen'))
     return redirect('profiles')
+
+@login_required
+def feedback_pending(request):
+    return render(request, 'profiles/feedback_pending.html', {})

--- a/onlineweb4/context_processors.py
+++ b/onlineweb4/context_processors.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 
 from apps.feedback.models import FeedbackRelation
 
+
 def context_settings(request):
     context_extras = {}
     if hasattr(settings, 'GOOGLE_ANALYTICS_KEY'):
@@ -12,6 +13,7 @@ def context_settings(request):
     if hasattr(settings, 'HOT_RELOAD'):
         context_extras['HOT_RELOAD'] = settings.HOT_RELOAD
     return context_extras
+
 
 def feedback_notifier(request):
     context_extras = {}

--- a/onlineweb4/context_processors.py
+++ b/onlineweb4/context_processors.py
@@ -1,4 +1,7 @@
+# -*- coding: utf-8 -*-
+
 from django.conf import settings
+from django.utils import timezone
 
 from apps.feedback.models import FeedbackRelation
 
@@ -19,6 +22,13 @@ def feedback_notifier(request):
     active_feedbacks = FeedbackRelation.objects.filter(active=True)
     for active_feedback in active_feedbacks:
         if active_feedback.content_object is None:
+            continue
+
+        # Making sure we have an end data, and that the event is over
+        # and that the feedback deadline is not passed (logic reused from apps.feedback.mommy)
+        end_date = active_feedback.content_end_date()
+        today_date = timezone.now().date()
+        if not end_date or end_date.date() >= today_date or (active_feedback.deadline - today_date).days < 0:
             continue
 
         # This method returns both bools and a list for some reason. Python crashes with the expression: x in bool,

--- a/onlineweb4/context_processors.py
+++ b/onlineweb4/context_processors.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+from apps.feedback.models import FeedbackRelation
 
 def context_settings(request):
     context_extras = {}
@@ -7,4 +8,25 @@ def context_settings(request):
         context_extras['GOOGLE_ANALYTICS_KEY'] = settings.GOOGLE_ANALYTICS_KEY
     if hasattr(settings, 'HOT_RELOAD'):
         context_extras['HOT_RELOAD'] = settings.HOT_RELOAD
+    return context_extras
+
+def feedback_notifier(request):
+    context_extras = {}
+    context_extras['feedback_pending'] = []
+    if not request.user.is_authenticated():
+        return context_extras
+
+    active_feedbacks = FeedbackRelation.objects.filter(active=True)
+    for active_feedback in active_feedbacks:
+        if active_feedback.content_object is None:
+            continue
+
+        # This method returns both bools and a list for some reason. Python crashes with the expression: x in bool,
+        # so we do this to fetch once and test twice
+        not_answered = active_feedback.not_answered()
+        if not_answered == False or request.user not in not_answered:
+            continue
+
+        context_extras['feedback_pending'].append(active_feedback)
+
     return context_extras

--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -126,7 +126,10 @@ TEMPLATES = [
                 "django.template.context_processors.tz",
                 "django.contrib.messages.context_processors.messages",
                 "sekizai.context_processors.sekizai", # Wiki
+
+                # Onlineweb4 specific context processors
                 "onlineweb4.context_processors.context_settings",
+                "onlineweb4.context_processors.feedback_notifier",
             ],
             'debug': DEBUG,
         }

--- a/templates/base.html
+++ b/templates/base.html
@@ -58,17 +58,25 @@
             {% if user.is_authenticated %}
                 <li>
                     <a href="#login_menu" class="dropdown-toggle dropdown-signin login glyphicon glyphicon-user" data-toggle="dropdown"></a>
-                    <span class="username_menu hidden-xs hidden-sm hidden-md">{{ user.username }}</span>
+                    <span class="username_menu hidden-xs hidden-sm hidden-md">
+                        {{ user.username }}
+                    </span>
 
                     <ul class="dropdown-menu login-box" role="menu">
-
                         {% if user.is_staff %}
                             <li><a href="/admin/">Administrasjon</a></li>
                         {% endif %}
                         {% if user.is_committee %}
                             <li><a href="/dashboard/">Dashboard</a></li>
                         {% endif %}
-                        <li><a href="{% url 'profiles' %}">Min side<span class="hidden-lg">: {{ user.username }}</span></a></li>
+                        <li>
+                            <a href="{% url 'profiles' %}">
+                                Min side<span class="hidden-lg">: {{ user.username }}</span>
+                                {% if feedback_pending %}
+                                    ({{ feedback_pending|length }})
+                                {% endif %}
+                            </a>
+                        </li>
                         <li><a href="{% url 'profiles_user_search' %}">Finn brukere</a></li>
                         <li class="divider"></li>
                         <li><a href="{% url 'auth_logout' %}">Logg ut</a></li>

--- a/templates/profiles/feedback_pending.html
+++ b/templates/profiles/feedback_pending.html
@@ -1,0 +1,35 @@
+<div class="row">
+    <div class="col-md-12">
+        <h3>Manglende tilbakemeldinger</h3>
+        <p>Kurs, bedriftspresentasjoner og andre arrangementer kan kreve at du besvarer et tilbakemeldingsskjema i etterkant av arrangementet.</p>
+        <p>Dersom du ikke besvarer disse skjemaene innen tiden kan du tildeles en prikk.</p>
+        <p>Skjemaer du har som ikke er besvart er listet i tabellen under.</p>
+
+        <table class="table">
+            <thead>
+                <th>Arrangement</th>
+                <th>Dato</th>
+                <th>Tidsfrist</th>
+                <th></th>
+            </thead>
+            <tbody>
+                {% if feedback_pending|length > 0 %}
+                    {% for feedback in feedback_pending %}
+                        <tr>
+                            <td><a href="{{ feedback.content_object.get_absolute_url }}">{{ feedback.content_object.title }}</a></td>
+                            <td>{{ feedback.content_object.event_start|date:"d. M Y H.i" }}</td>
+                           <td>
+                               {% if feedback.deadline %}
+                                   {{ feedback.deadline|date:"d. M Y" }}
+                               {% endif %}
+                           </td>
+                            <td>
+                                <a href="{{ feedback.get_absolute_url }}">Til skjemaet</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/templates/profiles/feedback_pending.html
+++ b/templates/profiles/feedback_pending.html
@@ -9,7 +9,7 @@
             <thead>
                 <th>Arrangement</th>
                 <th>Dato</th>
-                <th>Tidsfrist</th>
+                <th>Frist</th>
                 <th></th>
             </thead>
             <tbody>
@@ -20,7 +20,7 @@
                             <td>{{ feedback.content_object.event_start|date:"d. M Y H.i" }}</td>
                            <td>
                                {% if feedback.deadline %}
-                                   {{ feedback.deadline|date:"d. M Y" }}
+                                   {{ feedback.deadline|date:"d. M Y" }} 23.59
                                {% endif %}
                            </td>
                             <td>

--- a/templates/profiles/index.html
+++ b/templates/profiles/index.html
@@ -33,6 +33,13 @@ Min side - Online
                         <li class="{% ifequal 'overview' active_tab %}active{% endifequal %}">
                             <a href="{% url 'profiles_active' 'overview' %}" data-section="overview">Oversikt</a>
                         </li>
+                        {% if feedback_pending|length > 0 or active_tab == 'feedback_pending' %}
+                            <li class="{% ifequal 'feedback_pending' active_tab %}active{% endifequal %}">
+                                <a href="{% url 'profiles_active' 'feedback_pending' %}" data-section="feedback_pending">
+                                    Manglende tilbakemeldinger ({{ feedback_pending|length }})
+                                </a>
+                            </li>
+                        {% endif %}
                         <li class="{% ifequal 'edit' active_tab %}active{% endifequal %}">
                             <a href="{% url 'profiles_active' 'edit' %}" data-section="edit">Rediger profil</a>
                         </li>
@@ -69,6 +76,9 @@ Min side - Online
                     <div id="tab-content">
                         <section id="overview">
                             {% include "profiles/overview.html" %}
+                        </section>
+                        <section id="feedback_pending">
+                            {% include "profiles/feedback_pending.html" %}
                         </section>
                         <section id="edit">
                             {% include "profiles/edit.html" %}


### PR DESCRIPTION
In an effort to make feedback schemas easier to deal with, I've implemented this relatively simple sub section in the profile.

Right now, the feedback schemas are completely decoupled from the actual site, meaning you can not access a pending (or answered for that sake) schema from within ow4. You'll have to use the link sent in the daily reminding emails.

It's implemented as a context processor. It checks if the current user has any active schemas pending and adds it in the user menu dropdown. 

<img width="377" alt="skarmavbild 2016-11-03 kl 14 35 03" src="https://cloud.githubusercontent.com/assets/2326278/19968233/042c80b4-a1d4-11e6-8599-ed01a62fb6ea.png">

This will also reveal a new sub section in the profile where these schemas are nicely listed. 

<img width="1214" alt="skarmavbild 2016-11-03 kl 14 35 16" src="https://cloud.githubusercontent.com/assets/2326278/19968237/0b419178-a1d4-11e6-964a-90ce05024c5c.png">

<img width="1165" alt="skarmavbild 2016-11-03 kl 14 35 23" src="https://cloud.githubusercontent.com/assets/2326278/19968239/0b5e5d4e-a1d4-11e6-9aee-fe9a5f9e408c.png">