### PR TITLE
Use template files for payment mails

### DIFF
--- a/apps/payment/mommy.py
+++ b/apps/payment/mommy.py
@@ -222,7 +222,7 @@ class PaymentDelayHandler(Task):
     @staticmethod
     def send_notification_mail(payment_delay, unattend_deadline_passed):
         payment = payment_delay.payment
-        
+
         subject = _("Husk betaling for ") + payment.description()
 
         valid_to = payment_delay.valid_to.astimezone(tz('Europe/Oslo'))

--- a/apps/payment/mommy.py
+++ b/apps/payment/mommy.py
@@ -6,9 +6,9 @@ import logging
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.mail import EmailMessage
+from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.translation import ugettext as _
-from django.template.loader import render_to_string
 from pytz import timezone as tz
 
 from apps.events.models import AttendanceEvent, Attendee

--- a/templates/payment/email/delay_reminder_deadline_passed.txt
+++ b/templates/payment/email/delay_reminder_deadline_passed.txt
@@ -1,0 +1,10 @@
+Hei, du har ikke betalt for {{ payment_description }}.
+
+Fristen for betaling har gått ut.
+
+{% if payment_unattend_passed %}Du har fått en prikk og vil ikke kunne melde deg på nye arrangementer før du har betalt.{% else %}Du har fått en prikk og blitt meldt av arrangementet.{% endif %}
+
+Dersom du har spørsmål kan du sende mail til {{ payment_email }}.
+
+Mvh
+Linjeforeningen Online

--- a/templates/payment/email/delay_reminder_notification.txt
+++ b/templates/payment/email/delay_reminder_notification.txt
@@ -1,0 +1,14 @@
+Hei, du har ikke betalt for {{ payment_description }}.
+
+Fristen for å betale er {{ payment_deadline }}.
+
+{% if unattend_deadline_passed %}Hvis du ikke betaler innen fristen vil du få en prikk og du vil
+ikke ha mulighet til å melde deg på andre arrangementer før du har betalt.{% else %}Hvis du ikke betaler innen fristen vil du få en prikk og du vil bli meldt av arrangementet.{% endif %}
+
+For mer informasjon se:
+{{ payment_url }}
+
+Dersom du har spørsmål kan du sende mail til {{ payment_email }}.
+
+Mvh
+Linjeforeningen Online

--- a/templates/payment/email/payment_expired_list.txt
+++ b/templates/payment/email/payment_expired_list.txt
@@ -1,0 +1,2 @@
+Følgende brukere mangler betaling på {{ payment_description }}:{% for user in payment_users %}
+- {{ user.get_full_name }}{% endfor %}

--- a/templates/payment/email/reminder_deadline_passed.txt
+++ b/templates/payment/email/reminder_deadline_passed.txt
@@ -1,0 +1,11 @@
+Hei, du har ikke betalt for {{ payment_description }}.
+
+Fristen har gått ut og du har fått en prikk.
+
+For mer informasjon se:
+{{ payment_url }}
+
+Dersom du har spørsmål kan du sende mail til {{ payment_email }}.
+
+Mvh
+Linjeforeningen Online

--- a/templates/payment/email/reminder_notification.txt
+++ b/templates/payment/email/reminder_notification.txt
@@ -1,0 +1,11 @@
+Hei, du har ikke betalt for {{ payment_description }}.
+
+Fristen for å betale er {{ payment_deadline }}.
+
+For mer informasjon se:
+{{ payment_url }}
+
+Dersom du har spørsmål kan du sende mail til {{ payment_email }}.
+
+Mvh
+Linjeforeningen Online


### PR DESCRIPTION
Fixes #1573 and cleans up a lot of stuff.

Note: Some of the templates looks a bit clustered and compact. This is because the emails are sent in text format, meaning all newlines "matter". I've tested to see that the Django template parser does not remove/add newlines when parsing loops and conditional statements.