### PR TITLE
Change typeahead value key to avoid hiding people with same name

### DIFF
--- a/templates/profiles/users.html
+++ b/templates/profiles/users.html
@@ -53,7 +53,7 @@
 										</div>
 										<div class="col-md-10">
 											<div class="profile-name">{{ user.get_full_name|striptags }} &nbsp;</div>
-											<b>Telefon</b> 
+											<b>Telefon</b>
 											{% if user.privacy.expose_phone_number %}
 												{% firstof user.phone_number|striptags '<em>Ikke tilgjengelig</em>' %}
 											{% else %}
@@ -71,7 +71,7 @@
 						{% endif %}
 					{% endfor %}
 				</section>
-			{% endfor %}		
+			{% endfor %}
 		</div>
 		<div class="col-md-3 sidebar">
 			<div id="affix" class=" hidden-print hidden-xs hidden-sm">
@@ -111,7 +111,7 @@
                 });
             };
         })(jQuery);
-        
+
 
         $(function () {
             {% verbatim %}
@@ -127,6 +127,7 @@
                     return item;
                 },
                 template: user_search_template,
+                valueKey: 'id',
                 engine: Hogan
             }).on('typeahead:selected typeahead:autocompleted', function(e, datum) {
                 window.location = '/profile/view/' + datum.username;
@@ -153,6 +154,6 @@
 			    target: '#affix',
 			    offset: 90
 			});
-        });   
+        });
     </script>
 {% endblock %}


### PR DESCRIPTION
Change typeahead `keyValue` to `id` which is unique for all users, instead of `name`.

<img width="382" alt="skarmavbild 2016-11-16 kl 22 23 16" src="https://cloud.githubusercontent.com/assets/2326278/20366461/85cf93be-ac4b-11e6-860b-939bafe60813.png">

Editor also cleaned up some mess. [Relevant line](https://github.com/dotKom/onlineweb4/pull/1776/files#diff-cc7ef6fbee144aecff36c85ec2f04080R130).

Thank you @Bergalerga for informing us about this issue in #1774.