### PR TITLE
Make dashboard sidebar more mobile friendly by positioning it fixed

### DIFF
--- a/files/static/less/dashboard/main.less
+++ b/files/static/less/dashboard/main.less
@@ -213,11 +213,12 @@ body {
 }
 /*left side - contains sidebar*/
 .left-side {
-  position: absolute;
+  position: fixed;
   width: 220px;
   top: 0;
   bottom: 0;
   background-color: @sidebar-bg;
+  overflow-y: auto;
 }
 @media screen and (min-width: 992px) {
   /*Right side strech mode*/
@@ -431,17 +432,18 @@ img {
   .row-offcanvas-right .sidebar-offcanvas {
     right: -220px;
   }
-  .row-offcanvas-left .sidebar-offcanvas {
+  .row-offcanvas-left .left-side {
     left: -220px;
   }
   .row-offcanvas-right.active {
     right: 220px;
   }
-  .row-offcanvas-left.active {
-    left: 220px;
+  .row-offcanvas-left.active .right-side {
+    margin-left: 220px;
+    width: 100%;
   }
-  .sidebar-offcanvas {
-    left: 0;
+  .row-offcanvas-left.active .left-side {
+    left: 0px;
   }
   body.fixed .sidebar-offcanvas {
     margin-top: 50px;


### PR DESCRIPTION
The dashboard was never intended for mobile users. However, because we use Bootstrap we are at the very least given some responsiveness for free. The dashboard sidebar has a problem where, if the actual page content is shorter than the sidebar, it will render incorrectly.

This PR tries to fix that. Instead of having the sidebar positioned absolute, it is fixed and overflowed automatically on the y axis. This creates a secondary scrollbar, but I see no other options to solve this.

See illustrations below.

Current behavior:
![current](https://cloud.githubusercontent.com/assets/2326278/20368052/a1870ffe-ac52-11e6-946e-99e62abb602e.gif)

Suggested behavior:
![new](https://cloud.githubusercontent.com/assets/2326278/20368059/aae3cdd0-ac52-11e6-9e18-4c602719d18e.gif)

Sidenote: The content was altered by the inspector tool to create a view that has a taller sidebar than content, however this may happen in real life scenarios as well. With the fixed approach, scrolling feels more natural on mobile units. Desktops are left more or less unaltered.