### PR TITLE
Use reverse url for django-js-reverse instead

### DIFF
--- a/onlineweb4/urls.py
+++ b/onlineweb4/urls.py
@@ -5,6 +5,7 @@ from django.contrib import admin
 from django.http import HttpResponse
 from django.views.defaults import server_error
 from django.views.generic import TemplateView
+from django_js_reverse.views import urls_js
 from django_nyt.urls import get_pattern as get_notify_pattern
 from filebrowser.sites import site
 from wiki.urls import get_pattern as get_wiki_pattern
@@ -26,7 +27,7 @@ urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name='frontpage.html'), name='home'),
 
     # Django-js-reverse used to get django urls to react
-    url(r'^jsreverse/$', 'django_js_reverse.views.urls_js', name='js_reverse'),
+    url(r'^jsreverse/$', urls_js, name='js_reverse'),
 
     # nav-bar menu urls
     url(r'^#events$', TemplateView.as_view(template_name='frontpage.html'), name='events-link'),

--- a/templates/base.html
+++ b/templates/base.html
@@ -217,7 +217,7 @@
         <script src="{{ STATIC_URL }}js/libs/bootstrap.min.js"></script>
         <script src="{{ STATIC_URL }}js/libs/moment.min.js"></script>
         <script src="{{ STATIC_URL }}js/libs/jquery.cookie.js"></script>
-        <script src="{{ STATIC_URL }}django_js_reverse/js/reverse.js"></script>
+        <script src="{% url 'js_reverse' %}" type="text/javascript"></script>
         <script src="{{ STATIC_URL }}js/libs/picturefill.min.js"></script>
         {% compress js %}
         <script src="{{ STATIC_URL }}js/libs/jquery.debouncedresize.js"></script>


### PR DESCRIPTION
Avoids the need for `manage.py collectstatic_js_reverse`.