### PR TITLE
Add an initial Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build up run logs start stop down rm status
+.PHONY: build up run logs start stop down rm status exec django manage
 
 build:
 	docker-compose pull
@@ -26,5 +26,14 @@ rm:
 
 status:
 	docker-compose ps
+
+exec:
+	docker-compose exec
+
+django:
+	docker-compose exec django
+
+manage:
+	docker-compose exec django python manage.py
 
 default: build up

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+.PHONY: build up run logs start stop down rm status
+
+build:
+	docker-compose pull
+	docker-compose build
+
+up:
+	docker-compose up -d
+
+run: up
+
+logs:
+	docker-compose logs
+
+start:
+	docker-compose start
+
+stop:
+	docker-compose stop
+
+down:
+	docker-compose down
+
+rm:
+	docker-compose rm
+
+status:
+	docker-compose ps
+
+default: build up

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ aefaef
 
 Alternatively on Windows, use the GitHub for Windows app to setup everything
 
+Docker
+======
+
+We're using Docker and docker-compose for the development environment. Run `docker-compose pull` followed by `docker-compose build` to get your services up and ready, then start OW4 using `docker-compose up -d` (`-d` for "detached" mode). This will expose the Django development webserver on `http://localhost:8000`. For more information, check out `docker-compose.yml`. For logs when using detached mode, run `docker-compose logs` (or `docker-compose logs <service>` for logs for a specific service).
+
+The Docker setup can be streamlined by some simple make commands. Executing `make` will run `docker-compose pull`, `docker-compose build` and finally `docker-compose up -d` -- a simple way to build a new version of the project and get it up and running (note: this does not actually fetch the latest changes from GitHub!). For simply running OW4 using make, execute `make run`. These commands execute `docker-compose up -d`, which runs docker-compose in detached mode. To check the logs from Docker, check out `make logs` or `docker-compose logs` as described earlier.
+
+To find out if the container is running or not, execute `make status`. This will list currently running containers and their status.
+
 Vagrant
 =======
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The Docker setup can be streamlined by some simple make commands. Executing `mak
 
 To find out if the container is running or not, execute `make status`. This will list currently running containers and their status.
 
+To run commands agains the containers, use `docker-compose exec <container name> <command>`, e.g. `docker-compose exec django python manage.py migrate`. Do this using make with `make exec`. There's also a shortcut to run `manage.py` commands, e.g. `make manage migrate`.
+
 Vagrant
 =======
 


### PR DESCRIPTION
- `make` will pull, build and run OW4 using docker and docker-compose
- `make up` will run OW4 using `docker-compose up -d`, not re-building
anything.
- Check the readme or makefile for more information.