### PR TITLE
Only run webpack_resolve.py when debugging

### DIFF
--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -1,10 +1,8 @@
 # -*- coding: utf8 -*-
 import os
 import sys
-import webpack_loader
 from webpack_resolve import create_resolve_file
 
-import wiki
 from django.contrib.messages import constants as messages
 
 # Directory that contains this file.
@@ -91,10 +89,6 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 #    'django.contrib.staticfiles.finders.DefaultStorageFinder',
 )
-
-# Including django-wiki static files so we can import the less files.
-DJANGO_WIKI_STATIC = os.path.join(os.path.dirname(wiki.__file__), 'static')
-create_resolve_file()
 
 TEMPLATES = [
     {
@@ -448,3 +442,8 @@ for settings_module in ['filebrowser', 'django_wiki', 'local']:  # local last
     except ImportError as e:
         print("Could not import settings for '%s' : %s" % (settings_module,
                 str(e)))
+
+
+if DEBUG:
+    # Create webpack-extra-resolve.json
+    create_resolve_file()


### PR DESCRIPTION
Running it in production causes permission issues and is not needed.