### PR TITLE
Fixing rfidera by removing old image useage from old API

### DIFF
--- a/apps/api/rfid/events.py
+++ b/apps/api/rfid/events.py
@@ -53,7 +53,7 @@ class CompanyResource(ModelResource):
         queryset = Company.objects.all()
         resource_name = 'company'
         allowed_methods = ['get']
-        fields = ['image']
+        fields = ['name']
 
 
 class CompanyEventResource(ModelResource):
@@ -108,15 +108,6 @@ class EventResource(ModelResource):
 
             # Unset the image-field
             del(bundle.data['image'])
-
-        # Do the same thing for the company image
-        if bundle.data['company_event']:
-            for company in bundle.data['company_event']:
-                temp_image = FileObject(company.data['companies'].data['image'])
-                for ver in VERSIONS.keys():
-                    if ver.startswith('companies_thumb'):
-                        company.data['companies'].data['image_' + ver] = temp_image.version_generate(ver).url
-                del(company.data['companies'].data['image'])
 
         # Returning washed object
         return bundle

--- a/apps/api/rfid/events.py
+++ b/apps/api/rfid/events.py
@@ -53,7 +53,7 @@ class CompanyResource(ModelResource):
         queryset = Company.objects.all()
         resource_name = 'company'
         allowed_methods = ['get']
-        fields = ['old_image']
+        fields = ['image']
 
 
 class CompanyEventResource(ModelResource):
@@ -112,11 +112,11 @@ class EventResource(ModelResource):
         # Do the same thing for the company image
         if bundle.data['company_event']:
             for company in bundle.data['company_event']:
-                temp_image = FileObject(company.data['companies'].data['old_image'])
+                temp_image = FileObject(company.data['companies'].data['image'])
                 for ver in VERSIONS.keys():
                     if ver.startswith('companies_thumb'):
-                        company.data['companies'].data['old_image_' + ver] = temp_image.version_generate(ver).url
-                del(company.data['companies'].data['old_image'])
+                        company.data['companies'].data['image_' + ver] = temp_image.version_generate(ver).url
+                del(company.data['companies'].data['image'])
 
         # Returning washed object
         return bundle

--- a/apps/companyprofile/models.py
+++ b/apps/companyprofile/models.py
@@ -21,8 +21,6 @@ class Company(models.Model):
         return self.name
 
     def images(self):
-        if not self.old_image:
-            return []
         from apps.companyprofile.utils import find_image_versions
         return find_image_versions(self)
 


### PR DESCRIPTION
## What kind of a pull request is this?

- [x] Bugfix

## Code Checklist

- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible


## Description of changes
Took the lazy way out and just removed the old_image references for company events. Could've adapted the code for use with the "new" images, but since they haven't been used for however long anyways, just leaving them unused.
