### PR TITLE
Get full email address when trying to find dupes

### DIFF
--- a/apps/authentication/models.py
+++ b/apps/authentication/models.py
@@ -168,6 +168,11 @@ class OnlineUser(AbstractUser):
     def get_emails(self):
         return Email.objects.all().filter(user=self)
 
+    def get_online_mail(self):
+        if self.online_mail:
+            return self.online_mail + '@' + settings.OW4_GSUITE_SYNC.get('DOMAIN')
+        return None
+
     def get_active_suspensions(self):
         return self.suspension_set.filter(active=True)
 

--- a/apps/gsuite/mail_syncer/utils.py
+++ b/apps/gsuite/mail_syncer/utils.py
@@ -450,7 +450,7 @@ def _get_missing_ow4_users_for_g_suite(g_suite_users, ow4_users):
     missing_users = []
 
     for ow4_user in ow4_users:
-        if not _get_g_suite_user_from_g_suite_user_list(g_suite_users, ow4_user.online_mail):
+        if not _get_g_suite_user_from_g_suite_user_list(g_suite_users, ow4_user.get_online_mail()):
             missing_users.append(ow4_user)
 
     logger.debug('OW4 users missing in G Suite ({missing_users_count}): {missing_users}'.format(


### PR DESCRIPTION
## What kind of a pull request is this?

- [x] Bugfix
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible


## Description of changes

Since G Suite returns the full email address in the "email" field, we should check against the full online email address.

Also provides full Online user email as a helper method on OnlineUser object.
