### PR TITLE
Frontpage event filter logic change

### DIFF
--- a/assets/frontpage/events/containers/EventsContainer.js
+++ b/assets/frontpage/events/containers/EventsContainer.js
@@ -76,6 +76,7 @@ class EventsContainer extends Component {
     ];
     this.state = {
       events: [],
+      dirty: false,
       eventTypes: initialEventTypes(eventTypes),
     };
     this.setEventVisibility = this.setEventVisibility.bind(this);

--- a/assets/frontpage/events/utils/index.js
+++ b/assets/frontpage/events/utils/index.js
@@ -1,58 +1,51 @@
 export const toggleEventTypeDisplay = (state, eventType) => {
-  let newState = state;
+  const newState = Object.assign({}, state);
+  const selected = [];
   let eventCount = 0;
-  let selected = [];
-  for (let key in state.eventTypes) {
+
+  for (const type of Object.values(newState.eventTypes)) {
     eventCount++;
-    if (state.eventTypes[key].display) {
-      selected.push(key);
+    if (type.display) {
+      selected.push(type.id);
     }
   }
 
   // If only one event is selected and is being deselected, then show all and set dirty to false
-  if (selected.length === 1 && eventType === newState.eventTypes[selected[0]]) {
-    newState.dirty = false;
-    for (let key in state.eventTypes) {
-      newState.eventTypes[key] = Object.assign({}, newState.eventTypes[key], {
+  if (selected.length === 1 && eventType.id === selected[0]) {
+    state.dirty = false;
+    for (const type of Object.values(newState.eventTypes)) {
+      Object.assign(type, {
         display: true,
-      })
+      });
     }
   }
 
   // If only one event is unselected and is being selected, then show all and set dirty to true
   else if (selected.length === eventCount - 1 && selected.indexOf(eventType.id) === -1) {
-    newState.dirty = true;
-    for (let key in state.eventTypes) {
-      newState.eventTypes[key] = Object.assign({}, newState.eventTypes[key], {
+    state.dirty = true;
+    for (const type of Object.values(newState.eventTypes)) {
+      Object.assign(type, {
         display: true,
-      })
+      });
     }
   }
 
   // If all events are selected and dirty is false, then deselect the all other than the selected and set dirty to true
   else if (selected.length === eventCount && !state.dirty) {
-    newState.dirty = true;
-    for (let key in state.eventTypes) {
-      if (key !== eventType.id) {
-        newState.eventTypes[key] = Object.assign({}, newState.eventTypes[key], {
+    state.dirty = true;
+    for (const type of Object.values(newState.eventTypes)) {
+      if (type.id !== eventType.id) {
+        Object.assign(type, {
           display: false,
-        })
+        });
       }
     }
   }
 
-  // If all events are selected and dirty is true, then deselect the selected one and leave dirty as true
-  else if (selected.length === eventCount && state.dirty) {
-    newState.eventTypes = Object.assign({}, state.eventTypes, {
-      [eventType.id]: Object.assign({}, eventType, {
-        display: !eventType.display,
-      }),
-    });
-  }
-
-  // If none of the edge cases above
+  // If none of the edge cases above, then toggle as usual
   else {
-    newState.eventTypes = Object.assign({}, state.eventTypes, {
+    state.dirty = true;
+    Object.assign(newState.eventTypes, {
       [eventType.id]: Object.assign({}, eventType, {
         display: !eventType.display,
       }),
@@ -60,7 +53,7 @@ export const toggleEventTypeDisplay = (state, eventType) => {
   }
 
   return Object.assign({}, state.eventTypes, newState.eventTypes);
-};
+}
 
 export const setEventsForEventTypeId = (state, eventTypeId, events) => (
   Object.assign({}, state.eventTypes, {

--- a/assets/frontpage/events/utils/index.js
+++ b/assets/frontpage/events/utils/index.js
@@ -3,48 +3,47 @@ export const toggleEventTypeDisplay = (state, eventType) => {
   const selected = [];
   let eventCount = 0;
 
-  for (const type of Object.values(newState.eventTypes)) {
-    eventCount++;
+  Object.values(newState.eventTypes).forEach((type) => {
+    eventCount += 1;
     if (type.display) {
       selected.push(type.id);
     }
-  }
+  });
 
-  // If only one event is selected and is being deselected, then show all and set dirty to false
   if (selected.length === 1 && eventType.id === selected[0]) {
-    state.dirty = false;
-    for (const type of Object.values(newState.eventTypes)) {
+    // If only one event is selected and is being deselected,
+    // then show all and set dirty to false
+    Object.assign(state, { dirty: false });
+
+    Object.values(newState.eventTypes).forEach((type) => {
       Object.assign(type, {
         display: true,
       });
-    }
-  }
+    });
+  } else if (selected.length === eventCount - 1 && selected.indexOf(eventType.id) === -1) {
+    // If only one event is unselected and is being selected,
+    // then show all and set dirty to true
+    Object.assign(state, { dirty: true });
 
-  // If only one event is unselected and is being selected, then show all and set dirty to true
-  else if (selected.length === eventCount - 1 && selected.indexOf(eventType.id) === -1) {
-    state.dirty = true;
-    for (const type of Object.values(newState.eventTypes)) {
+    Object.values(newState.eventTypes).forEach((type) => {
       Object.assign(type, {
         display: true,
       });
-    }
-  }
+    });
+  } else if (selected.length === eventCount && !state.dirty) {
+    // If all events are selected and dirty is false,
+    // then deselect the all other than the selected and set dirty to true
+    Object.assign(state, { dirty: true });
 
-  // If all events are selected and dirty is false, then deselect the all other than the selected and set dirty to true
-  else if (selected.length === eventCount && !state.dirty) {
-    state.dirty = true;
-    for (const type of Object.values(newState.eventTypes)) {
-      if (type.id !== eventType.id) {
+    Object.values(newState.eventTypes)
+      .filter(type => type.id !== eventType.id)
+      .forEach((type) => {
         Object.assign(type, {
           display: false,
         });
-      }
-    }
-  }
-
-  // If none of the edge cases above, then toggle as usual
-  else {
-    state.dirty = true;
+      });
+  } else {
+    // If none of the edge cases above, then toggle as usual
     Object.assign(newState.eventTypes, {
       [eventType.id]: Object.assign({}, eventType, {
         display: !eventType.display,
@@ -53,7 +52,7 @@ export const toggleEventTypeDisplay = (state, eventType) => {
   }
 
   return Object.assign({}, state.eventTypes, newState.eventTypes);
-}
+};
 
 export const setEventsForEventTypeId = (state, eventTypeId, events) => (
   Object.assign({}, state.eventTypes, {

--- a/assets/frontpage/events/utils/index.js
+++ b/assets/frontpage/events/utils/index.js
@@ -1,10 +1,66 @@
-export const toggleEventTypeDisplay = (state, eventType) => (
-  Object.assign({}, state.eventTypes, {
-    [eventType.id]: Object.assign({}, eventType, {
-      display: !eventType.display,
-    }),
-  })
-);
+export const toggleEventTypeDisplay = (state, eventType) => {
+  let newState = state;
+  let eventCount = 0;
+  let selected = [];
+  for (let key in state.eventTypes) {
+    eventCount++;
+    if (state.eventTypes[key].display) {
+      selected.push(key);
+    }
+  }
+
+  // If only one event is selected and is being deselected, then show all and set dirty to false
+  if (selected.length === 1 && eventType === newState.eventTypes[selected[0]]) {
+    newState.dirty = false;
+    for (let key in state.eventTypes) {
+      newState.eventTypes[key] = Object.assign({}, newState.eventTypes[key], {
+        display: true,
+      })
+    }
+  }
+
+  // If only one event is unselected and is being selected, then show all and set dirty to true
+  else if (selected.length === eventCount - 1 && selected.indexOf(eventType.id) === -1) {
+    newState.dirty = true;
+    for (let key in state.eventTypes) {
+      newState.eventTypes[key] = Object.assign({}, newState.eventTypes[key], {
+        display: true,
+      })
+    }
+  }
+
+  // If all events are selected and dirty is false, then deselect the all other than the selected and set dirty to true
+  else if (selected.length === eventCount && !state.dirty) {
+    newState.dirty = true;
+    for (let key in state.eventTypes) {
+      if (key !== eventType.id) {
+        newState.eventTypes[key] = Object.assign({}, newState.eventTypes[key], {
+          display: false,
+        })
+      }
+    }
+  }
+
+  // If all events are selected and dirty is true, then deselect the selected one and leave dirty as true
+  else if (selected.length === eventCount && state.dirty) {
+    newState.eventTypes = Object.assign({}, state.eventTypes, {
+      [eventType.id]: Object.assign({}, eventType, {
+        display: !eventType.display,
+      }),
+    });
+  }
+
+  // If none of the edge cases above
+  else {
+    newState.eventTypes = Object.assign({}, state.eventTypes, {
+      [eventType.id]: Object.assign({}, eventType, {
+        display: !eventType.display,
+      }),
+    });
+  }
+
+  return Object.assign({}, state.eventTypes, newState.eventTypes);
+};
 
 export const setEventsForEventTypeId = (state, eventTypeId, events) => (
   Object.assign({}, state.eventTypes, {


### PR DESCRIPTION
## Changing the logic of frontpage event types

- [ ] QA / Code Review


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [x] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
<!-- this means that other people can use this code without having to do/change anything -->
- [ ] I have updated the build configuration
- [ ] These changes requires changes to configuration in production <!-- E.g. an API token -->
    - [ ] I have applied the required changes in production
    - [ ] I cannot apply the required changes in production before this is deployed.


## Description of changes

Added more logic to which buttons is toggled on event types. This is because people mostly want to filter out all other options when they select one. When selecting all manually, the logic will notice and not deselect all again, but just toggle them as usual. People will mostly only click once and leave, so it is important to do the first step most intuitive as possible.

## Use cases in screenshots

First look:
![image](https://cloud.githubusercontent.com/assets/8504538/25460231/aacb45e4-2ae2-11e7-88c5-48cdec31f0c5.png)

Then, after selecting"Kurs":
![image](https://cloud.githubusercontent.com/assets/8504538/25460265/c98cfa72-2ae2-11e7-8b5a-62bf24edfc79.png)

After selecting all:
![image](https://cloud.githubusercontent.com/assets/8504538/25460287/ea572a52-2ae2-11e7-8a8d-eb5793f6704f.png)

Then, after selecting "Kurs" again (after all was selected manually):
![image](https://cloud.githubusercontent.com/assets/8504538/25460309/08c82f7c-2ae3-11e7-8fcb-43c475cd7917.png)

