### PR TITLE
Make OW4 an OpenID Connect Provider

### DIFF
--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -142,6 +142,7 @@ MIDDLEWARE_CLASSES = (
     'middleware.http.Http403Middleware',
     'reversion.middleware.RevisionMiddleware',
     'oauth2_provider.middleware.OAuth2TokenMiddleware',
+    'oidc_provider.middleware.SessionManagementMiddleware',
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
@@ -230,6 +231,7 @@ INSTALLED_APPS = (
     'corsheaders',
     'datetimewidget',
     'webpack_loader',
+    'oidc_provider',
 
     # Django apps
     'django.contrib.admin',

--- a/onlineweb4/urls.py
+++ b/onlineweb4/urls.py
@@ -3,11 +3,9 @@ from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.http import HttpResponse
-from django.views.defaults import server_error
 from django.views.generic import TemplateView
 from django_js_reverse.views import urls_js
 from django_nyt.urls import get_pattern as get_notify_pattern
-from filebrowser.sites import site
 from wiki.urls import get_pattern as get_wiki_pattern
 from onlineweb4 import views
 
@@ -231,6 +229,11 @@ if 'rest_framework' in settings.INSTALLED_APPS:
 
     urlpatterns += [
         url(r'^api/v1/', include(api_urls()))
+    ]
+
+if 'oidc_provider' in settings.INSTALLED_APPS:
+    urlpatterns += [
+        url(r'^openid/', include('oidc_provider.urls', namespace='oidc_provider'))
     ]
 
 #500 view

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ django-datetime-widget==0.9.3   # Datetime widget for forms
 django-webpack-loader==0.5.0    # Integration with webpack
 dj-database-url==0.4.2          # Allows to configure databases using URLs
 python-decouple==3.0            # Configuration and settings management
+django-oidc-provider==0.5.0     # OpenID Connect Provider
 
 #test tools
 django-nose>=1.4,<1.5           # We use this test runner locally

--- a/templates/oidc_provider/authorize.html
+++ b/templates/oidc_provider/authorize.html
@@ -1,0 +1,42 @@
+{% extends "sso/index.html" %}
+{% block content %}
+<div id="sso-panel">
+{% if not error %}
+    <div id="sso-panel-header">
+        <h3>Ekstern autentisering</h3>
+    </div>
+    <div id="sso-panel-body">
+        <h4>Tjenesten {{ client.name }} ønsker tilgang til denne informasjonen om deg.</h4>
+        <form id="sso-authorization-form" method="post" action="{% url 'oidc_provider:authorize' %}">
+            {% csrf_token %}
+
+            {{ hidden_inputs }}
+
+            <p>Tjenesten behøver følgende tilganger:</p>
+            <ul class="sso-permissions">
+            {% for scope in scopes %}
+            <li>
+                <strong>{{ scope.name }}</strong>
+                <br />
+                <i>{{ scope.description }}</i>
+            </li>
+            {% endfor %}
+            </ul>
+            <br />
+            <div id="sso-control-buttons">
+                <input type="submit" class="btn btn-large btn-success" name="allow" value="Godta" />
+                <input type="submit" class="btn btn-large btn-danger pull-right" value="Avslå" />
+            </div>
+        </form>
+    </div>
+    <p class="text-center"><small><i class="glyphicon glyphicon-lock"></i> Ekstern autentisering benytter OAuth 2.0 gjennom TLS</small></p>
+{% else %}
+    <div id="sso-panel-header">
+        <h3>En feil skjedde</h3>
+    </div>
+    <div id="sso-panel-body">
+        {{ error.description }}
+    </div>
+{% endif %}
+</div>
+{% endblock %}

--- a/templates/oidc_provider/authorize.html
+++ b/templates/oidc_provider/authorize.html
@@ -29,7 +29,7 @@
             </div>
         </form>
     </div>
-    <p class="text-center"><small><i class="glyphicon glyphicon-lock"></i> Ekstern autentisering benytter OAuth 2.0 gjennom TLS</small></p>
+    <p class="text-center"><small><i class="glyphicon glyphicon-lock"></i> Ekstern autentisering benytter OpenID Connect og OAuth 2.0 gjennom TLS</small></p>
 {% else %}
     <div id="sso-panel-header">
         <h3>En feil skjedde</h3>


### PR DESCRIPTION
## What kind of a pull request is this?

- [x] QA / Code Review


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
- [x] These changes requires changes to configuration in production
    - [ ] I have applied the required changes in production
    - [x] I cannot apply the required changes in production before this is deployed.


## Description of changes

Makes OW4 an OpenID Connect provider so that we can create clients using OIDC rather than pure OAuth2.

The change required in production is to run `python manage.py creatersatoken` to create an RSA token for the OIDC server to provide.
