### PR TITLE
Feature/alpine django

### DIFF
--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3-alpine
 MAINTAINER dotkom
 
 ENV APP_DIR=/srv/app
@@ -6,10 +6,11 @@ ENV APP_DIR=/srv/app
 RUN mkdir -p $APP_DIR
 WORKDIR $APP_DIR
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-    libjpeg-dev \
-    ghostscript
+RUN apk add --no-cache \
+    build-base \
+    git \
+    imagemagick zlib-dev jpeg-dev \
+    postgresql-dev
 
 COPY requirements.txt $APP_DIR/requirements.txt
 RUN pip install -r $APP_DIR/requirements.txt

--- a/Dockerfile.testbase-prod
+++ b/Dockerfile.testbase-prod
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.4
 MAINTAINER dotkom@online.ntnu.no
 
 # Install deps

--- a/manage.py
+++ b/manage.py
@@ -2,6 +2,8 @@
 import os
 import sys
 
+import threading; threading.stack_size(4*80*1024)
+
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "onlineweb4.settings")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,9 +44,6 @@ django-oidc-provider==0.5.0     # OpenID Connect Provider
 django-nose>=1.4,<1.5           # We use this test runner locally
 nose==1.3.7                     # We use this test runner locally
 
-# Frigg
-requests[security]==2.13.0
-
 # Wiki
 wiki==0.3b1
 


### PR DESCRIPTION
## What kind of a pull request is this?

- [x] QA / Code Review

## (Possible) Breaking Changes

- [x] The changes are backwards compatible
- [x] I have updated the build configuration


## Description of changes
Use alpine instead of debian as base for django image

### Build time and image sizes overview

| version | size | build time | including image pull |
| --- | --- | --- | --- |
| debian | 939 MB | 2 min 3 sec | false |
| debian | 939 MB | 2 min 27 sec | true |
| alpine | 499 MB | 2 min 9 sec | false |
| alpine | 499 MB | 2 min 12 sec | true |

### Build times and sizes detail

#### python3-alpine - cached python:3-alpine
docker-compose build --no-cache django  1,37s user 0,15s system 1% cpu 2:09,05 total

| REPOSITORY | TAG | IMAGE ID | CREATED | SIZE |
| --- | --- | --- | --- | --- |
| onlineweb4_django | latest | ee940288165a | 24 seconds ago | 499MB |

#### python:3 - cached python:3
docker-compose build --no-cache django  1,33s user 0,18s system 1% cpu 2:03,65 total

| REPOSITORY | TAG | IMAGE ID | CREATED | SIZE |
| --- | --- | --- | --- | --- | 
| onlineweb4_django | latest | cd17fe69de66 | 5 seconds ago | 939MB |

#### python:3-alpine - pull
docker-compose build --no-cache django  1,56s user 0,22s system 1% cpu 2:12,83 total

#### python:3 - pull
docker-compose build --no-cache django  1,50s user 0,22s system 1% cpu 2:27,84 total

### Conclusion

While the build times are quite similar, the image sizes are reduced to half.

They can further be reduced if we find ways to remove dependencies to e.g. `git` (and probably `base-build`)  (by not installing dependencies using `git+https://` in `requirements.txt`) and if we manage to find a fix for #1827.
