### PR TITLE
changed RUN npm to RUN yarn and 6-slim to 8.5-alpine

### DIFF
--- a/Dockerfile.webpack
+++ b/Dockerfile.webpack
@@ -1,4 +1,4 @@
-FROM node:6-slim
+FROM node:8.5-alpine
 MAINTAINER dotkom
 
 ENV APP_DIR=/srv/app
@@ -7,6 +7,6 @@ RUN mkdir -p $APP_DIR
 WORKDIR $APP_DIR
 
 COPY package.json $APP_DIR/package.json
-RUN npm install
+RUN yarn
 
 CMD ["bash"]


### PR DESCRIPTION
## What kind of a pull request is this?
dockerfile updates

## Description of changes
npm has some problems installing the "transform-runtime" plugin. 
This was resolved by using yarn instead.