### PR TITLE
Add jQuery as a external dependency to fix weird jQuery plugin errors

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -223,6 +223,11 @@
         <script src="https://cdn.ravenjs.com/3.17.0/raven.min.js" crossorigin="anonymous"></script>
         <script>Raven.config('{% sentry_public_dsn "https" %}').install()</script>
 
+        <script
+            src="https://code.jquery.com/jquery-2.2.4.min.js"
+            integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44="
+            crossorigin="anonymous"
+        ></script>
         <script src="https://maps.googleapis.com/maps/api/js?v=3&amp;sensor=true"></script>
         <script src="{% url 'js_reverse' %}" type="text/javascript"></script>
         {% render_bundle 'common' 'js' %}

--- a/templates/dashboard_base.html
+++ b/templates/dashboard_base.html
@@ -329,6 +329,12 @@
         <script src="https://cdn.ravenjs.com/3.17.0/raven.min.js" crossorigin="anonymous"></script>
         <script>Raven.config('{% sentry_public_dsn "https" %}').install()</script>
         <script src="{% url 'js_reverse' %}" type="text/javascript"></script>
+        <script
+            src="https://code.jquery.com/jquery-2.2.4.min.js"
+            integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44="
+            crossorigin="anonymous"
+        ></script>
+
         {% render_bundle 'common' 'js' %}
         {% render_bundle 'dashboard' 'js' %}
     {% endblock %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -125,6 +125,7 @@ const webpackConfig = {
   externals: {
     // django-js-reverse adds a global Urls object which we use to generate urls in javascript
     urls: 'Urls',
+    jquery: 'jQuery',
   },
   module: {
     /*


### PR DESCRIPTION
This works because jQuery will always be global which ensures that
jQuery plugins can register on the global $ object.
