### PR TITLE
Added autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "> 5% in NO"
   ],
   "dependencies": {
+    "autoprefixer": "^7.1.4",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0",
@@ -15,6 +16,7 @@
     "classnames": "^2.2.5",
     "corejs-typeahead": "^1.1.0",
     "cropperjs": "^1.0.0-beta",
+    "cssnano": "^3.10.0",
     "dropzone": "^4.3.0",
     "eonasdan-bootstrap-datetimepicker": "^4.17.43",
     "es6-promise": "^4.0.5",
@@ -28,6 +30,7 @@
     "masonry-layout": "^4.1.1",
     "moment": "^2.16.0",
     "picturefill": "^3.0.2",
+    "postcss-loader": "^2.0.6",
     "react": "^15.3.0",
     "react-bootstrap": "^0.30.5",
     "react-dom": "^15.3.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,9 @@
+module.exports = ({ file, options, env }) => {
+  return {
+  plugins: {
+    'autoprefixer': {},
+    'cssnano': env === 'production' ? {
+      preset: 'default',
+    } : false,
+  },
+}};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -164,6 +164,12 @@ const webpackConfig = {
               sourceMap: true,
             },
           },
+          {
+            loader: 'postcss-loader',
+            options: {
+              sourceMap: true,
+            },
+          },
         ],
       },
       {
@@ -175,6 +181,12 @@ const webpackConfig = {
           },
           {
             loader: 'css-loader',
+            options: {
+              sourceMap: true,
+            },
+          },
+          {
+            loader: 'postcss-loader',
             options: {
               sourceMap: true,
             },


### PR DESCRIPTION
This will follow [browserlist](https://github.com/ai/browserslist), which is hella neat.
This allows us to write CSS (or LESS) without thinking about vendor prefixes. It also allows us to remove vendor prefixes from existing code. That is really handy for, oh I don't know, maybe like a big CSS rework?
