### PR TITLE
Enabled the globalhistory plugin for the wiki

### DIFF
--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -286,6 +286,7 @@ INSTALLED_APPS = (
     'wiki.plugins.macros',
     'wiki.plugins.help',
     'wiki.plugins.links',
+    'wiki.plugins.globalhistory',
 
 )
 


### PR DESCRIPTION
## What kind of a pull request is this?

- [x] Feature ?
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
- [ ] I have updated the build configuration


## Description of changes

This PR enables the global history plugin for the wiki. This is the first step in opening editing of the wiki to more users.

Go to http://localhost:8000/wiki/_plugin/globalhistory/ to see the history.