### PR TITLE
Parallelize drone CI tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ pipeline:
     image: registry.online.ntnu.no/dotkom/onlineweb4-testbase
     when:
       event: [push, pull_request, tag, deployment]
-      branch: master
+      branch: develop
     commands:
       - cp onlineweb4/settings/example-local.py onlineweb4/settings/local.py
       - npm install --depth=0 --quiet
@@ -50,7 +50,7 @@ pipeline:
     secrets: [codecov_token]
     when:
       event: [push, pull_request, tag, deployment]
-      branch: master
+      branch: develop
     group: testing
     commands:
       - py.test --cov=apps

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,8 @@ pipeline:
   setup:
     image: registry.online.ntnu.no/dotkom/onlineweb4-testbase
     when:
-      event: pull_request
+      event: [push, pull_request, tag, deployment]
+      branch: master
     commands:
       - cp onlineweb4/settings/example-local.py onlineweb4/settings/local.py
       - npm install --depth=0 --quiet
@@ -48,7 +49,8 @@ pipeline:
     image: registry.online.ntnu.no/dotkom/onlineweb4-testbase
     secrets: [codecov_token]
     when:
-      event: pull_request
+      event: [push, pull_request, tag, deployment]
+      branch: master
     group: testing
     commands:
       - py.test --cov=apps

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,7 +18,6 @@ pipeline:
     commands:
       - cp onlineweb4/settings/example-local.py onlineweb4/settings/local.py
       - npm install --depth=0 --quiet
-      - pip install -r requirements.txt -r requirements-testing.txt --quiet --cache-dir pip-cache
 
   npm-build:
     image: registry.online.ntnu.no/dotkom/onlineweb4-testbase
@@ -36,16 +35,7 @@ pipeline:
     commands:
       - npm run lint
 
-  python-lint:
-    image: registry.online.ntnu.no/dotkom/onlineweb4-testbase
-    when:
-      event: pull_request
-    group: testing
-    commands:
-      - isort -c -rc apps middleware scripts utils
-      - flake8 apps middleware scripts utils
-
-  django-tests:
+  python-tests:
     image: registry.online.ntnu.no/dotkom/onlineweb4-testbase
     secrets: [codecov_token]
     when:
@@ -53,6 +43,9 @@ pipeline:
       branch: develop
     group: testing
     commands:
+      - pip install -r requirements.txt -r requirements-testing.txt --quiet --cache-dir pip-cache
+      - isort -c -rc apps middleware scripts utils
+      - flake8 apps middleware scripts utils
       - py.test --cov=apps
       - pip install codecov --quiet
       - codecov

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,19 +10,47 @@ pipeline:
     volumes:
       - /tmp/cache:/cache
 
-  test:
+  setup:
     image: registry.online.ntnu.no/dotkom/onlineweb4-testbase
-    secrets: [codecov_token]
     when:
       event: pull_request
     commands:
       - cp onlineweb4/settings/example-local.py onlineweb4/settings/local.py
       - npm install --depth=0 --quiet
       - pip install -r requirements.txt -r requirements-testing.txt --quiet --cache-dir pip-cache
+
+  npm-build:
+    image: registry.online.ntnu.no/dotkom/onlineweb4-testbase
+    when:
+      event: pull_request
+    group: testing
+    commands:
       - npm run build:prod
+
+  js-lint:
+    image: registry.online.ntnu.no/dotkom/onlineweb4-testbase
+    when:
+      event: pull_request
+    group: testing
+    commands:
       - npm run lint
+
+  python-lint:
+    image: registry.online.ntnu.no/dotkom/onlineweb4-testbase
+    when:
+      event: pull_request
+    group: testing
+    commands:
       - isort -c -rc apps middleware scripts utils
       - flake8 apps middleware scripts utils
+
+  django-tests:
+    image: registry.online.ntnu.no/dotkom/onlineweb4-testbase
+    secrets: [codecov_token]
+    when:
+      event: pull_request
+    group: testing
+    commands:
       - py.test --cov=apps
       - pip install codecov --quiet
       - codecov

--- a/.drone.yml
+++ b/.drone.yml
@@ -80,5 +80,6 @@ pipeline:
     when:
       event: push
       branch: develop
+      status: success
     script:
       - /srv/www/ow4dev/deploy.sh


### PR DESCRIPTION
## Description of changes

This way you'll potentially get feedback a bit quicker since tests run in parallell.

Previously you could have two errors in different test runs (e.g. one lint error and one test error). The tests would exit after the first non-zero error code, which hid the fact that you failed tests. Only when you fixed the linting problem the failing test would appear. This is a silly way of doing things.

Also, it should be easier to see what category the test failure is in, since each build step has a name which tells you what's there (linting, testing, ...)
