### PR TITLE
Added image-credits to images on events

### DIFF
--- a/assets/events/details/less/event_details.less
+++ b/assets/events/details/less/event_details.less
@@ -1,6 +1,17 @@
 @import "~common/less/colors.less";
 
 section#event-details {
+    .event-details-single-image{
+      position: relative;
+    }
+    .event-details-image-credits{
+      position: absolute;
+      bottom: 0;
+      padding: 3px 7px;
+      background-color: rgba(0, 0, 0, 0.57);
+      color: white;
+      margin: 0;
+    }
     .row-space {
         margin-bottom: 30px;
         @media screen and (max-width: 767px) {

--- a/templates/events/details.html
+++ b/templates/events/details.html
@@ -305,30 +305,33 @@
                     </div>
                 </div>
                 <div class="col-md-5 event-status-companies-container">
-                    <div>
-                        {% if event.companies.all %}
-                            <div class="row">
-                                <div class="col-md-12 event-status-companies">
-                                    <div class="title">Medarrangører</div>
-                                    {% for company_relation in event.companies.all %}
-                                        <div class="heading clearfix row-space">
-                                            <a href="{% url 'company_details' company_relation.company.pk %}">
-                                                <div class="title">{{ company_relation.company.name }}</div>
-                                                <div class="image-holder">
-                                                    <picture>
-                                                        <source srcset="{{ company_relation.company.image.lg }}" media="(max-width: 992px)">
-                                                        <img src="{{ company_relation.company.image.md }}" width="100%" alt="{{ company_relation.company.name }}" />
-                                                    </picture>
-                                                </div>
-                                            </a>
-                                        </div>
-                                    {% endfor %}
-                                </div>
+                    {% if event.companies.all %}
+                        <div class="row">
+                            <div class="col-md-12 event-status-companies">
+                                <div class="title">Medarrangører</div>
+                                {% for company_relation in event.companies.all %}
+                                    <div class="heading clearfix row-space">
+                                        <a href="{% url 'company_details' company_relation.company.pk %}">
+                                            <div class="title">{{ company_relation.company.name }}</div>
+                                            <div class="image-holder">
+                                                <picture>
+                                                    <source srcset="{{ company_relation.company.image.lg }}" media="(max-width: 992px)">
+                                                    <img src="{{ company_relation.company.image.md }}" width="100%" alt="{{ company_relation.company.name }}" />
+                                                </picture>
+                                            </div>
+                                        </a>
+                                    </div>
+                                {% endfor %}
                             </div>
-                        {% else %}
-                            <img class="event-image" src="{{ event.image.lg }}" alt="{{ event.image.description }}" />
-                        {% endif %}
-                    </div>
+                        </div>
+                    {% else %}
+                        <div class="event-details-single-image">
+                          <img class="event-image" src="{{ event.image.lg }}" alt="{{ event.image.description }}" />
+                          {% if event.image.photographer %}
+                            <p class="event-details-image-credits">Foto: {{ event.image.photographer }}</p>
+                          {% endif %}
+                        </div>
+                    {% endif %}
                 </div>
             </div>
 


### PR DESCRIPTION
## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
<!-- this means that other people can use this code without having to do/change anything -->
- [ ] I have updated the build configuration
- [ ] These changes requires changes to configuration in production <!-- E.g. an API token -->
    - [ ] I have applied the required changes in production
    - [ ] I cannot apply the required changes in production before this is deployed.


## Description of changes
Added a p-tag under the current img-tag. Wrapped both the img-tag and the p-tag inside a div-tag with the class "event-details-single-image". This was so that I could position the p-tag inside the image.

Also removed an unnecessary div-tag that the images were wrapped in before..

## Screenshots

### Before 
<img width="1279" alt="screen shot 2017-11-15 at 20 52 10" src="https://user-images.githubusercontent.com/24507952/32857073-fe47dcb0-ca46-11e7-8805-6bd74f1e16c6.png">

### After 
<img width="1280" alt="screen shot 2017-11-15 at 20 52 22" src="https://user-images.githubusercontent.com/24507952/32857079-0373cf8c-ca47-11e7-857a-733f68822afe.png">