### PR TITLE
Fix #1835. Upgrade django-reversion.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ django-dynamic-fixture==1.9.5   # Dynamic fixtures for models
 django-recaptcha==1.3.1         # Google ReCaptcha
 django-oauth-toolkit==1.0.0    # OAuth2 authentication support
 django-watson==1.4.3            # Indexed model search lib
-django-reversion==2.0.6         # Model version history with middleware hooks to all post_save signals
+django-reversion==2.0.10        # Model version history with middleware hooks to all post_save signals
 git+https://github.com/dotkom/django-guardian.git@1b184d5377200ab4ad59b343ae8af9a863124510#egg=django-guardian==1.4.9b          # Per Object permissions framework
 django-taggit==0.22.1           # Generic multi-model tagging library
 django-taggit-serializer==0.1.5 # REST Framework serializers for Django-taggit


### PR DESCRIPTION
## What kind of a pull request is this?

- [x] QA / Code Review

## Description of changes

#1835 was created when we faced issues with nibble not working after having upgraded django-reversion to v2.0.8. 

Django-reversion implemented https://github.com/etianen/django-reversion/pull/649 in v2.0.10 which targets the issues we faced in #1835.

I just installed v2.0.10 locally and tried purchasing something using nibble and it worked. :tada:

I also tried installing v2.0.8 and that _failed_ with the error described in the issue.

I'm not sure if we had other triggers for this, but if we did, we should check if they still break. Otherwise we're probably :tm: safe to upgrade this.