### PR TITLE
URL Integration tests for some event views

### DIFF
--- a/apps/events/forms.py
+++ b/apps/events/forms.py
@@ -16,8 +16,8 @@ class CaptchaForm(forms.Form):
         max_length=100)
     mark_rules = forms.BooleanField(label=_('Jeg godtar <a href="/profile/#marks" target="_blank">prikkreglene</a>'),
                                     error_messages={'required': _('Du må godta prikkereglene!')})
-    captcha = ReCaptchaField(error_messages={'required': _('Du klarte ikke captchaen! Er du en bot?'),
-                                             'invalid': _('Du klarte ikke captchaen! Er du en bot?')})
+    captcha = ReCaptchaField(error_messages={'captcha_error': _('Du klarte ikke captchaen! Er du en bot?'),
+                                             'captcha_invalid': _('Du klarte ikke captchaen! Er du en bot?')})
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop('user', None)

--- a/apps/events/tests/all_tests.py
+++ b/apps/events/tests/all_tests.py
@@ -463,15 +463,6 @@ class EventsURLTestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_events_detail(self):
-        event = create_generic_event()
-
-        url = reverse('events_details', args=(event.id, event.slug))
-
-        response = self.client.get(url)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
     def test_search_events(self):
         query = ''
 

--- a/apps/events/tests/detail_view_tests.py
+++ b/apps/events/tests/detail_view_tests.py
@@ -1,12 +1,14 @@
-from .utils import generate_event, add_to_trikom
-from ..models import GroupRestriction, TYPE_CHOICES
-from apps.authentication.models import OnlineUser
 from django.contrib.auth.models import Group
-from django.test import TestCase
-
 from django.core.urlresolvers import reverse
-from rest_framework import status
+from django.test import TestCase
 from django_dynamic_fixture import G
+from rest_framework import status
+
+from apps.authentication.models import OnlineUser
+
+from ..models import TYPE_CHOICES, GroupRestriction
+from .utils import (add_payment_delay, add_to_trikom, attend_user_to_event, generate_event,
+                    generate_payment, pay_for_event)
 
 
 class EventsURLTestCase(TestCase):
@@ -22,11 +24,11 @@ class EventsURLTestCase(TestCase):
         self.client.force_login(self.user)
 
         self.event = generate_event(TYPE_CHOICES[0][0])
+        self.event_url = reverse(
+            'events_details', args=(self.event.id, self.event.slug))
 
     def test_ok(self):
-        url = reverse('events_details', args=(self.event.id, self.event.slug))
-
-        response = self.client.get(url)
+        response = self.client.get(self.event_url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -42,9 +44,8 @@ class EventsURLTestCase(TestCase):
         add_to_trikom(self.user)
         trikom = Group.objects.get(name__iexact='trikom')
         G(GroupRestriction, event=self.event, groups=[trikom])
-        url = reverse('events_details', args=(self.event.id, self.event.slug))
 
-        response = self.client.get(url)
+        response = self.client.get(self.event_url)
         messages = list(response.context['messages'])
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -54,10 +55,79 @@ class EventsURLTestCase(TestCase):
         add_to_trikom(self.user)
         arrkom = Group.objects.get(name__iexact='arrkom')
         G(GroupRestriction, event=self.event, groups=[arrkom])
-        url = reverse('events_details', args=(self.event.id, self.event.slug))
 
-        response = self.client.get(url)
+        response = self.client.get(self.event_url)
         messages = [str(message) for message in response.context['messages']]
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("Du har ikke tilgang til dette arrangementet.", messages)
+
+    def test_payment_logged_out(self):
+        payment = generate_payment(self.event)
+
+        self.client.logout()
+        response = self.client.get(self.event_url)
+        context = response.context
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(context['payment'], payment)
+        self.assertEqual(context['user_paid'], False)
+        self.assertEqual(context['payment_delay'], None)
+        self.assertEqual(context['payment_relation_id'], None)
+
+    def test_payment_not_attended(self):
+        payment = generate_payment(self.event)
+
+        response = self.client.get(self.event_url)
+        context = response.context
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(context['payment'], payment)
+        self.assertEqual(context['user_attending'], False)
+        self.assertEqual(context['user_paid'], False)
+        self.assertEqual(context['payment_delay'], None)
+        self.assertEqual(context['payment_relation_id'], None)
+
+    def test_payment_attended(self):
+        payment = generate_payment(self.event)
+        attend_user_to_event(self.event, self.user)
+
+        response = self.client.get(self.event_url)
+        context = response.context
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(context['payment'], payment)
+        self.assertEqual(context['user_attending'], True)
+        self.assertEqual(context['user_paid'], False)
+        self.assertEqual(context['payment_delay'], None)
+        self.assertEqual(context['payment_relation_id'], None)
+
+    def test_payment_paid(self):
+        payment = generate_payment(self.event)
+        attend_user_to_event(self.event, self.user)
+        payment_relation = pay_for_event(self.event, self.user)
+
+        response = self.client.get(self.event_url)
+        context = response.context
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(context['payment'], payment)
+        self.assertEqual(context['user_attending'], True)
+        self.assertEqual(context['user_paid'], True)
+        self.assertEqual(context['payment_delay'], None)
+        self.assertEqual(context['payment_relation_id'], payment_relation.id)
+
+    def test_payment_attended_with_delay(self):
+        payment = generate_payment(self.event)
+        payment_delay = add_payment_delay(payment, self.user)
+        attend_user_to_event(self.event, self.user)
+
+        response = self.client.get(self.event_url)
+        context = response.context
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(context['payment'], payment)
+        self.assertEqual(context['user_attending'], True)
+        self.assertEqual(context['user_paid'], False)
+        self.assertEqual(context['payment_delay'], payment_delay)
+        self.assertEqual(context['payment_relation_id'], None)

--- a/apps/events/tests/detail_view_tests.py
+++ b/apps/events/tests/detail_view_tests.py
@@ -1,0 +1,15 @@
+from .utils import generate_event
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+from rest_framework import status
+
+
+class EventsURLTestCase(TestCase):
+    def test_ok(self):
+        event = generate_event()
+
+        url = reverse('events_details', args=(event.id, event.slug))
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/apps/events/tests/detail_view_tests.py
+++ b/apps/events/tests/detail_view_tests.py
@@ -11,7 +11,7 @@ from .utils import (add_payment_delay, add_to_trikom, attend_user_to_event, gene
                     generate_payment, pay_for_event)
 
 
-class EventsURLTestCase(TestCase):
+class EventsDetailTestMixin:
     def setUp(self):
         G(Group, pk=1, name="arrKom")
         G(Group, pk=3, name="bedKom")
@@ -27,6 +27,8 @@ class EventsURLTestCase(TestCase):
         self.event_url = reverse(
             'events_details', args=(self.event.id, self.event.slug))
 
+
+class EventsDetailRestricted(EventsDetailTestMixin, TestCase):
     def test_ok(self):
         response = self.client.get(self.event_url)
 
@@ -62,6 +64,8 @@ class EventsURLTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("Du har ikke tilgang til dette arrangementet.", messages)
 
+
+class EventsDetailPayment(EventsDetailTestMixin, TestCase):
     def test_payment_logged_out(self):
         payment = generate_payment(self.event)
 

--- a/apps/events/tests/detail_view_tests.py
+++ b/apps/events/tests/detail_view_tests.py
@@ -1,15 +1,63 @@
-from .utils import generate_event
+from .utils import generate_event, add_to_trikom
+from ..models import GroupRestriction, TYPE_CHOICES
+from apps.authentication.models import OnlineUser
+from django.contrib.auth.models import Group
 from django.test import TestCase
+
 from django.core.urlresolvers import reverse
 from rest_framework import status
+from django_dynamic_fixture import G
 
 
 class EventsURLTestCase(TestCase):
-    def test_ok(self):
-        event = generate_event()
+    def setUp(self):
+        G(Group, pk=1, name="arrKom")
+        G(Group, pk=3, name="bedKom")
+        G(Group, pk=6, name="fagKom")
+        G(Group, pk=5, name="eksKom")
+        G(Group, pk=8, name="triKom")
+        G(Group, pk=12, name="Komiteer")
 
-        url = reverse('events_details', args=(event.id, event.slug))
+        self.user = G(OnlineUser)
+        self.client.force_login(self.user)
+
+        self.event = generate_event(TYPE_CHOICES[0][0])
+
+    def test_ok(self):
+        url = reverse('events_details', args=(self.event.id, self.event.slug))
 
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_404(self):
+        event = generate_event()
+        url = reverse('events_details', args=(event.id + 10, event.slug))
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_group_restricted_access(self):
+        add_to_trikom(self.user)
+        trikom = Group.objects.get(name__iexact='trikom')
+        G(GroupRestriction, event=self.event, groups=[trikom])
+        url = reverse('events_details', args=(self.event.id, self.event.slug))
+
+        response = self.client.get(url)
+        messages = list(response.context['messages'])
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(messages), 0)
+
+    def test_group_restricted_no_access(self):
+        add_to_trikom(self.user)
+        arrkom = Group.objects.get(name__iexact='arrkom')
+        G(GroupRestriction, event=self.event, groups=[arrkom])
+        url = reverse('events_details', args=(self.event.id, self.event.slug))
+
+        response = self.client.get(url)
+        messages = [str(message) for message in response.context['messages']]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("Du har ikke tilgang til dette arrangementet.", messages)

--- a/apps/events/tests/utils.py
+++ b/apps/events/tests/utils.py
@@ -32,11 +32,13 @@ def attend_user_to_event(event, user):
     )
 
 
-def pay_for_event(event, user):
+def pay_for_event(event, user, *args, **kwargs):
     return G(
         PaymentRelation,
         payment=event.attendance_event.payment(),
-        user=user
+        user=user,
+        *args,
+        **kwargs
     )
 
 

--- a/apps/events/tests/utils.py
+++ b/apps/events/tests/utils.py
@@ -10,7 +10,8 @@ from ..utils import get_organizer_by_event_type
 
 
 def generate_event(event_type=TYPE_CHOICES[1][0]):
-    event = G(Event, event_type=event_type, organizer=get_organizer_by_event_type(event_type))
+    event = G(Event, event_type=event_type,
+              organizer=get_organizer_by_event_type(event_type))
     G(AttendanceEvent, event=event)
     return event
 

--- a/apps/events/tests/utils.py
+++ b/apps/events/tests/utils.py
@@ -1,8 +1,11 @@
 from django.contrib.auth.models import Group
+from django.contrib.contenttypes.models import ContentType
 from django_dynamic_fixture import G
 from guardian.shortcuts import assign_perm, get_perms_for_model
 
-from ..models import TYPE_CHOICES, AttendanceEvent, Event
+from apps.payment.models import Payment, PaymentDelay, PaymentRelation
+
+from ..models import TYPE_CHOICES, AttendanceEvent, Attendee, Event
 from ..utils import get_organizer_by_event_type
 
 
@@ -10,6 +13,38 @@ def generate_event(event_type=TYPE_CHOICES[1][0]):
     event = G(Event, event_type=event_type, organizer=get_organizer_by_event_type(event_type))
     G(AttendanceEvent, event=event)
     return event
+
+
+def generate_payment(event):
+    return G(
+        Payment,
+        object_id=event.id,
+        content_type=ContentType.objects.get_for_model(AttendanceEvent)
+    )
+
+
+def attend_user_to_event(event, user):
+    return G(
+        Attendee,
+        event=event.attendance_event,
+        user=user
+    )
+
+
+def pay_for_event(event, user):
+    return G(
+        PaymentRelation,
+        payment=event.attendance_event.payment(),
+        user=user
+    )
+
+
+def add_payment_delay(payment, user):
+    return G(
+        PaymentDelay,
+        payment=payment,
+        user=user
+    )
 
 
 def add_to_committee(user, group=None):

--- a/apps/events/tests/view_tests.py
+++ b/apps/events/tests/view_tests.py
@@ -14,7 +14,7 @@ from .utils import (add_payment_delay, add_to_trikom, attend_user_to_event, gene
                     generate_payment, pay_for_event)
 
 
-class EventsDetailTestMixin:
+class EventsTestMixin:
     def setUp(self):
         G(Group, pk=1, name="arrKom")
         G(Group, pk=3, name="bedKom")
@@ -31,7 +31,7 @@ class EventsDetailTestMixin:
             'events_details', args=(self.event.id, self.event.slug))
 
 
-class EventsDetailRestricted(EventsDetailTestMixin, TestCase):
+class EventsDetailRestricted(EventsTestMixin, TestCase):
     def test_ok(self):
         response = self.client.get(self.event_url)
 
@@ -68,7 +68,7 @@ class EventsDetailRestricted(EventsDetailTestMixin, TestCase):
         self.assertIn("Du har ikke tilgang til dette arrangementet.", messages)
 
 
-class EventsDetailPayment(EventsDetailTestMixin, TestCase):
+class EventsDetailPayment(EventsTestMixin, TestCase):
     def test_payment_logged_out(self):
         payment = generate_payment(self.event)
 
@@ -140,7 +140,7 @@ class EventsDetailPayment(EventsDetailTestMixin, TestCase):
         self.assertEqual(context['payment_relation_id'], None)
 
 
-class EventsDetailExtras(EventsDetailTestMixin, TestCase):
+class EventsDetailExtras(EventsTestMixin, TestCase):
     def extras_post(self, event_url, extras_id):
         return self.client.post(
             event_url,
@@ -195,7 +195,7 @@ class EventsDetailExtras(EventsDetailTestMixin, TestCase):
                          'Lagret ditt valg')
 
 
-class EventsAttend(EventsDetailTestMixin, TestCase):
+class EventsAttend(EventsTestMixin, TestCase):
     def setUp(self):
         super().setUp()
         os.environ['RECAPTCHA_TESTING'] = 'True'


### PR DESCRIPTION
Tests for viewing event(includes group restrictions, extras and payment), choosing extras, attending and unattending. 

Also contains some minor fixes that I found while adding tests:

- Custom captcha errors weren't used
- Error checks done while choosing extras weren't working

