### PR TITLE
Create tests for event payment delay related views

### DIFF
--- a/apps/events/tests/utils.py
+++ b/apps/events/tests/utils.py
@@ -3,6 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from django_dynamic_fixture import G
 from guardian.shortcuts import assign_perm, get_perms_for_model
 
+from apps.authentication.models import OnlineUser
 from apps.payment.models import Payment, PaymentDelay, PaymentRelation
 
 from ..models import TYPE_CHOICES, AttendanceEvent, Attendee, Event
@@ -16,11 +17,13 @@ def generate_event(event_type=TYPE_CHOICES[1][0]):
     return event
 
 
-def generate_payment(event):
+def generate_payment(event, *args, **kwargs):
     return G(
         Payment,
         object_id=event.id,
-        content_type=ContentType.objects.get_for_model(AttendanceEvent)
+        content_type=ContentType.objects.get_for_model(AttendanceEvent),
+        *args,
+        **kwargs
     )
 
 
@@ -48,6 +51,14 @@ def add_payment_delay(payment, user):
         payment=payment,
         user=user
     )
+
+
+def generate_user(username):
+    return G(OnlineUser, username=username, ntnu_username=username)
+
+
+def generate_attendee(event, username):
+    return attend_user_to_event(event, generate_user(username))
 
 
 def add_to_committee(user, group=None):

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -5,6 +5,7 @@ lettuce>=0.2.20
 nose-cov>=1.6
 flake8==3.5.0
 isort==4.2.15
+freezegun==0.3.9
 
 # py.test
 pytest==3.3.0


### PR DESCRIPTION
To make it easier to write tests using `datetime.now` I added [freezegun](https://github.com/spulec/freezegun) as a dependency. 