### PR TITLE
Payment mommy handling of users who are manually marked as paid

### DIFF
--- a/apps/payment/models.py
+++ b/apps/payment/models.py
@@ -54,9 +54,6 @@ class Payment(models.Model):
     changed_date = models.DateTimeField(auto_now=True, editable=False)
     last_changed_by = models.ForeignKey(User, editable=False, null=True)  # Blank and null is temperarly
 
-    def paid_users(self):
-        return [payment_relation.user for payment_relation in self.paymentrelation_set.filter(refunded=False)]
-
     def payment_delays(self):
         return self.paymentdelay_set.filter(active=True)
 

--- a/apps/payment/mommy.py
+++ b/apps/payment/mommy.py
@@ -114,11 +114,8 @@ class PaymentReminder(Task):
 
     @staticmethod
     def not_paid(payment):
-        attendees = [attendee.user for attendee in payment.content_object.attendees_qs]
-        paid_users = payment.paid_users()
-
-        # Creates a list of users in attendees but not in the list of paid users
-        not_paid_users = [user for user in attendees if user not in paid_users]
+        attendees = payment.content_object.attendees_qs
+        not_paid_users = [attendee.user for attendee in attendees if not attendee.paid]
 
         # Removes users with active payment delays from the list
         return [user for user in not_paid_users if user not in payment.payment_delay_users()]


### PR DESCRIPTION
Mommy did not properly handle users who were manually marked as paid such as organizers.
This was because they never generated a PaymentRelation. 

This PR changes this check to use the Attendee.paid field instead. This field is the one shown in the dashboard and is already automatically updated when a PaymentRelation is created anyway. 