### PR TITLE
Comply with stylelint-config-standard

### DIFF
--- a/assets/careeropportunity/less/career.less
+++ b/assets/careeropportunity/less/career.less
@@ -1,138 +1,138 @@
 @import '~common/less/colors.less';
 
 #career {
-    img {
-        width: 100%;
+  img {
+    width: 100%;
+  }
+
+  .meta {
+    padding: 5px 0 0 0;
+    border-top: 1px dotted #ccc;
+    font-size: 11px;
+    color: #aaa;
+  }
+
+  article {
+    margin-bottom: 40px;
+    padding-bottom: 30px;
+
+    h1 {
+      font-size: 20px;
+      font-weight: 400;
+      color: #ee7810;
+      margin-top: 0;
     }
 
-    .meta {
-        padding: 5px 0 0 0;
-        border-top: 1px dotted #ccc;
-        font-size: 11px;
-        color: #aaa;
-    }
-
-    article {
-        margin-bottom: 40px;
-        padding-bottom: 30px;
-
-        h1 {
-            font-size: 20px;
-            font-weight: 400;
-            color: #ee7810;
-            margin-top: 0;
-        }
-
-        .ingress {
-          margin-bottom: 10px;
-          line-height: 1.625em;
-        }
-
-    }
-    
-    input {
+    .ingress {
       margin-bottom: 10px;
+      line-height: 1.625em;
     }
 
-    .filters {
-        background: @baby-blue-medium;
-        padding: 15px;
-        margin-bottom: 20px;
+  }
+    
+  input {
+    margin-bottom: 10px;
+  }
 
-        button {
-            background-color: @baby-blue;
-            color: #fff;
-            border: none;
-            display: inline-block;
-            text-align: center;
-            width: 100%;
-            font-size: 13px;
-            padding-bottom: 10px;
-            padding-top: 10px;
-        }
+  .filters {
+    background: @baby-blue-medium;
+    padding: 15px;
+    margin-bottom: 20px;
 
-        .TagContainer {
-            padding: 0;
-            margin: 0;
-            display: block;
-            margin-top: 10px;
-            margin-bottom: 15px;
-
-            button {
-                display: inline-flex;
-                padding: 10px;
-                margin-right: 5px;
-                margin-bottom: 5px;
-                color: white;
-                width: auto;
-                background:@baby-blue;
-                cursor: pointer;
-            }
-
-            button.selected {
-              background: darken(@baby-blue, 10%);
-            }
-        }
-
-        h3 {
-            margin-top: 0px;
-            font-size: 20px;
-            color: white;
-        }
+    button {
+      background-color: @baby-blue;
+      color: #fff;
+      border: none;
+      display: inline-block;
+      text-align: center;
+      width: 100%;
+      font-size: 13px;
+      padding-bottom: 10px;
+      padding-top: 10px;
     }
+
+    .TagContainer {
+      padding: 0;
+      margin: 0;
+      display: block;
+      margin-top: 10px;
+      margin-bottom: 15px;
+
+      button {
+        display: inline-flex;
+        padding: 10px;
+        margin-right: 5px;
+        margin-bottom: 5px;
+        color: white;
+        width: auto;
+        background:@baby-blue;
+        cursor: pointer;
+      }
+
+      button.selected {
+        background: darken(@baby-blue, 10%);
+      }
+    }
+
+    h3 {
+      margin-top: 0;
+      font-size: 20px;
+      color: white;
+    }
+  }
 }
 
 section#careeropportunities {
-    .career-ingress {
-        font-weight:300;
-    }
+  .career-ingress {
+    font-weight:300;
+  }
 
-    .career-title {
-        font-size:20px;
-    }
+  .career-title {
+    font-size:20px;
+  }
 }
 
 section#careeropportunity {
-    .careerdescription {
-        margin-bottom: 40px;
+  .careerdescription {
+    margin-bottom: 40px;
+  }
+
+  .company {
+    margin-top: 15px;
+    padding-left: 15px;
+    padding-right: 15px;
+    padding-bottom: 10px;
+    box-sizing: border-box;
+    background: @baby-blue-medium;
+
+    h3, p {
+      color: white;
     }
 
-    .company {
-        margin-top: 15px;
-        padding-left: 15px;
-        padding-right: 15px;
-        padding-bottom: 10px;
-        box-sizing: border-box;
-        background: @baby-blue-medium;
-
-        h3, p {
-            color: white;
-        }
-
-        h3 {
-            font-size:19px;
-        }
-
-        .company-ingress p {
-            color:white;
-            font-weight:300;
-            font-size:14px;
-        }
-
-        .company-image-caption {
-            font-weight:300;
-            font-size:11px;
-            color:white;
-            text-transform: uppercase;
-        }
-
-        a:hover {
-            text-decoration: none;
-        }
+    h3 {
+      font-size:19px;
     }
+
+    .company-ingress p {
+      color:white;
+      font-weight:300;
+      font-size:14px;
+    }
+
+    .company-image-caption {
+      font-weight:300;
+      font-size:11px;
+      color:white;
+      text-transform: uppercase;
+    }
+
+    a:hover {
+      text-decoration: none;
+    }
+  }
 }
 
 #opportunity-company-name h3 {
-    text-align: center;
-    margin-top: -10px;
+  text-align: center;
+  margin-top: -10px;
 }

--- a/assets/careeropportunity/less/career.less
+++ b/assets/careeropportunity/less/career.less
@@ -1,5 +1,10 @@
 @import '~common/less/colors.less';
 
+#opportunity-company-name h3 {
+  text-align: center;
+  margin-top: -10px;
+}
+
 #career {
   img {
     width: 100%;
@@ -129,9 +134,4 @@ section#careeropportunity {
       text-decoration: none;
     }
   }
-}
-
-#opportunity-company-name h3 {
-  text-align: center;
-  margin-top: -10px;
 }

--- a/assets/careeropportunity/less/career.less
+++ b/assets/careeropportunity/less/career.less
@@ -27,9 +27,8 @@
       margin-bottom: 10px;
       line-height: 1.625em;
     }
-
   }
-    
+
   input {
     margin-bottom: 10px;
   }
@@ -65,7 +64,7 @@
         margin-bottom: 5px;
         color: white;
         width: auto;
-        background:@baby-blue;
+        background: @baby-blue;
         cursor: pointer;
       }
 
@@ -84,11 +83,11 @@
 
 section#careeropportunities {
   .career-ingress {
-    font-weight:300;
+    font-weight: 300;
   }
 
   .career-title {
-    font-size:20px;
+    font-size: 20px;
   }
 }
 
@@ -110,19 +109,19 @@ section#careeropportunity {
     }
 
     h3 {
-      font-size:19px;
+      font-size: 19px;
     }
 
     .company-ingress p {
-      color:white;
-      font-weight:300;
-      font-size:14px;
+      color: white;
+      font-weight: 300;
+      font-size: 14px;
     }
 
     .company-image-caption {
-      font-weight:300;
-      font-size:11px;
-      color:white;
+      font-weight: 300;
+      font-size: 11px;
+      color: white;
       text-transform: uppercase;
     }
 

--- a/assets/common/datetimepicker/datetimepicker.less
+++ b/assets/common/datetimepicker/datetimepicker.less
@@ -9,6 +9,6 @@
   margin: -1px;
   padding: 0;
   overflow: hidden;
-  clip: rect(0,0,0,0);
+  clip: rect(0, 0, 0, 0);
   border: 0;
 }

--- a/assets/common/less/colors.less
+++ b/assets/common/less/colors.less
@@ -1,13 +1,13 @@
 /* Stuff */
-@grey-background:#0E3559;
+@grey-background:#0e3559;
 
 /* Orange heading */
 @heading: #ee7810;
 
 /* Committee colors */
 @fagkom-color: #a1d40a;
-@bedkom-color: #3366AA;
-@arrkom-color: #B70000;
+@bedkom-color: #36a;
+@arrkom-color: #b70000;
 
 
 /* Classes which apply text color */
@@ -18,20 +18,20 @@
 
 
 
-@baby-blue:#027BBB;
-@baby-blue-medium:#49A0CC;
-@baby-blue-light:#32AFFF;
-@light-blue-soft:#D6EAFF;
+@baby-blue:#027bbb;
+@baby-blue-medium:#49a0cc;
+@baby-blue-light:#32afff;
+@light-blue-soft:#d6eaff;
 
 
-@light-orange:#EE974F;
-@skin-orange:#FFD2A5;
+@light-orange:#ee974f;
+@skin-orange:#ffd2a5;
 
 
 
 
 /* RANDOM SHIT (throw?) */
-@content-bg:#FFF;
+@content-bg:#fff;
 @sidebar-heading:#b3b2b2;
 @sidebar-bg:#f0f8fd;
 

--- a/assets/common/less/colors.less
+++ b/assets/common/less/colors.less
@@ -9,26 +9,19 @@
 @bedkom-color: #36a;
 @arrkom-color: #b70000;
 
-
 /* Classes which apply text color */
-.fagkom { color:@fagkom-color; }
-.bedkom{ color:@bedkom-color; }
-.arrkom { color:@arrkom-color; }
-.orange { color:@heading; }
-
-
+.fagkom { color: @fagkom-color; }
+.bedkom { color: @bedkom-color; }
+.arrkom { color: @arrkom-color; }
+.orange { color: @heading; }
 
 @baby-blue:#027bbb;
 @baby-blue-medium:#49a0cc;
 @baby-blue-light:#32afff;
 @light-blue-soft:#d6eaff;
 
-
 @light-orange:#ee974f;
 @skin-orange:#ffd2a5;
-
-
-
 
 /* RANDOM SHIT (throw?) */
 @content-bg:#fff;

--- a/assets/common/less/gallery.less
+++ b/assets/common/less/gallery.less
@@ -78,7 +78,7 @@
 }
 
 .image-selection-thumbnail-image {
-  box-siging: border-box;
+  box-sizing: border-box;
   float: left;
   width: 40%;
   padding: 10px;

--- a/assets/common/less/gallery.less
+++ b/assets/common/less/gallery.less
@@ -4,9 +4,11 @@
 .responsive-image {
   width: 100%;
 }
+
 #gallery {
   width: 100%;
 }
+
 #gallery__image-edit-container, #gallery__image-active {
   width: 100%;
 }
@@ -21,12 +23,15 @@
   width: 100%;
   margin-bottom: 3px;
 }
+
 #gallery__image-edit__sidebar > div.form-group > .input-group > label.input-group-addon {
   width: 80px;
 }
+
 #gallery__image-edit--preview-wrapper {
   overflow: hidden;
 }
+
 #gallery__image-edit--log {
   vertical-align: middle;
 }
@@ -48,14 +53,17 @@
 #image-selection-wrapper {
   display: none;
 }
+
 #image-upload-wrapper {
   display: none;
 }
+
 #single-image-field-thumbnail {
   margin-top: 5px;
   margin-bottom: 5px;
   display: block;
 }
+
 .image-selection-thumbnail {
   margin: 0 auto;
   cursor: pointer;
@@ -68,8 +76,8 @@
   overflow: auto;
   background-image: linear-gradient(0deg, #f6f6f6, #fefefe);
 }
-.image-selection-thumbnail-image {
 
+.image-selection-thumbnail-image {
   box-siging: border-box;
   float: left;
   width: 40%;
@@ -81,8 +89,8 @@
     border: 1px solid #ccc;
   }
 }
-.image-selection-thumbnail-text {
 
+.image-selection-thumbnail-text {
   box-sizing: border-box;
   float: left;
   width: 60%;
@@ -96,12 +104,14 @@
     line-height: 18px;
     vertical-align: middle;
   }
+
   .image-timestamp {
-    margin: 0px;
+    margin: 0;
     font-size: 11px;
     color: #888;
     font-style: italic;
   }
+
   .image-description {
     color: #666;
     font-size: 12px;
@@ -109,9 +119,10 @@
     line-height: 12px;
   }
 }
+
 .image-selection-thumbnail-active {
   border-color: #66afe9;
-  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0,0,0,0.075), 0 0 8px rgba(102, 175, 233, 0.6);
 }
 
 #gallery__upload-button, #gallery__edit-button {
@@ -119,7 +130,7 @@
   text-decoration: none;
   display: block;
   -webkit-box-shadow: 0 3px 12px rgba(0, 0, 0, 0.075);
-  box-shadow: 0px 2px 12px rgba(0, 0, 0, 0.075);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.075);
   min-width: 200px;
   max-width: 200px;
   min-height: 75px;

--- a/assets/common/less/gallery.less
+++ b/assets/common/less/gallery.less
@@ -122,7 +122,7 @@
 
 .image-selection-thumbnail-active {
   border-color: #66afe9;
-  box-shadow: inset 0 1px 1px rgba(0,0,0,0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
 }
 
 #gallery__upload-button, #gallery__edit-button {
@@ -142,9 +142,8 @@
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  margin-bottom: 5px;
   padding: 10px;
-  margin: 0 auto;
+  margin: 0 auto 5px;
   cursor: pointer;
 }
 

--- a/assets/common/typeahead/less/typeahead.less
+++ b/assets/common/typeahead/less/typeahead.less
@@ -13,7 +13,7 @@
   width: 300px;
   border: 1px solid #66afe9;
   border-radius: 4px;
-  box-shadow: inset 0 1px 1px rgba(0,0,0,0.075), 0 0 8px rgba(102, 175, 266, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 266, 0.6);
   background-color: #fff;
   cursor: pointer;
 

--- a/assets/common/typeahead/less/typeahead.less
+++ b/assets/common/typeahead/less/typeahead.less
@@ -9,26 +9,26 @@
 }
 
 .tt-dataset-users-plain {
-    margin-top: -1px;
-    width: 300px;
-    border: 1px solid #66afe9;
-    border-radius: 4px;
-    box-shadow: inset 0 1px 1px rgba(0,0,0,0.075), 0 0 8px rgba(102, 175, 266, 0.6);
-    background-color: #fff;
-    cursor: pointer;
+  margin-top: -1px;
+  width: 300px;
+  border: 1px solid #66afe9;
+  border-radius: 4px;
+  box-shadow: inset 0 1px 1px rgba(0,0,0,0.075), 0 0 8px rgba(102, 175, 266, 0.6);
+  background-color: #fff;
+  cursor: pointer;
 
-    .user-meta h4 {
-        font-size: 14px;
-        padding-left: 5px;
-        line-height: 20px;
-        margin-top: 5px;
-        margin-bottom: 5px;
-    }
+  .user-meta h4 {
+    font-size: 14px;
+    padding-left: 5px;
+    line-height: 20px;
+    margin-top: 5px;
+    margin-bottom: 5px;
+  }
 
-    .tt-cursor {
-      color: #fff;
-      background-color: #0097cf;
-    }
+  .tt-cursor {
+    color: #fff;
+    background-color: #0097cf;
+  }
 }
 
 .tt-hint {
@@ -37,12 +37,12 @@
 
 // Needed until https://github.com/corejavascript/typeahead.js/pull/107 is merged
 .visuallyhidden {
-    position: absolute;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-    height: 1px;
-    width: 1px;
-    margin: -1px;
-    padding: 0;
-    border: 0;
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
 }

--- a/assets/contact/less/contact.less
+++ b/assets/contact/less/contact.less
@@ -1,17 +1,17 @@
 /* Contact */
 
-.form-control{
+.form-control {
   margin-top: 10px;
 }
 
-#submitContactForm{
+#submitContactForm {
   margin-top: 10px;
 }
 
-#choice_label{
+#choice_label {
   font-weight: bold;
 }
 
-#captcha{
+#captcha {
   margin-top: 10px;
 }

--- a/assets/contact/less/contact.less
+++ b/assets/contact/less/contact.less
@@ -1,17 +1,17 @@
 /* Contact */
 
 .form-control{
-    margin-top: 10px;
+  margin-top: 10px;
 }
 
 #submitContactForm{
-    margin-top: 10px;
+  margin-top: 10px;
 }
 
 #choice_label{
-    font-weight: bold;
+  font-weight: bold;
 }
 
 #captcha{
-    margin-top: 10px;
+  margin-top: 10px;
 }

--- a/assets/core/less/about.less
+++ b/assets/core/less/about.less
@@ -1,14 +1,15 @@
 
 section#about {
-    .nav-pills li a {
-        padding: 4px 10px;
-        border-radius: 0px;
-    }
+  .nav-pills li a {
+    padding: 4px 10px;
+    border-radius: 0;
+  }
 }
+
 /* Ingress for nodes section */
 #noder p:first-child {
-    font-size:16px;
-    color:#777;
-    font-weight:300;
+  font-size:16px;
+  color:#777;
+  font-weight:300;
 
 }

--- a/assets/core/less/about.less
+++ b/assets/core/less/about.less
@@ -8,8 +8,7 @@ section#about {
 
 /* Ingress for nodes section */
 #noder p:first-child {
-  font-size:16px;
-  color:#777;
-  font-weight:300;
-
+  font-size: 16px;
+  color: #777;
+  font-weight: 300;
 }

--- a/assets/core/less/article.less
+++ b/assets/core/less/article.less
@@ -99,6 +99,7 @@ section#article_archive {
     font-size: 20px;
   }
 
+  /* stylelint-disable-next-line no-descending-specificity */
   img {
     margin-bottom: 60px;
   }
@@ -120,6 +121,7 @@ section#article_archive {
     padding-bottom: 10px;
   }
 
+  /* stylelint-disable-next-line no-descending-specificity */
   p {
     margin-bottom: 5px;
     font-size: 16px;

--- a/assets/core/less/article.less
+++ b/assets/core/less/article.less
@@ -1,5 +1,20 @@
 @import '~common/less/colors.less';
 
+.article-details-ingress > p {
+  .ingress;
+
+  font-size: 20px;
+}
+
+.article-details-content {
+  font-size: 13px;
+  font-weight: 400;
+  margin: 0;
+
+  p {
+    max-width: 80%;
+  }
+}
 
 section#article-details {
   h2,h3,h4 {
@@ -202,24 +217,8 @@ section#article_archive {
 }
 
 .article-latestnews {
-  font-size:18px;
-  font-weight:500;
-}
-
-.article-details-ingress > p {
-  .ingress;
-
-  font-size:20px;
-}
-
-.article-details-content {
-  font-size:13px;
-  font-weight:400;
-  margin:0;
-
-  p {
-    max-width: 80%;
-  }
+  font-size: 18px;
+  font-weight: 500;
 }
 
 @media only screen and (max-device-width: 800px), only screen and (device-width: 1024px) and (device-height: 600px), only screen and (width: 1280px) and (orientation: landscape), only screen and (device-width: 800px), only screen and (max-width: 767px) {

--- a/assets/core/less/article.less
+++ b/assets/core/less/article.less
@@ -13,19 +13,19 @@ section#article-details {
   }
 
   .article-media {
-    margin:20px 0 20px 0;
+    margin: 20px 0 20px 0;
   }
 
   .tag-cloud {
-    margin-top:20px;
-    margin-bottom:30px;
+    margin-top: 20px;
+    margin-bottom: 30px;
 
     .tag {
-      padding:10px;
-      margin-right:5px;
+      padding: 10px;
+      margin-right: 5px;
       margin-bottom: 5px;
-      color:white;
-      background:@baby-blue;
+      color: white;
+      background: @baby-blue;
       display: inline-block;
     }
   }
@@ -45,29 +45,28 @@ section#article-details {
   }
 
   .article-detail-meta {
-    font-weight:300;
-    margin-bottom:10px;
+    font-weight: 300;
+    margin-bottom: 10px;
 
     .meta-caption {
-      font-weight:600;
+      font-weight: 600;
     }
   }
 
   .related-articles {
     h4 {
-      font-size:16px;
-      font-weight:300;
-      color:#666;
+      font-size: 16px;
+      font-weight: 300;
+      color: #666;
     }
 
     .bilde img {
       width: 100%;
     }
-
   }
 
   .row-space {
-    margin-bottom:40px;
+    margin-bottom: 40px;
   }
 
   #article-frontpage-featured {
@@ -77,7 +76,6 @@ section#article-details {
   #article-frontpage-normal {
     min-height: 134px;
   }
-
 }
 
 section#article_archive {
@@ -103,7 +101,7 @@ section#article_archive {
   .article-detail-meta {
     color: #ee7810;
     font-size: 18px;
-    font-weight:400;
+    font-weight: 400;
     padding-bottom: 10px;
   }
 
@@ -130,9 +128,9 @@ section#article_archive {
     .tag {
       display: inline-block;
       margin-bottom: 5px;
-      padding:10px;
-      color:white;
-      background:@baby-blue;
+      padding: 10px;
+      color: white;
+      background: @baby-blue;
     }
   }
 
@@ -180,14 +178,13 @@ section#article_archive {
   padding-top: 25px;
   padding-bottom: 67.5%;
   overflow: hidden;
-
 }
 
 .flex-video.widescreen {
-  padding-top:0;
+  padding-top: 0;
   padding-bottom: 57.25%;
 }
-.flex-video.vimeo { padding-top:0; }
+.flex-video.vimeo { padding-top: 0; }
 
 .flex-video iframe,
 .flex-video object,
@@ -195,13 +192,13 @@ section#article_archive {
   position: absolute;
   top: 0;
   left: 0;
-  width:100%;
-  height:100%;
+  width: 100%;
+  height: 100%;
 }
 
 .article-details-ingress {
-  margin-bottom:20px;
-  color:blue;
+  margin-bottom: 20px;
+  color: blue;
 }
 
 .article-latestnews {

--- a/assets/core/less/article.less
+++ b/assets/core/less/article.less
@@ -2,222 +2,229 @@
 
 
 section#article-details {
+  h2,h3,h4 {
+    margin-top: 25px;
+    margin-bottom: 25px;
+  }
 
-    h2,h3,h4 {
-        margin-top: 25px;
-        margin-bottom: 25px;
+  h5,h6 {
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+
+  .article-media {
+    margin:20px 0 20px 0;
+  }
+
+  .tag-cloud {
+    margin-top:20px;
+    margin-bottom:30px;
+
+    .tag {
+      padding:10px;
+      margin-right:5px;
+      margin-bottom: 5px;
+      color:white;
+      background:@baby-blue;
+      display: inline-block;
+    }
+  }
+
+  .photograph-detail-meta {
+    font-weight: 300;
+    margin-left: -15px;
+    margin-top: 5px;
+
+    .meta-caption {
+      font-weight: 600;
     }
 
-    h5,h6 {
-        margin-top: 20px;
-        margin-bottom: 20px;
+    p {
+      display: inline;
+    }
+  }
+
+  .article-detail-meta {
+    font-weight:300;
+    margin-bottom:10px;
+
+    .meta-caption {
+      font-weight:600;
+    }
+  }
+
+  .related-articles {
+    h4 {
+      font-size:16px;
+      font-weight:300;
+      color:#666;
     }
 
-    .article-media {
-        margin:20px 0 20px 0;
-    }
-
-    .tag-cloud {
-        margin-top:20px;
-        margin-bottom:30px;
-            .tag {
-                padding:10px;
-                margin-right:5px;
-                margin-bottom: 5px;
-                color:white;
-                background:@baby-blue;
-                display: inline-block;
-            }
-        }
-    .photograph-detail-meta {
-        font-weight: 300;
-        margin-left: -15px;
-        margin-top: 5px;
-        .meta-caption {
-            font-weight: 600;
-        }
-        p {
-            display: inline;
-        }
-    }
-    .article-detail-meta {
-        font-weight:300;
-        margin-bottom:10px;
-        .meta-caption {
-            font-weight:600;
-        }
-    }
-
-    .related-articles {
-        h4 {
-            font-size:16px;
-            font-weight:300;
-            color:#666;
-        }
     .bilde img {
-        width: 100%;
+      width: 100%;
     }
 
-    }
+  }
 
-    .row-space {
-        margin-bottom:40px;
-    }
+  .row-space {
+    margin-bottom:40px;
+  }
 
-    #article-frontpage-featured {
-        min-height: 368px;
-    }
-    #article-frontpage-normal {
-        min-height: 134px;
-    }
+  #article-frontpage-featured {
+    min-height: 368px;
+  }
+
+  #article-frontpage-normal {
+    min-height: 134px;
+  }
 
 }
 
 section#article_archive {
+  h3 {
+    margin-top: 0;
+    font-size: 20px;
+  }
+
+  img {
+    margin-bottom: 60px;
+  }
+
+  #filterbox {
+    background: @baby-blue-medium;
+    padding: 15px;
+    margin-bottom: 20px;
 
     h3 {
-        margin-top: 0px;
-        font-size: 20px;
+      color: white;
     }
+  }
 
-    img {
-        margin-bottom: 60px;
-    }
+  .article-detail-meta {
+    color: #ee7810;
+    font-size: 18px;
+    font-weight:400;
+    padding-bottom: 10px;
+  }
 
-    #filterbox {
+  p {
+    margin-bottom: 5px;
+    font-size: 16px;
+    font-weight: 300;
+  }
 
-        background: @baby-blue-medium;
-        padding: 15px;
-        margin-bottom: 20px;
-
-        h3 {
-            color: white;
-        }
-    }
-
-    .article-detail-meta {
-
-        color: #ee7810;
-        font-size: 18px;
-
-        font-weight:400;
-        padding-bottom: 10px;
-    }
+  .meta {
+    border-top: 1px dotted #ccc;
+    margin-top: 10px;
 
     p {
-        margin-bottom: 5px;
-        font-size: 16px;
-        font-weight: 300;
+      font-size: 11px;
+    }
+  }
+
+  .tag-cloud {
+    a:hover {
+      color: white;
     }
 
-    .meta {
-        border-top: 1px dotted #ccc;
-        margin-top: 10px;
-        p {
-            font-size: 11px;
-        }
+    .tag {
+      display: inline-block;
+      margin-bottom: 5px;
+      padding:10px;
+      color:white;
+      background:@baby-blue;
+    }
+  }
+
+  .date-filter {
+    .tag {
+      padding: 10px;
+      text-align: center;
+      color: white;
+      margin-bottom: 5px;
     }
 
-    .tag-cloud {
-        a:hover {
-            color: white;
-        }
-        .tag {
-            display: inline-block;
-            margin-bottom: 5px;
-            padding:10px;
-            color:white;
-            background:@baby-blue;
-        }
+    .tag-all {
+      display: block;
+      text-align: center;
+      background: @light-orange;
     }
 
-    .date-filter {
-
-        .tag {
-            padding: 10px;
-            text-align: center;
-            color: white;
-            margin-bottom: 5px;
-        }
-
-        .tag-all {
-            display: block;
-            text-align: center;
-            background: @light-orange;
-        }
-
-        .tag-year {
-            display: block;
-            background: @baby-blue;
-        }
-
-        .tag-month {
-            display: block;
-            background: @baby-blue-light;
-        }
+    .tag-year {
+      display: block;
+      background: @baby-blue;
     }
-    .article-hidden {
-        display: none;
+
+    .tag-month {
+      display: block;
+      background: @baby-blue-light;
     }
+  }
+
+  .article-hidden {
+    display: none;
+  }
 }
 
 .media-padding {
-    padding: 0px !important;
+  padding: 0 !important;
 }
 
 .video-container {
-    background-color: #000;
-    overflow: auto;
+  background-color: #000;
+  overflow: auto;
 }
 
 .flex-video {
-    position: relative;
-    padding-top: 25px;
-    padding-bottom: 67.5%;
-    overflow: hidden;
+  position: relative;
+  padding-top: 25px;
+  padding-bottom: 67.5%;
+  overflow: hidden;
 
 }
 
 .flex-video.widescreen {
-    padding-top:0;
-    padding-bottom: 57.25%;
+  padding-top:0;
+  padding-bottom: 57.25%;
 }
 .flex-video.vimeo { padding-top:0; }
 
 .flex-video iframe,
 .flex-video object,
 .flex-video embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width:100%;
-    height:100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width:100%;
+  height:100%;
 }
 
 .article-details-ingress {
-    margin-bottom:20px;
-   color:blue;
+  margin-bottom:20px;
+  color:blue;
 }
 
 .article-latestnews {
-    font-size:18px;
-    font-weight:500;
+  font-size:18px;
+  font-weight:500;
 }
 
 .article-details-ingress > p {
-    .ingress;
-    font-size:20px;
+  .ingress;
+
+  font-size:20px;
 }
 
 .article-details-content {
-    font-size:13px;
-    font-weight:400;
-    margin:0;
-    p {
-        max-width: 80%;
-    }
+  font-size:13px;
+  font-weight:400;
+  margin:0;
+
+  p {
+    max-width: 80%;
+  }
 }
 
 @media only screen and (max-device-width: 800px), only screen and (device-width: 1024px) and (device-height: 600px), only screen and (width: 1280px) and (orientation: landscape), only screen and (device-width: 800px), only screen and (max-width: 767px) {
-    .flex-video { padding-top: 0; }
+  .flex-video { padding-top: 0; }
 }

--- a/assets/core/less/articlewidget.less
+++ b/assets/core/less/articlewidget.less
@@ -4,7 +4,7 @@ section#articles {
   }
 
   h3, h4 {
-    color:#666;
+    color: #666;
     text-align: left;
     word-wrap: break-word;
   }

--- a/assets/core/less/articlewidget.less
+++ b/assets/core/less/articlewidget.less
@@ -1,19 +1,19 @@
 section#articles {
-	img {
-        width: 100%;
+  img {
+    width: 100%;
+  }
+
+  h3, h4 {
+    color:#666;
+    text-align: left;
+    word-wrap: break-word;
+  }
+
+  #article-frontpage-normal {
+    @media (max-width: 991px) {
+      .article-widget-mobile-view-separator {
+        clear: both;
+      }
     }
-
-	h3, h4 {
-		color:#666;
-		text-align: left;
-		word-wrap: break-word;
-	}
-
-	#article-frontpage-normal {
-		@media (max-width: 991px) {
-			.article-widget-mobile-view-separator {
-				clear: both;
-			}
-		}
-	}
+  }
 }

--- a/assets/core/less/business.less
+++ b/assets/core/less/business.less
@@ -2,8 +2,8 @@
 -------------------------------------------------- */
 section#business {
   .sales-contact {
-    background:white;
-    color:@baby-blue;
+    background: white;
+    color: @baby-blue;
     font-size: 15px;
     line-height: normal;
     vertical-align: center;
@@ -15,47 +15,44 @@ section#business {
     }
   }
 
-
   .sale-box {
-    background:@baby-blue;
-    padding-top:10px;
-    color:white;
-    font-weight:300;
-    text-align:center;
-
-
+    background: @baby-blue;
+    padding-top: 10px;
+    color: white;
+    font-weight: 300;
+    text-align: center;
 
     .sale-heading {
-      font-size:20px;
-      font-weight:300;
+      font-size: 20px;
+      font-weight: 300;
       text-transform: uppercase;
       padding-bottom: 5px;
     }
 
     .sale-chevron {
-      font-size:18px;
+      font-size: 18px;
     }
   }
 
   .sale-content {
-    font-weight:300;
-    padding:10px;
+    font-weight: 300;
+    padding: 10px;
     margin-bottom: 15px;
-    font-size:15px;
-    background:@light-blue-soft;
+    font-size: 15px;
+    background: @light-blue-soft;
 
     .sale-points {
-      margin-top:10px;
-      padding-left:20px;
+      margin-top: 10px;
+      padding-left: 20px;
     }
 
     span {
-      color:@heading;
-      padding-right:5px;
+      color: @heading;
+      padding-right: 5px;
     }
 
     li {
-      padding-bottom:10px;
+      padding-bottom: 10px;
     }
   }
 

--- a/assets/core/less/business.less
+++ b/assets/core/less/business.less
@@ -1,66 +1,65 @@
 /* Business
 -------------------------------------------------- */
 section#business {
+  .sales-contact {
+    background:white;
+    color:@baby-blue;
+    font-size: 15px;
+    line-height: normal;
+    vertical-align: center;
+    padding-top: 10px;
+    padding-bottom: 10px;
 
-    .sales-contact {
-        background:white;
-        color:@baby-blue;
-        font-size: 15px;
-        line-height: normal;
-        vertical-align: center;
-        padding-top: 10px;
-        padding-bottom: 10px;
+    i.glyphicon {
+      color: @heading;
+    }
+  }
 
-        i.glyphicon {
-            color: @heading;
-        }
+
+  .sale-box {
+    background:@baby-blue;
+    padding-top:10px;
+    color:white;
+    font-weight:300;
+    text-align:center;
+
+
+
+    .sale-heading {
+      font-size:20px;
+      font-weight:300;
+      text-transform: uppercase;
+      padding-bottom: 5px;
     }
 
+    .sale-chevron {
+      font-size:18px;
+    }
+  }
 
-    .sale-box {
-        background:@baby-blue;
-        padding-top:10px;
-        color:white;
-        font-weight:300;
-        text-align:center;
+  .sale-content {
+    font-weight:300;
+    padding:10px;
+    margin-bottom: 15px;
+    font-size:15px;
+    background:@light-blue-soft;
 
-
-
-        .sale-heading {
-            font-size:20px;
-            font-weight:300;
-            text-transform: uppercase;
-            padding-bottom: 5px;
-        }
-
-        .sale-chevron {
-            font-size:18px;
-        }
+    .sale-points {
+      margin-top:10px;
+      padding-left:20px;
     }
 
-    .sale-content {
-        font-weight:300;
-        padding:10px;
-        margin-bottom: 15px;
-        font-size:15px;
-        background:@light-blue-soft;
-
-        .sale-points {
-            margin-top:10px;
-            padding-left:20px;
-        }
-
-        span {
-            color:@heading;
-            padding-right:5px;
-        }
-
-        li {
-            padding-bottom:10px;
-        }
+    span {
+      color:@heading;
+      padding-right:5px;
     }
 
-    /*.business-ingress {
+    li {
+      padding-bottom:10px;
+    }
+  }
+
+  /*.business-ingress {
         margin-bottom:20px;
 
         >p {
@@ -68,7 +67,7 @@ section#business {
         }
     }*/
 
-    /*.contact-buttons {
+  /*.contact-buttons {
         margin:0 auto;
     }
 

--- a/assets/core/less/company.less
+++ b/assets/core/less/company.less
@@ -2,30 +2,30 @@
 ----------------------------- */
 
 section#company {
-    .contactinfo {
-        margin-top: 15px;
-        background: @baby-blue-medium;
-        color: white;
-        padding-left: 15px;
-        padding-right: 15px;
-        padding-top: 15px;
-        padding-bottom: 10px;
-        box-sizing: border-box;
+  .contactinfo {
+    margin-top: 15px;
+    background: @baby-blue-medium;
+    color: white;
+    padding-left: 15px;
+    padding-right: 15px;
+    padding-top: 15px;
+    padding-bottom: 10px;
+    box-sizing: border-box;
 
-        p {
-            font-weight: 300;
-            font-size: 14px;
-            color: white;
-            display: inline;
-        }
-
-        i, a {
-            color: white;
-            margin-bottom: 15px;
-        }
-
-        i {
-            margin-right:10px;
-        }
+    p {
+      font-weight: 300;
+      font-size: 14px;
+      color: white;
+      display: inline;
     }
+
+    i, a {
+      color: white;
+      margin-bottom: 15px;
+    }
+
+    i {
+      margin-right:10px;
+    }
+  }
 }

--- a/assets/core/less/company.less
+++ b/assets/core/less/company.less
@@ -25,7 +25,7 @@ section#company {
     }
 
     i {
-      margin-right:10px;
+      margin-right: 10px;
     }
   }
 }

--- a/assets/core/less/core.less
+++ b/assets/core/less/core.less
@@ -21,21 +21,21 @@
 @nav-height: auto;
 
 html {
-    overflow-x: hidden;
-    background: #333;
+  overflow-x: hidden;
+  background: #333;
 }
 
 body {
-    background:#FFF;
-    color:#555;
-    font:13px "Open Sans",arial,sans-serif;
-    font-weight:400;
-    margin:0;
-    overflow: hidden;
+  background:#fff;
+  color:#555;
+  font:13px "Open Sans",arial,sans-serif;
+  font-weight:400;
+  margin:0;
+  overflow: hidden;
 }
 
 @media all and (max-width: 980px) {
-    /*
+  /*
     body {
         margin-top: 0px;
         padding-top: 0px;
@@ -52,143 +52,144 @@ body {
 
 /* Desktop */
 @media all and (min-width: @media-desktop-min) {
-    .container-fluid {
-        margin:0 auto;
-        width:1200px;
-    }
+  .container-fluid {
+    margin:0 auto;
+    width:1200px;
+  }
 }
 
 /* Mobil e.l. */
 @media all and (max-width: @media-desktop-min) {
-    .container-fluid {
-        margin: 0px 20px;
-        /*background: green;*/
-    }
+  .container-fluid {
+    margin: 0 20px;
+
+    /*background: green;*/
+  }
 }
 
 span.dates {
-    color:#2fa3d3;
-    float: right;
+  color:#2fa3d3;
+  float: right;
 }
 
 /* Mobil e.l. */
 @media all and (max-width: 768px) {
-    #articles {
-        .row-fluid {
-            .span2 {
-                display: inline-block;
-                vertical-align: top;
-                width: 100%;
-                text-align: center;
-            }
-        }
+  #articles {
+    .row-fluid {
+      .span2 {
+        display: inline-block;
+        vertical-align: top;
+        width: 100%;
+        text-align: center;
+      }
     }
+  }
 }
 
 /* Globals
 -------------------------------------------------- */
 section {
-    margin-bottom:20px;
+  margin-bottom:20px;
 }
 
 .messages {
-    padding:0;
+  padding:0;
 }
 
 .alert {
-    margin-top:10px;
+  margin-top:10px;
 }
 
 .grayed {
-    background:@grey-background;
+  background:@grey-background;
 }
 
 .dark-grayed {
-    background:#666;
+  background:#666;
 }
 
 .footer {
-    padding:20px;
-    color:#fbfbfb;
+  padding:20px;
+  color:#fbfbfb;
 }
 
 .ingress {
-    font-size:16px;
-    color:#777;
-    font-weight:300;
+  font-size:16px;
+  color:#777;
+  font-weight:300;
 }
 
 h1{
-    text-transform: uppercase;
-    font-weight:600;
-    color:@heading;
-    font-size:24px;
+  text-transform: uppercase;
+  font-weight:600;
+  color:@heading;
+  font-size:24px;
 }
 
 h2{
-    font-weight:600;
-    color:@heading;
-    font-size:24px;
+  font-weight:600;
+  color:@heading;
+  font-size:24px;
 }
 
 h3 {
-    font-weight:400;
+  font-weight:400;
 }
 
 h4 {
-    text-align:left;
-    font-weight:400;
-    font-size:18px;
+  text-align:left;
+  font-weight:400;
+  font-size:18px;
 }
 
 p {
-    color: #666;
-    line-height: 1.625em;
+  color: #666;
+  line-height: 1.625em;
 }
 
 a,
 a:active,
 a:focus {
-    outline: none;
+  outline: none;
 }
 
 .centered {
-    text-align: center;
+  text-align: center;
 }
 
 .row-space {
-    margin-bottom:30px;
+  margin-bottom:30px;
 }
 
 .row-space-sm {
-    margin-bottom:20px;
+  margin-bottom:20px;
 }
 
 .row-space-top {
-    margin-top:30px;
+  margin-top:30px;
 }
 
 .row-space-top-sm {
-    margin-top:20px;
+  margin-top:20px;
 }
 
 .archive-link {
-    text-transform:uppercase;
-    font-size:18px;
-    text-align:right;
-    margin-top:21px;
+  text-transform:uppercase;
+  font-size:18px;
+  text-align:right;
+  margin-top:21px;
 }
 
 ul li {
-    padding: 2px 0;
+  padding: 2px 0;
 }
 
 #about-tabs li,
 .subnavbar li,
 .navbar li {
-    padding: 0;
+  padding: 0;
 }
 
 .popover {
-    z-index: 9;
+  z-index: 9;
 }

--- a/assets/core/less/core.less
+++ b/assets/core/less/core.less
@@ -26,11 +26,11 @@ html {
 }
 
 body {
-  background:#fff;
-  color:#555;
-  font:13px "Open Sans",arial,sans-serif;
-  font-weight:400;
-  margin:0;
+  background: #fff;
+  color: #555;
+  font: 13px "Open Sans", arial, sans-serif;
+  font-weight: 400;
+  margin: 0;
   overflow: hidden;
 }
 
@@ -53,8 +53,8 @@ body {
 /* Desktop */
 @media all and (min-width: @media-desktop-min) {
   .container-fluid {
-    margin:0 auto;
-    width:1200px;
+    margin: 0 auto;
+    width: 1200px;
   }
 }
 
@@ -68,7 +68,7 @@ body {
 }
 
 span.dates {
-  color:#2fa3d3;
+  color: #2fa3d3;
   float: right;
 }
 
@@ -89,57 +89,57 @@ span.dates {
 /* Globals
 -------------------------------------------------- */
 section {
-  margin-bottom:20px;
+  margin-bottom: 20px;
 }
 
 .messages {
-  padding:0;
+  padding: 0;
 }
 
 .alert {
-  margin-top:10px;
+  margin-top: 10px;
 }
 
 .grayed {
-  background:@grey-background;
+  background: @grey-background;
 }
 
 .dark-grayed {
-  background:#666;
+  background: #666;
 }
 
 .footer {
-  padding:20px;
-  color:#fbfbfb;
+  padding: 20px;
+  color: #fbfbfb;
 }
 
 .ingress {
-  font-size:16px;
-  color:#777;
-  font-weight:300;
+  font-size: 16px;
+  color: #777;
+  font-weight: 300;
 }
 
-h1{
+h1 {
   text-transform: uppercase;
-  font-weight:600;
-  color:@heading;
-  font-size:24px;
+  font-weight: 600;
+  color: @heading;
+  font-size: 24px;
 }
 
-h2{
-  font-weight:600;
-  color:@heading;
-  font-size:24px;
+h2 {
+  font-weight: 600;
+  color: @heading;
+  font-size: 24px;
 }
 
 h3 {
-  font-weight:400;
+  font-weight: 400;
 }
 
 h4 {
-  text-align:left;
-  font-weight:400;
-  font-size:18px;
+  text-align: left;
+  font-weight: 400;
+  font-size: 18px;
 }
 
 p {
@@ -158,35 +158,33 @@ a:focus {
 }
 
 .row-space {
-  margin-bottom:30px;
+  margin-bottom: 30px;
 }
 
 .row-space-sm {
-  margin-bottom:20px;
+  margin-bottom: 20px;
 }
 
 .row-space-top {
-  margin-top:30px;
+  margin-top: 30px;
 }
 
 .row-space-top-sm {
-  margin-top:20px;
+  margin-top: 20px;
 }
 
 .archive-link {
-  text-transform:uppercase;
-  font-size:18px;
-  text-align:right;
-  margin-top:21px;
+  text-transform: uppercase;
+  font-size: 18px;
+  text-align: right;
+  margin-top: 21px;
 }
 
 ul li {
   padding: 2px 0;
 }
 
-#about-tabs li,
-.subnavbar li,
-.navbar li {
+.navbar li, .subnavbar li, #about-tabs li {
   padding: 0;
 }
 

--- a/assets/core/less/errorform.less
+++ b/assets/core/less/errorform.less
@@ -1,4 +1,4 @@
 
 .error-form {
-    margin: 15px 0px;
+  margin: 15px 0;
 }

--- a/assets/core/less/errorform.less
+++ b/assets/core/less/errorform.less
@@ -1,4 +1,3 @@
-
 .error-form {
   margin: 15px 0;
 }

--- a/assets/core/less/eventwidget.less
+++ b/assets/core/less/eventwidget.less
@@ -167,18 +167,17 @@ section#events {
       @media (min-width: 992px) {
         width: 455px;
 
-        // Remove border-bottom from last row
-        &:nth-child(odd):nth-last-child(2),
-        &:last-child {
-          border: none;
-        }
-
         &:nth-child(odd) {
           float: left;
         }
 
         &:nth-child(even) {
           float: right;
+        }
+
+        // Remove border-bottom from last row
+        &:last-child, &:nth-child(odd):nth-last-child(2) {
+          border: none;
         }
       }
 

--- a/assets/core/less/eventwidget.less
+++ b/assets/core/less/eventwidget.less
@@ -5,74 +5,74 @@ section#events {
 
   .hero {
     .hero-time {
-      font-size:18px;
+      font-size: 18px;
     }
 
     .hero-title p {
-      color:#666;
-      font-weight:400;
-      font-size:18px;
-      margin-bottom:10px;
+      color: #666;
+      font-weight: 400;
+      font-size: 18px;
+      margin-bottom: 10px;
       word-wrap: break-word;
     }
 
     .hero-ingress p {
-      font-weight:400;
+      font-weight: 400;
     }
 
     .hero-date {
-      background:@baby-blue;
-      display:block;
-      color:#fff;
-      padding:2px;
-      text-align:center;
-      font-weight:300;
-      font-size:18px;
+      background: @baby-blue;
+      display: block;
+      color: #fff;
+      padding: 2px;
+      text-align: center;
+      font-weight: 300;
+      font-size: 18px;
     }
   }
 
   /* Old stuff for refrence below */
 
   .event-title {
-    font-size:17px;
-    margin-bottom:5px;
-    color:#666;
+    font-size: 17px;
+    margin-bottom: 5px;
+    color: #666;
     margin-top: -7px;
   }
 
   .event-ingress {
-    font-size:12px;
-    color:#777;
-    font-weight:300;
+    font-size: 12px;
+    color: #777;
+    font-weight: 300;
   }
 
   .event-calendar-box {
-    padding:3px 3px 3px 3px;
-    text-align:center;
-    font-weight:400;
-    font-size:19px;
-    width: 6%
+    padding: 3px 3px 3px 3px;
+    text-align: center;
+    font-weight: 400;
+    font-size: 19px;
+    width: 6%;
   }
 
   .event-arrkom {
     .event-calendar-box();
 
-    background:@arrkom-color;
-    color:@arrkom-color;
+    background: @arrkom-color;
+    color: @arrkom-color;
   }
 
   .event-fagkom {
     .event-calendar-box();
 
-    background:@fagkom-color;
-    color:@fagkom-color;
+    background: @fagkom-color;
+    color: @fagkom-color;
   }
 
   .event-bedkom {
     .event-calendar-box();
 
-    background:@bedkom-color;
-    color:@bedkom-color;
+    background: @bedkom-color;
+    color: @bedkom-color;
   }
 
   /* Gets overridden below if needed */
@@ -94,15 +94,15 @@ section#events {
 
   .event-calendar-date {
     display: block;
-    background:#fff;
+    background: #fff;
     padding: 3px;
   }
 
   .event-calendar-month {
-    color:#fff;
-    font-size:13px;
-    font-weight:400;
-    text-transform:uppercase;
+    color: #fff;
+    font-size: 13px;
+    font-weight: 400;
+    text-transform: uppercase;
   }
 
   .event-filters {
@@ -196,9 +196,7 @@ section#events {
         color: #666;
       }
     }
-
   }
-
 
   @media (max-width: 991px) {
     ul.event-list:nth-child(1) {

--- a/assets/core/less/eventwidget.less
+++ b/assets/core/less/eventwidget.less
@@ -1,213 +1,216 @@
 section#events {
+  #eventimage {
+    margin-bottom: 15px;
+  }
 
-    #eventimage {
-	margin-bottom: 15px;
+  .hero {
+    .hero-time {
+      font-size:18px;
     }
 
-    .hero {
+    .hero-title p {
+      color:#666;
+      font-weight:400;
+      font-size:18px;
+      margin-bottom:10px;
+      word-wrap: break-word;
+    }
 
-        .hero-time {
-            font-size:18px;
+    .hero-ingress p {
+      font-weight:400;
+    }
+
+    .hero-date {
+      background:@baby-blue;
+      display:block;
+      color:#fff;
+      padding:2px;
+      text-align:center;
+      font-weight:300;
+      font-size:18px;
+    }
+  }
+
+  /* Old stuff for refrence below */
+
+  .event-title {
+    font-size:17px;
+    margin-bottom:5px;
+    color:#666;
+    margin-top: -7px;
+  }
+
+  .event-ingress {
+    font-size:12px;
+    color:#777;
+    font-weight:300;
+  }
+
+  .event-calendar-box {
+    padding:3px 3px 3px 3px;
+    text-align:center;
+    font-weight:400;
+    font-size:19px;
+    width: 6%
+  }
+
+  .event-arrkom {
+    .event-calendar-box();
+
+    background:@arrkom-color;
+    color:@arrkom-color;
+  }
+
+  .event-fagkom {
+    .event-calendar-box();
+
+    background:@fagkom-color;
+    color:@fagkom-color;
+  }
+
+  .event-bedkom {
+    .event-calendar-box();
+
+    background:@bedkom-color;
+    color:@bedkom-color;
+  }
+
+  /* Gets overridden below if needed */
+  [class*='event-type-'] {
+    .event-arrkom;
+  }
+
+  .event-type-1 {
+    .event-arrkom;
+  }
+
+  .event-type-2 {
+    .event-bedkom;
+  }
+
+  .event-type-3 {
+    .event-fagkom;
+  }
+
+  .event-calendar-date {
+    display: block;
+    background:#fff;
+    padding: 3px;
+  }
+
+  .event-calendar-month {
+    color:#fff;
+    font-size:13px;
+    font-weight:400;
+    text-transform:uppercase;
+  }
+
+  .event-filters {
+    padding-bottom: 20px;
+    float: right;
+    margin-top: -10px;
+  }
+
+  .event-filter-button {
+    background-color: #027bbb;
+    color: #fff;
+    padding: 4px 8px;
+    font-weight: 600;
+    border-color: #0f88c7;
+    border-radius: 0;
+  }
+
+  .event-filter-button:hover {
+    background: #2291cc;
+    border-color: #319fda;
+  }
+
+  .event-kurs {
+    background-color: @fagkom-color;
+    color: #fff;
+  }
+
+  .event-sosialt {
+    background-color: @arrkom-color;
+    color: #fff;
+  }
+
+  .event-bedriftspresentasjon {
+    background-color: @baby-blue;
+    color: #fff;
+  }
+
+  .event-annet {
+    background-color: @heading;
+    color: #fff;
+  }
+
+  .hidden-event-button {
+    background-color: #fff;
+    color: #000;
+  }
+
+  .hidden-event-button:hover {
+    background-color: #f2f2f2;
+  }
+
+  ul.event-list {
+    list-style: none;
+    margin-top: 8px;
+    padding: 0 15px;
+
+    li {
+      padding: 10px 0;
+      border-bottom: 1px solid #e0e0e0;
+      font-size: 14px;
+
+      @media (min-width: 992px) {
+        width: 455px;
+
+        // Remove border-bottom from last row
+        &:nth-child(odd):nth-last-child(2),
+        &:last-child {
+          border: none;
         }
 
-        .hero-title p {
-            color:#666;
-            font-weight:400;
-            font-size:18px;
-            margin-bottom:10px;
-            word-wrap: break-word;
+        &:nth-child(odd) {
+          float: left;
         }
 
-        .hero-ingress p {
-            font-weight:400;
+        &:nth-child(even) {
+          float: right;
         }
+      }
 
-        .hero-date {
-            background:@baby-blue;
-            display:block;
-            color:#FFF;
-            padding:2px;
-            text-align:center;
-            font-weight:300;
-            font-size:18px;
-        }
-    }
+      @media (min-width: 1200px) {
+        width: 555px;
+      }
 
-    /* Old stuff for refrence below */
-
-    .event-title {
-        font-size:17px;
-        margin-bottom:5px;
-        color:#666;
-        margin-top: -7px;
-    }
-
-    .event-ingress {
-        font-size:12px;
-        color:#777;
-        font-weight:300;
-    }
-
-    .event-calendar-box {
-        padding:3px 3px 3px 3px;
-        text-align:center;
-        font-weight:400;
-        font-size:19px;
-        width: 6%
-    }
-
-    .event-arrkom {
-        .event-calendar-box();
-        background:@arrkom-color;
-        color:@arrkom-color;
-    }
-
-    .event-fagkom {
-        .event-calendar-box();
-        background:@fagkom-color;
-        color:@fagkom-color;
-    }
-
-    .event-bedkom {
-        .event-calendar-box();
-        background:@bedkom-color;
-        color:@bedkom-color;
-    }
-
-    /* Gets overridden below if needed */
-    [class*='event-type-'] {
-        .event-arrkom;
-    }
-
-    .event-type-1 {
-        .event-arrkom;
-    }
-
-    .event-type-2 {
-        .event-bedkom;
-    }
-
-    .event-type-3 {
-        .event-fagkom;
-    }
-
-    .event-calendar-date {
-        display: block;
-        background:#FFF;
-        padding: 3px;
-    }
-
-    .event-calendar-month {
-        color:#FFF;
-        font-size:13px;
-        font-weight:400;
-        text-transform:uppercase;
-    }
-
-    .event-filters {
-        padding-bottom: 20px;
+      span {
         float: right;
-        margin-top: -10px;
+        color: #ccc;
+        color: #428bca;
+      }
+
+      a {
+        color: #666;
+      }
     }
 
-    .event-filter-button {
-      background-color: #027bbb;
-      color: #FFF;
-      padding: 4px 8px;
-      font-weight: 600;
-      border-color: #0f88c7;
-      border-radius: 0;
+  }
+
+
+  @media (max-width: 991px) {
+    ul.event-list:nth-child(1) {
+      margin-bottom: 0;
+
+      li:last-child {
+        border-bottom: 1px solid #e0e0e0;
+      }
     }
 
-    .event-filter-button:hover {
-      background: #2291cc;
-      border-color: #319fda;
+    ul.event-list:nth-child(2) {
+      margin-top: 0;
     }
-
-    .event-kurs {
-        background-color: @fagkom-color;
-        color: #FFF;
-    }
-
-    .event-sosialt {
-        background-color: @arrkom-color;
-        color: #FFF;
-    }
-
-    .event-bedriftspresentasjon {
-        background-color: @baby-blue;
-        color: #FFF;
-    }
-
-    .event-annet {
-        background-color: @heading;
-        color: #FFF;
-    }
-
-    .hidden-event-button {
-        background-color: #FFF;
-        color: #000;
-    }
-
-    .hidden-event-button:hover {
-      background-color: #f2f2f2;
-    }
-
-    ul.event-list {
-        list-style: none;
-        margin-top: 8px;
-        padding: 0 15px;
-
-        li {
-            padding: 10px 0;
-            border-bottom: 1px solid #e0e0e0;
-            font-size: 14px;
-
-            @media (min-width: 992px) {
-                width: 455px;
-
-                // Remove border-bottom from last row
-                &:nth-child(odd):nth-last-child(2),
-                &:last-child {
-                    border: none;
-                }
-
-                &:nth-child(odd) {
-                    float: left;
-                }
-                &:nth-child(even) {
-                    float: right;
-                }
-            }
-
-            @media (min-width: 1200px) {
-                width: 555px;
-            }
-
-            span {
-                float: right;
-                color: #ccc;
-                color: #428bca;
-            }
-
-            a {
-                color: #666;
-            }
-        }
-
-    }
-
-
-    @media (max-width: 991px) {
-        ul.event-list:nth-child(1) {
-            margin-bottom: 0;
-
-            li:last-child {
-                border-bottom: 1px solid #e0e0e0;
-            }
-        }
-        ul.event-list:nth-child(2) {
-            margin-top: 0;
-        }
-    }
+  }
 }

--- a/assets/core/less/footer.less
+++ b/assets/core/less/footer.less
@@ -29,16 +29,6 @@
       color: #666;
     }
   }
-	
-  #footer-map {
-    width: 100%;
-    height: 300px;
-  }
-
-  #footer-map .gmnoprint,
-  #footer-map div a img {
-    display: none;
-  }
 
   .socialIcon-link {
     margin-right: 18px;
@@ -50,5 +40,15 @@
     &:hover {
       opacity: 0.7;
     }
+  }
+
+  #footer-map {
+    width: 100%;
+    height: 300px;
+  }
+
+  #footer-map .gmnoprint,
+  #footer-map div a img {
+    display: none;
   }
 }

--- a/assets/core/less/footer.less
+++ b/assets/core/less/footer.less
@@ -1,54 +1,54 @@
 #footer {
-	margin-bottom: 0;
-	background: #333;
-	padding: 30px;
-	margin-top: 100px;
+  margin-bottom: 0;
+  background: #333;
+  padding: 30px;
+  margin-top: 100px;
 
-	.contact-info {
-		.contact-item {
-			font-weight: 300;
-			font-size: 14px;
-			margin-bottom: 5px;
-			color: #BBB;
+  .contact-info {
+    .contact-item {
+      font-weight: 300;
+      font-size: 14px;
+      margin-bottom: 5px;
+      color: #bbb;
 
-			span {
-				color: #666;
-				margin-right: 10px;
-			}
-		}
-	}
+      span {
+        color: #666;
+        margin-right: 10px;
+      }
+    }
+  }
 
-	.address {
-		font-weight: 300;
-		font-size: 14px;
-		margin-top: 30px;
-		color: #BBB;
+  .address {
+    font-weight: 300;
+    font-size: 14px;
+    margin-top: 30px;
+    color: #bbb;
     margin-bottom: 30px;
 
-		.address-heading {
-			color: #666;
-		}
-	}
+    .address-heading {
+      color: #666;
+    }
+  }
 	
-	#footer-map {
-	   width: 100%;
-	   height: 300px;
-	}
+  #footer-map {
+    width: 100%;
+    height: 300px;
+  }
 
-	#footer-map .gmnoprint,
-	#footer-map div a img {
-		display: none;
-	}
+  #footer-map .gmnoprint,
+  #footer-map div a img {
+    display: none;
+  }
 
-	.socialIcon-link {
-		margin-right: 18px;
+  .socialIcon-link {
+    margin-right: 18px;
 
-		img {
-			width: 32px;
-		}
+    img {
+      width: 32px;
+    }
 
-		&:hover {
-			opacity: .7;
-		}
-	}
+    &:hover {
+      opacity: 0.7;
+    }
+  }
 }

--- a/assets/core/less/navbar.less
+++ b/assets/core/less/navbar.less
@@ -76,10 +76,6 @@
   border-top: 5px solid rgba(255, 255, 255, 1);
 }
 
-.mn-nav li:hover a {
-  text-decoration: none;
-}
-
 .mn-nav li a {
   display: block;
   line-height: @navbar-height;
@@ -87,6 +83,10 @@
   padding: 0 13px;
   text-transform: uppercase;
   color: #fff;
+}
+
+.mn-nav li:hover a {
+  text-decoration: none;
 }
 
 .mn-nav li:first-child img {

--- a/assets/core/less/navbar.less
+++ b/assets/core/less/navbar.less
@@ -8,13 +8,13 @@
 
 @navbar-height:                    57px;
 
-@navbar-default-color:             #FFF;
+@navbar-default-color:             #fff;
 @navbar-default-bg:                #004b80;
 
-@navbar-default-link-color:                #FFF;
-@navbar-default-link-hover-color:          #FFF;
+@navbar-default-link-color:                #fff;
+@navbar-default-link-hover-color:          #fff;
 @navbar-default-link-hover-bg:             rgba(255,255,255,0.1);
-@navbar-default-link-active-color:         #FFF;
+@navbar-default-link-active-color:         #fff;
 @navbar-default-link-active-bg:            transparent;
 
 @navbar-default-brand-hover-color:         darken(@navbar-default-link-color, 10%);
@@ -29,234 +29,248 @@
 @state-danger-border:            darken(spin(@state-danger-bg, -10), 3%);
 
 #mainnav {
-    position: fixed;
-    width: 100%;
-    background: #004b80;
-    height: @navbar-height;
-    z-index: 10;
+  position: fixed;
+  width: 100%;
+  background: #004b80;
+  height: @navbar-height;
+  z-index: 10;
 }
 #mainnav .container     { position: relative; }
 #mainnav .glyphicon     { top: 0; }
 #mainnav .dropdown-menu { margin: 0 0 0 -1px; border-top: none; }
 #mainnav .dropdown-menu .divider { padding: 0; }
 
-    #mainnav .container > ul {
-        list-style: none;
-        padding: 0;
-        display: inline-block;
-        vertical-align: middle;
-        margin: 0;
-        padding: 0;
-    }
-.mn-nav {
-    -webkit-transform: translate3d(0,0,0);
-}
-.mn-nav li {
-    line-height: @navbar-height;
-    display: inline-block;
-    border-top: 5px solid rgba(255, 255, 255, 0.1);
-    margin: 0;
-    margin-right: -3px; /* removes space between inline-block elements */
+#mainnav .container > ul {
+  list-style: none;
+  padding: 0;
+  display: inline-block;
+  vertical-align: middle;
+  margin: 0;
+  padding: 0;
 }
 
-    .mn-nav li > .online-logo-link {
-        padding:0 13px 0 0;
-    }
-    .mn-nav li:hover {
-        background: rgba(255, 255, 255, .1);
-    }
-    .mn-nav li.active {
-        border-top: 5px solid rgba(255, 255, 255, 1);
-    }
-    .mn-nav li:hover a {
-        text-decoration: none;
-    }
-    .mn-nav li a {
-        display: block;
-        line-height: @navbar-height;
-        margin-top: -7px;
-        padding: 0 13px;
-        text-transform: uppercase;
-        color: #fff;
-    }
-    .mn-nav li:first-child img {
-        margin-top: -5px;
-        width: 140px;
-        height: 35px;
-    }
-    .mn-nav li:first-child,
-    .mn-nav li:first-child:hover,
-    .mn-nav li:first-child.active {
-        border: none;
-        background: none;
-    }
+.mn-nav {
+  -webkit-transform: translate3d(0,0,0);
+}
+
+.mn-nav li {
+  line-height: @navbar-height;
+  display: inline-block;
+  border-top: 5px solid rgba(255, 255, 255, 0.1);
+  margin: 0;
+  margin-right: -3px; /* removes space between inline-block elements */
+}
+
+.mn-nav li > .online-logo-link {
+  padding:0 13px 0 0;
+}
+
+.mn-nav li:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.mn-nav li.active {
+  border-top: 5px solid rgba(255, 255, 255, 1);
+}
+
+.mn-nav li:hover a {
+  text-decoration: none;
+}
+
+.mn-nav li a {
+  display: block;
+  line-height: @navbar-height;
+  margin-top: -7px;
+  padding: 0 13px;
+  text-transform: uppercase;
+  color: #fff;
+}
+
+.mn-nav li:first-child img {
+  margin-top: -5px;
+  width: 140px;
+  height: 35px;
+}
+
+.mn-nav li:first-child,
+.mn-nav li:first-child:hover,
+.mn-nav li:first-child.active {
+  border: none;
+  background: none;
+}
 
 svg, rect {
-    -webkit-transition: all 0.3s;
-       -moz-transition: all 0.3s;
-            transition: all 0.3s;
+  -webkit-transition: all 0.3s;
+  -moz-transition: all 0.3s;
+  transition: all 0.3s;
+  -webkit-transition-timing-function: ease-in-out;
+  -moz-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
 
-    -webkit-transition-timing-function: ease-in-out;
-       -moz-transition-timing-function: ease-in-out;
-            transition-timing-function: ease-in-out;
-}
 .mn-svg {
-    position: absolute;
-    top: 0;
-    left: 0;
-    fill: #fff;
+  position: absolute;
+  top: 0;
+  left: 0;
+  fill: #fff;
 }
-    .mn-svg-rect-top {
-        -webkit-transform: translate3d(0, -8px, 0);
-           -moz-transform: translate3d(0, -8px, 0);
-                transform: translate3d(0, -8px, 0);
-    }
-    .mn-svg-rect-bottom {
-        -webkit-transform: translate3d(0, 8px, 0);
-           -moz-transform: translate3d(0, 8px, 0);
-                transform: translate3d(0, 8px, 0);
-    }
+
+.mn-svg-rect-top {
+  -webkit-transform: translate3d(0, -8px, 0);
+  -moz-transform: translate3d(0, -8px, 0);
+  transform: translate3d(0, -8px, 0);
+}
+
+.mn-svg-rect-bottom {
+  -webkit-transform: translate3d(0, 8px, 0);
+  -moz-transform: translate3d(0, 8px, 0);
+  transform: translate3d(0, 8px, 0);
+}
 
 .transform-button {
-    -webkit-transform: translate3d(0, 0, 0);
-       -moz-transform: translate3d(0, 0, 0);
-            transform: translate3d(0, 0, 0);
+  -webkit-transform: translate3d(0, 0, 0);
+  -moz-transform: translate3d(0, 0, 0);
+  transform: translate3d(0, 0, 0);
 }
 
 .rotate-button {
-    -webkit-transform: rotate3d(0, 0, 1, 135deg);
-       -moz-transform: rotate3d(0, 0, 1, 135deg);
-            transform: rotate3d(0, 0, 1, 135deg);
+  -webkit-transform: rotate3d(0, 0, 1, 135deg);
+  -moz-transform: rotate3d(0, 0, 1, 135deg);
+  transform: rotate3d(0, 0, 1, 135deg);
 }
+
 .rotate-button-ccw {
-    -webkit-transform: rotate3d(0, 0, 1, -135deg);
-       -moz-transform: rotate3d(0, 0, 1, -135deg);
-            transform: rotate3d(0, 0, 1, -135deg);
+  -webkit-transform: rotate3d(0, 0, 1, -135deg);
+  -moz-transform: rotate3d(0, 0, 1, -135deg);
+  transform: rotate3d(0, 0, 1, -135deg);
 }
 
 #main-sponsor {
-    position: absolute;
-    top: 3px;
-    right: 20px;
-    text-transform: uppercase;
-    color: #fff;
+  position: absolute;
+  top: 3px;
+  right: 20px;
+  text-transform: uppercase;
+  color: #fff;
 }
-    .ms-span {
-        display: block;
-        color: #fff;
-        font-size: 9px;
-        opacity: 0.3;
-        padding: 3px 0 0 13px;
-        position: relative;
-        right: -5px;
-    }
-    .ms-img {
-        position: relative;
-        top: 0;
-        left: 18px;
 
-        width: 128px;
-        margin: 5px 0 0 0;
-    }
+.ms-span {
+  display: block;
+  color: #fff;
+  font-size: 9px;
+  opacity: 0.3;
+  padding: 3px 0 0 13px;
+  position: relative;
+  right: -5px;
+}
+
+.ms-img {
+  position: relative;
+  top: 0;
+  left: 18px;
+  width: 128px;
+  margin: 5px 0 0 0;
+}
 
 /* mn-collapse */
 #mainnav ul.mn-collapse {
-    display: none;
-    position: absolute;
-    top: 0;
-    left: 0;
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
 }
-    .mn-collapse button {
-        position: relative;
-        height: @navbar-height;
-        width: @navbar-height;
-        background: none;
-        border: none;
-        margin-top: -2px;
-    }
-    .mn-collapse li {
-        display: inline-block;
-        vertical-align: middle;
-    }
+
+.mn-collapse button {
+  position: relative;
+  height: @navbar-height;
+  width: @navbar-height;
+  background: none;
+  border: none;
+  margin-top: -2px;
+}
+
+.mn-collapse li {
+  display: inline-block;
+  vertical-align: middle;
+}
 
 .mn-user-nav {
-    position: absolute;
-    top: 0;
-    right: 180px;
+  position: absolute;
+  top: 0;
+  right: 180px;
 }
 
 .mn-user-nav li {
-    display: inline;
+  display: inline;
 }
 
 .mn-user-nav > li.username {
-    display: inline-block;
-    color: #fff;
-    background: rgba(255, 255, 255, 0.1);
-    top: 0;
-    line-height: @navbar-height;
-    height: @navbar-height;
-    padding-left: 20px;
-    padding-right: 20px;
-    margin-right: -3px;
+  display: inline-block;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+  top: 0;
+  line-height: @navbar-height;
+  height: @navbar-height;
+  padding-left: 20px;
+  padding-right: 20px;
+  margin-right: -3px;
 }
 
 .username_menu{
-    padding-left: 10px;
-    color: #fff;
+  padding-left: 10px;
+  color: #fff;
 }
 
 .mn-user-nav > li > a {
-    color: #fff;
-    margin: 0;
-    border-radius: 0;
-    border: 0;
-    line-height: @navbar-height;
-    background: rgba(255, 255, 255, 0.1);
-    padding: 0 20px;
-    text-decoration: none;
+  color: #fff;
+  margin: 0;
+  border-radius: 0;
+  border: 0;
+  line-height: @navbar-height;
+  background: rgba(255, 255, 255, 0.1);
+  padding: 0 20px;
+  text-decoration: none;
 }
+
 .mn-user-nav > li > a:hover {
-    text-decoration: none;
-    background: rgba(255, 255, 255, 0.2);
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.2);
 }
 
 
 .subnavbar {
-    position: fixed;
-    top: @navbar-height;
-    left: 0;
-    z-index: 5;
+  position: fixed;
+  top: @navbar-height;
+  left: 0;
+  z-index: 5;
+  width: 100%;
+  background: rgba(160, 160, 160, 1);
 
-    width: 100%;
-    background: rgba(160, 160, 160, 1);
+  ul {
+    padding: 0;
+    margin: 0 -15px;
+  }
 
-    ul {
-        padding: 0;
-        margin: 0 -15px;
+  a {
+    color: #fff;
+    display: block;
+    padding: 0 15px;
+    text-decoration: none;
+    line-height: 40px;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.1);
     }
+  }
 
-    a {
-        color: #fff;
-        display: block;
-        padding: 0 15px;
-        text-decoration: none;
-        line-height: 40px;
+  li {
+    font-size: 12px;
+    display: inline-block;
+    margin-right: -3px;
 
-        &:hover {
-            background: rgba(255, 255, 255, 0.1);
-        }
+    &.active {
+      background: rgba(255, 255, 255, 0.2);
     }
-
-    li {
-        font-size: 12px;
-        display: inline-block;
-        margin-right: -3px;
-
-        &.active {
-            background: rgba(255, 255, 255, 0.2);
-        }
-    }
+  }
 }
 
 /* Controls gap between navbar and content */
@@ -268,170 +282,182 @@ svg, rect {
 
 .subnavbar   + div.messages .alert,
 #mainnav     + div.messages .alert {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 
 
 @media (max-width: 991px) {
-    .mn-user-nav {
-        right: 150px;
-    }
+  .mn-user-nav {
+    right: 150px;
+  }
 
-    .mn-user-nav > li > a {
-        padding: 0 15px;
-    }
+  .mn-user-nav > li > a {
+    padding: 0 15px;
+  }
 }
 
 @media (max-width: 767px) {
-    #mainnav .dropdown-menu {
-        -webkit-transform: translateX(-50%);
-                transform: translateX(-50%);
-    }
-    #mainnav ul.mn-nav {
-        display: block;
-        position: absolute;
-        top: @navbar-height;
-        left: 0;
-        width: 100%;
-        background: rgba(25, 25, 25, 1);
+  #mainnav .dropdown-menu {
+    -webkit-transform: translateX(-50%);
+    transform: translateX(-50%);
+  }
+
+  #mainnav ul.mn-nav {
+    display: block;
+    position: absolute;
+    top: @navbar-height;
+    left: 0;
+    width: 100%;
+    background: rgba(25, 25, 25, 1);
+    opacity: 0;
+    transition: opacity 0.3s ease-in-out;
         
-        opacity: 0;
-        transition: opacity .3s ease-in-out;
+    &.mn-nav-open {
+      opacity: 1;
+    }
         
-        &.mn-nav-open {
-            opacity: 1;
-        }
-        
-        &:not(.animation-in-process):not(.mn-nav-open) {
-            display: none;
-        }
+    &:not(.animation-in-process):not(.mn-nav-open) {
+      display: none;
     }
-    #mainnav .mn-nav li:first-child {
-        display: none;
-    }
-        .mn-nav li,
-        .mn-nav li.active {
-            line-height: 40px;
-            border-top: none;
-            display: block;
-        }
-        .mn-nav li a {
-            color: none;
-            margin-top: 0;
-            font-size: 12px;
-            line-height: 40px;
-        }
+  }
+
+  #mainnav .mn-nav li:first-child {
+    display: none;
+  }
+
+  .mn-nav li,
+  .mn-nav li.active {
+    line-height: 40px;
+    border-top: none;
+    display: block;
+  }
+
+  .mn-nav li a {
+    color: none;
+    margin-top: 0;
+    font-size: 12px;
+    line-height: 40px;
+  }
 
 
-    #mainnav ul.mn-collapse {
-        display: block;
-    }
-        .mn-collapse li {
-        }
-        .mn-collapse a {
-            display: block;
-            height: @navbar-height;
-        }
-        .mn-collapse a img {
-            margin-top: 15px;
-        }
-        .online-logo {
-            width: 95px;
-        }
+  #mainnav ul.mn-collapse {
+    display: block;
+  }
+
+  .mn-collapse li {
+  }
+
+  .mn-collapse a {
+    display: block;
+    height: @navbar-height;
+  }
+
+  .mn-collapse a img {
+    margin-top: 15px;
+  }
+
+  .online-logo {
+    width: 95px;
+  }
 
 
-    .mn-user-nav {
-        right: 105px;
-    }
+  .mn-user-nav {
+    right: 105px;
+  }
 
-    #main-sponsor {
-        top: 12px;
-        right: 15px
-    }
-        .ms-span {
-            font-size:6px;
-            padding: 3px 0 0 13px;
-            right: -5px;
-        }
-        .ms-img {
-            top: 0;
-            left: 36px;
-            width: 65px;
-            margin: 5px 0 0 0;
-        }
+  #main-sponsor {
+    top: 12px;
+    right: 15px
+  }
 
-    .subnavbar ul {
-        white-space: nowrap;
-        overflow: scroll;
-        -webkit-overflow-scrolling: touch;
-    }
-        .subnavbar ul li a:hover,
-        .subnavbar ul li a.active {
-            background: rgba(255,255,255, 0.1);
-        }
+  .ms-span {
+    font-size:6px;
+    padding: 3px 0 0 13px;
+    right: -5px;
+  }
+
+  .ms-img {
+    top: 0;
+    left: 36px;
+    width: 65px;
+    margin: 5px 0 0 0;
+  }
+
+  .subnavbar ul {
+    white-space: nowrap;
+    overflow: scroll;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .subnavbar ul li a:hover,
+  .subnavbar ul li a.active {
+    background: rgba(255,255,255, 0.1);
+  }
 }
 
 /* Logos
 -------------------------------------------------- */
 .dropdown-form li > form > .login-extra > a {
-    padding:20px 0 0 0;
-    display:block;
+  padding:20px 0 0 0;
+  display:block;
 }
 
 /* Login
 -------------------------------------------------- */
 #login-form-btn-group {
-    clear: both;
-    border-top: 1px solid #CCC;
-    padding: 10px 15px 35px 15px;
+  clear: both;
+  border-top: 1px solid #ccc;
+  padding: 10px 15px 35px 15px;
 
-    a {
-        text-transform: none;
-        float: left;
-        padding: 5px 11px;
-    }
+  a {
+    text-transform: none;
+    float: left;
+    padding: 5px 11px;
+  }
 
-    a:first-child {
-        margin: 0 10px 5px 0;
-    }
+  a:first-child {
+    margin: 0 10px 5px 0;
+  }
 }
 
 .login-btn {
-    margin: 10px 0 0 0;
-    padding: 4px 10px!important;
-    border-radius: 5px;
-    display: block;
-    float: right;
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    background: rgba(255, 255, 255, 0.1);
+  margin: 10px 0 0 0;
+  padding: 4px 10px!important;
+  border-radius: 5px;
+  display: block;
+  float: right;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.1);
 }
+
 .login-box {
-    width: 250px;
+  width: 250px;
 
-    .navbar-form {
-        width: auto;
-        margin-left: 0;
-        margin-right: 0;
-        padding-top: 0;
-        padding-bottom: 0;
-        border: none;
-        button[type=submit] {
-            margin: 10px 0 0 0;
-        }
+  .navbar-form {
+    width: auto;
+    margin-left: 0;
+    margin-right: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    border: none;
+
+    button[type=submit] {
+      margin: 10px 0 0 0;
     }
+  }
 
-    border-radius: 0px;
+  border-radius: 0;
 }
 
 .dropdown-menu > li > p {
-    display: block;
-    padding: 3px 20px;
-    clear: both;
-    font-weight: normal;
-    line-height: 1.42857143;
-    color: #333333;
-    white-space: nowrap;
+  display: block;
+  padding: 3px 20px;
+  clear: both;
+  font-weight: normal;
+  line-height: 1.42857143;
+  color: #333;
+  white-space: nowrap;
 }
 
 label[for='id_password'] {

--- a/assets/core/less/navbar.less
+++ b/assets/core/less/navbar.less
@@ -165,6 +165,7 @@ svg, rect {
   margin-top: -2px;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 .mn-collapse li {
   display: inline-block;
   vertical-align: middle;
@@ -176,6 +177,7 @@ svg, rect {
   right: 180px;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 .mn-user-nav li {
   display: inline;
 }
@@ -197,6 +199,7 @@ svg, rect {
   color: #fff;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 .mn-user-nav > li > a {
   color: #fff;
   margin: 0;
@@ -221,6 +224,7 @@ svg, rect {
   width: 100%;
   background: rgba(160, 160, 160, 1);
 
+  /* stylelint-disable no-descending-specificity*/
   ul {
     padding: 0;
     margin: 0 -15px;
@@ -247,6 +251,7 @@ svg, rect {
       background: rgba(255, 255, 255, 0.2);
     }
   }
+  /* stylelint-enable */
 }
 
 /* Controls gap between navbar and content */
@@ -300,6 +305,7 @@ svg, rect {
     display: none;
   }
 
+  /* stylelint-disable-next-line no-descending-specificity */
   .mn-nav li,
   .mn-nav li.active {
     line-height: 40px;
@@ -318,6 +324,7 @@ svg, rect {
     display: block;
   }
 
+  /* stylelint-disable-next-line no-descending-specificity */
   .mn-collapse a {
     display: block;
     height: @navbar-height;

--- a/assets/core/less/navbar.less
+++ b/assets/core/less/navbar.less
@@ -1,32 +1,6 @@
 /* Navbar
 -------------------------------------------------- */
-@dropdown-link-active-color:     #fff;
-@dropdown-link-active-bg:        @component-active-bg;
-
-@dropdown-link-hover-color:      #fff;
-@dropdown-link-hover-bg:         @dropdown-link-active-bg;
-
 @navbar-height:                    57px;
-
-@navbar-default-color:             #fff;
-@navbar-default-bg:                #004b80;
-
-@navbar-default-link-color:                #fff;
-@navbar-default-link-hover-color:          #fff;
-@navbar-default-link-hover-bg:             rgba(255,255,255,0.1);
-@navbar-default-link-active-color:         #fff;
-@navbar-default-link-active-bg:            transparent;
-
-@navbar-default-brand-hover-color:         darken(@navbar-default-link-color, 10%);
-@nav-pills-active-link-hover-color:         #fff;
-
-@state-warning-text:             #c09853;
-@state-warning-bg:               #fcf8e3;
-@state-warning-border:           darken(spin(@state-warning-bg, -10), 3%);
-
-@state-danger-text:              #b94a48;
-@state-danger-bg:                #f2dede;
-@state-danger-border:            darken(spin(@state-danger-bg, -10), 3%);
 
 #mainnav {
   position: fixed;

--- a/assets/core/less/navbar.less
+++ b/assets/core/less/navbar.less
@@ -35,14 +35,17 @@
   height: @navbar-height;
   z-index: 10;
 }
-#mainnav .container     { position: relative; }
-#mainnav .glyphicon     { top: 0; }
-#mainnav .dropdown-menu { margin: 0 0 0 -1px; border-top: none; }
+#mainnav .container { position: relative; }
+#mainnav .glyphicon { top: 0; }
+
+#mainnav .dropdown-menu {
+  margin: 0 0 0 -1px;
+  border-top: none;
+}
 #mainnav .dropdown-menu .divider { padding: 0; }
 
 #mainnav .container > ul {
   list-style: none;
-  padding: 0;
   display: inline-block;
   vertical-align: middle;
   margin: 0;
@@ -50,7 +53,7 @@
 }
 
 .mn-nav {
-  -webkit-transform: translate3d(0,0,0);
+  -webkit-transform: translate3d(0, 0, 0);
 }
 
 .mn-nav li {
@@ -62,7 +65,7 @@
 }
 
 .mn-nav li > .online-logo-link {
-  padding:0 13px 0 0;
+  padding: 0 13px 0 0;
 }
 
 .mn-nav li:hover {
@@ -215,7 +218,7 @@ svg, rect {
   margin-right: -3px;
 }
 
-.username_menu{
+.username_menu {
   padding-left: 10px;
   color: #fff;
 }
@@ -235,7 +238,6 @@ svg, rect {
   text-decoration: none;
   background: rgba(255, 255, 255, 0.2);
 }
-
 
 .subnavbar {
   position: fixed;
@@ -274,18 +276,16 @@ svg, rect {
 }
 
 /* Controls gap between navbar and content */
-.subnavbar   + section           { padding: 87px 0 0 0; }
-.subnavbar   + div.messages      { padding: 97px 0 0 0; }
+.subnavbar + section { padding: 87px 0 0 0; }
+.subnavbar + div.messages { padding: 97px 0 0 0; }
 
-#mainnav     + section           { padding: 62px 0 0 0; }
-#mainnav     + div.messages      { padding: 62px 0 0 0; }
+#mainnav + section { padding: 62px 0 0 0; }
+#mainnav + div.messages { padding: 62px 0 0 0; }
 
-.subnavbar   + div.messages .alert,
-#mainnav     + div.messages .alert {
+.subnavbar + div.messages .alert,
+#mainnav + div.messages .alert {
   margin-bottom: 0;
 }
-
-
 
 @media (max-width: 991px) {
   .mn-user-nav {
@@ -312,11 +312,11 @@ svg, rect {
     background: rgba(25, 25, 25, 1);
     opacity: 0;
     transition: opacity 0.3s ease-in-out;
-        
+
     &.mn-nav-open {
       opacity: 1;
     }
-        
+
     &:not(.animation-in-process):not(.mn-nav-open) {
       display: none;
     }
@@ -340,12 +340,8 @@ svg, rect {
     line-height: 40px;
   }
 
-
   #mainnav ul.mn-collapse {
     display: block;
-  }
-
-  .mn-collapse li {
   }
 
   .mn-collapse a {
@@ -361,18 +357,17 @@ svg, rect {
     width: 95px;
   }
 
-
   .mn-user-nav {
     right: 105px;
   }
 
   #main-sponsor {
     top: 12px;
-    right: 15px
+    right: 15px;
   }
 
   .ms-span {
-    font-size:6px;
+    font-size: 6px;
     padding: 3px 0 0 13px;
     right: -5px;
   }
@@ -392,15 +387,15 @@ svg, rect {
 
   .subnavbar ul li a:hover,
   .subnavbar ul li a.active {
-    background: rgba(255,255,255, 0.1);
+    background: rgba(255, 255, 255, 0.1);
   }
 }
 
 /* Logos
 -------------------------------------------------- */
 .dropdown-form li > form > .login-extra > a {
-  padding:20px 0 0 0;
-  display:block;
+  padding: 20px 0 0 0;
+  display: block;
 }
 
 /* Login
@@ -423,7 +418,7 @@ svg, rect {
 
 .login-btn {
   margin: 10px 0 0 0;
-  padding: 4px 10px!important;
+  padding: 4px 10px !important;
   border-radius: 5px;
   display: block;
   float: right;

--- a/assets/core/less/offline.less
+++ b/assets/core/less/offline.less
@@ -49,7 +49,8 @@ section#offline {
         opacity: 0;
         text-decoration: none;
         margin-top: -24px;
-        position: relative; bottom: -24px;
+        position: relative;
+        bottom: -24px;
       }
     }
 

--- a/assets/core/less/offline.less
+++ b/assets/core/less/offline.less
@@ -2,151 +2,152 @@
 
 /* Help mixin */
 .transition_easer(@seconds: 0.2s) {
-    -webkit-transition: all @seconds ease-in-out;
-    -moz-transition: all @seconds ease-in-out;
-    -o-transition: all @seconds ease-in-out;
-    -ms-transition: all @seconds ease-in-out;
+  -webkit-transition: all @seconds ease-in-out;
+  -moz-transition: all @seconds ease-in-out;
+  -o-transition: all @seconds ease-in-out;
+  -ms-transition: all @seconds ease-in-out;
 }
 
 /* Offline */
+
 /* TODO: find out where this #offline is used */
 div#offline {
-    position: relative;
-    text-align: center;
-    margin: 0px auto;
+  position: relative;
+  text-align: center;
+  margin: 0 auto;
 }
 
 section#offline {
-    p {
-        margin-right: 15px;
-    }
+  p {
+    margin-right: 15px;
+  }
 }
 
 #offline-wrapper {
-    overflow: hidden;
-    height: 226px;
+  overflow: hidden;
+  height: 226px;
 
-    .offline_issue {
-        display: inline-block;
-        margin: 1em;
-        text-align: center;
+  .offline_issue {
+    display: inline-block;
+    margin: 1em;
+    text-align: center;
+    -moz-box-shadow: 5px 5px 5px #ccc;
+    -webkit-box-shadow: 5px 5px 5px #ccc;
+    box-shadow: 5px 5px 5px #ccc;
 
-        -moz-box-shadow: 5px 5px 5px #ccc;
-        -webkit-box-shadow: 5px 5px 5px #ccc;
-        box-shadow: 5px 5px 5px #ccc;
+    a {
+      text-decoration: none;
+      line-height: 2em;
+      display: block;
 
-        a {
-            text-decoration: none;
-            line-height: 2em;
-            display: block;
+      &:first-child {
+        .transition_easer;
 
-            &:first-child {
-                .transition_easer;
-                display: block;
-                color: #fff;
-                background: #333;
-                opacity: 0;
-                text-decoration: none;
-                margin-top: -24px;
-                position: relative; bottom: -24px;
-            }
-        }
-
-
-        span {
-            .transition_easer;
-            display: block;
-            color: #fff;
-            background: #333;
-            opacity: 0;
-            line-height: 2em;
-            margin-bottom: -24px;
-            position: relative; top: -24px;
-
-        }
-
-        .offline_issue_archive {
-            transition: none;
-        }
-
-        &:hover {
-            -moz-box-shadow: 10px 10px 10px #666;
-            -webkit-box-shadow: 10px 10px 10px #666;
-            box-shadow: 10px 10px 10px #666;
-
-            span {
-                opacity: 0.75;
-            }
-
-            a {
-                &:first-child {
-                    opacity: 0.75;
-                }
-            }
-        }
+        display: block;
+        color: #fff;
+        background: #333;
+        opacity: 0;
+        text-decoration: none;
+        margin-top: -24px;
+        position: relative; bottom: -24px;
+      }
     }
+
+
+    span {
+      .transition_easer;
+
+      display: block;
+      color: #fff;
+      background: #333;
+      opacity: 0;
+      line-height: 2em;
+      margin-bottom: -24px;
+      position: relative; top: -24px;
+
+    }
+
+    .offline_issue_archive {
+      transition: none;
+    }
+
+    &:hover {
+      -moz-box-shadow: 10px 10px 10px #666;
+      -webkit-box-shadow: 10px 10px 10px #666;
+      box-shadow: 10px 10px 10px #666;
+
+      span {
+        opacity: 0.75;
+      }
+
+      a {
+        &:first-child {
+          opacity: 0.75;
+        }
+      }
+    }
+  }
 }
 
 #offline-nav {
-    text-align: center;
+  text-align: center;
 
-    .paddright {
-        margin-right: 10px;
-    }
-    .paddleft {
-        margin-left: 10px;
+  .paddright {
+    margin-right: 10px;
+  }
 
-        a {
-            border-left-width: 1px;
-        }
-    }
+  .paddleft {
+    margin-left: 10px;
 
-    .first a{
-        border-left-width: 1px;
+    a {
+      border-left-width: 1px;
     }
+  }
 
-    .pagination ul > li {
-        display: inline-block;
-    }
+  .first a{
+    border-left-width: 1px;
+  }
+
+  .pagination ul > li {
+    display: inline-block;
+  }
 }
 
 .filterbox {
+  background-color: @baby-blue-medium;
+  padding: 15px;
+  margin-bottom: 20px;
 
-    background-color: @baby-blue-medium;
-    padding: 15px;
-    margin-bottom: 20px;
+  a, li {
+    color: white;
+  }
 
-    a, li {
-        color: white;
+  a:hover {
+    color: #027bbb;
+    border-radius: 0;
+  }
+
+  li.active a {
+    border-radius: 0;
+    background-color: #027bbb;
+  }
+
+  li.active a:hover {
+    background-color: #027bbb;
+  }
+
+  h3 {
+    color: white;
+    font-size: 20px;
+    font-weight: 400;
+    margin-top: 0;
+  }
+
+  #filter-menu {
+    a {
+      padding: 5px 15px;
+      border-radius: 0;
     }
-
-    a:hover {
-        color: #027bbb;
-        border-radius: 0px;
-    }
-
-    li.active a {
-        border-radius: 0px;
-	background-color: #027bbb;
-    }
-
-    li.active a:hover {
-	background-color: #027bbb;
-    }
-
-    h3 {
-        color: white;
-        font-size: 20px;
-        font-weight: 400;
-        margin-top: 0px;
-    }
-
-    #filter-menu {
-
-         a {
-            padding: 5px 15px;
-            border-radius: 0px;
-        }
-    }
+  }
 
 }

--- a/assets/core/less/offline.less
+++ b/assets/core/less/offline.less
@@ -23,97 +23,6 @@ section#offline {
   }
 }
 
-#offline-wrapper {
-  overflow: hidden;
-  height: 226px;
-
-  .offline_issue {
-    display: inline-block;
-    margin: 1em;
-    text-align: center;
-    -moz-box-shadow: 5px 5px 5px #ccc;
-    -webkit-box-shadow: 5px 5px 5px #ccc;
-    box-shadow: 5px 5px 5px #ccc;
-
-    a {
-      text-decoration: none;
-      line-height: 2em;
-      display: block;
-
-      &:first-child {
-        .transition_easer;
-
-        display: block;
-        color: #fff;
-        background: #333;
-        opacity: 0;
-        text-decoration: none;
-        margin-top: -24px;
-        position: relative;
-        bottom: -24px;
-      }
-    }
-
-
-    span {
-      .transition_easer;
-
-      display: block;
-      color: #fff;
-      background: #333;
-      opacity: 0;
-      line-height: 2em;
-      margin-bottom: -24px;
-      position: relative; top: -24px;
-
-    }
-
-    .offline_issue_archive {
-      transition: none;
-    }
-
-    &:hover {
-      -moz-box-shadow: 10px 10px 10px #666;
-      -webkit-box-shadow: 10px 10px 10px #666;
-      box-shadow: 10px 10px 10px #666;
-
-      span {
-        opacity: 0.75;
-      }
-
-      a {
-        &:first-child {
-          opacity: 0.75;
-        }
-      }
-    }
-  }
-}
-
-#offline-nav {
-  text-align: center;
-
-  .paddright {
-    margin-right: 10px;
-  }
-
-  .paddleft {
-    margin-left: 10px;
-
-    a {
-      border-left-width: 1px;
-    }
-  }
-
-  .first a{
-    border-left-width: 1px;
-  }
-
-  .pagination ul > li {
-    display: inline-block;
-  }
-}
-
 .filterbox {
   background-color: @baby-blue-medium;
   padding: 15px;
@@ -150,5 +59,94 @@ section#offline {
       border-radius: 0;
     }
   }
+}
 
+#offline-nav {
+  text-align: center;
+
+  .paddright {
+    margin-right: 10px;
+  }
+
+  .paddleft {
+    margin-left: 10px;
+
+    a {
+      border-left-width: 1px;
+    }
+  }
+
+  .first a {
+    border-left-width: 1px;
+  }
+
+  .pagination ul > li {
+    display: inline-block;
+  }
+}
+
+#offline-wrapper {
+  overflow: hidden;
+  height: 226px;
+
+  span {
+    .transition_easer;
+
+    display: block;
+    color: #fff;
+    background: #333;
+    opacity: 0;
+    line-height: 2em;
+    margin-bottom: -24px;
+    position: relative;
+    top: -24px;
+  }
+
+  .offline_issue {
+    display: inline-block;
+    margin: 1em;
+    text-align: center;
+    -moz-box-shadow: 5px 5px 5px #ccc;
+    -webkit-box-shadow: 5px 5px 5px #ccc;
+    box-shadow: 5px 5px 5px #ccc;
+
+    a {
+      text-decoration: none;
+      line-height: 2em;
+      display: block;
+
+      &:first-child {
+        .transition_easer;
+
+        display: block;
+        color: #fff;
+        background: #333;
+        opacity: 0;
+        text-decoration: none;
+        margin-top: -24px;
+        position: relative;
+        bottom: -24px;
+      }
+    }
+
+    .offline_issue_archive {
+      transition: none;
+    }
+
+    &:hover {
+      -moz-box-shadow: 10px 10px 10px #666;
+      -webkit-box-shadow: 10px 10px 10px #666;
+      box-shadow: 10px 10px 10px #666;
+
+      span {
+        opacity: 0.75;
+      }
+
+      a {
+        &:first-child {
+          opacity: 0.75;
+        }
+      }
+    }
+  }
 }

--- a/assets/core/less/offlinewidget.less
+++ b/assets/core/less/offlinewidget.less
@@ -8,7 +8,7 @@
     color: #428bca;
     border-radius: 50%;
     height: 40px;
-    width:  40px;
+    width: 40px;
     margin: auto auto;
 
     // override opacity
@@ -18,7 +18,7 @@
     text-shadow: none;
 
     // override hover and focus
-    &:hover{
+    &:hover {
       color: #2a6496;
     }
 
@@ -38,5 +38,4 @@
       display: inline-block;
     }
   }
-
 }

--- a/assets/core/less/offlinewidget.less
+++ b/assets/core/less/offlinewidget.less
@@ -1,44 +1,42 @@
 /* Offline
 -------------------------------------------------- */
 #offlineCarousel {
+  text-align: center;
+
+  .carousel-control {
     text-align: center;
+    color: #428bca;
+    border-radius: 50%;
+    height: 40px;
+    width:  40px;
+    margin: auto auto;
 
-    .carousel-control {
-        text-align: center;
+    // override opacity
+    .opacity(0.9);
 
-        color: #428bca;
-        border-radius: 50%;
-        height: 40px;
-        width:  40px;
+    // override text-shadow
+    text-shadow: none;
 
-        margin: auto auto;
-
-        // override opacity
-        .opacity(0.9);
-
-        // override text-shadow
-        text-shadow: none;
-
-        // override hover and focus
-        &:hover{
-            color: #2A6496;
-        }
-
-        // override mixin gradient
-        &.left,
-        &.right {
-            background-image: none;
-        }
+    // override hover and focus
+    &:hover{
+      color: #2a6496;
     }
 
-    .item {
-        a:not(:first-child) {
-            margin-left: 10px;
-        }
-
-        img {
-            display: inline-block;
-        }
+    // override mixin gradient
+    &.left,
+    &.right {
+      background-image: none;
     }
+  }
+
+  .item {
+    a:not(:first-child) {
+      margin-left: 10px;
+    }
+
+    img {
+      display: inline-block;
+    }
+  }
 
 }

--- a/assets/core/less/z_override_abakus.less
+++ b/assets/core/less/z_override_abakus.less
@@ -31,7 +31,6 @@ a:hover {
   background-color: @abakus-red;
 }
 
-
 /* Frontpage: events */
 section#events {
   .hero {

--- a/assets/core/less/z_override_abakus.less
+++ b/assets/core/less/z_override_abakus.less
@@ -34,21 +34,21 @@ a:hover {
 
 /* Frontpage: events */
 section#events {
-    .hero {
-        .hero-date {
-          background: @abakus-red;
-        }
+  .hero {
+    .hero-date {
+      background: @abakus-red;
     }
+  }
 
-    .event-filter-button {
-      background-color: @abakus-red;
-      border-color: lighten(@abakus-red, 10%);
-    }
+  .event-filter-button {
+    background-color: @abakus-red;
+    border-color: lighten(@abakus-red, 10%);
+  }
 
-    .event-filter-button:hover {
-      background: lighten(@abakus-red, 10%);
-      border-color: lighten(@abakus-red, 20%);
-    }
+  .event-filter-button:hover {
+    background: lighten(@abakus-red, 10%);
+    border-color: lighten(@abakus-red, 20%);
+  }
 }
 
 /* Frontpage: Offline Carousel */
@@ -61,6 +61,7 @@ section#business {
   .sale-box {
     background: @abakus-gray;
   }
+
   .sale-content {
     background: lighten(@abakus-gray, 50%);
   }

--- a/assets/dashboard/approval/less/approval.less
+++ b/assets/dashboard/approval/less/approval.less
@@ -1,22 +1,22 @@
 .headings {
-    font-weight:600;
-    font-size:15px;
-    margin-bottom: 5px;
+  font-weight:600;
+  font-size:15px;
+  margin-bottom: 5px;
 }
 
 #approval-list .application {
-    border-top: 1px solid #eeeeee;
-    padding: 2px;
+  border-top: 1px solid #eee;
+  padding: 2px;
 }
 
 #approval-list .application .cell {
-    margin-top: 8px;
+  margin-top: 8px;
 }
 
 #approval-list div.confirm {
-    display: none;
+  display: none;
 }
 
 #approval-list div.confirm textarea {
-    width: 100%;
+  width: 100%;
 }

--- a/assets/dashboard/approval/less/approval.less
+++ b/assets/dashboard/approval/less/approval.less
@@ -1,6 +1,6 @@
 .headings {
-  font-weight:600;
-  font-size:15px;
+  font-weight: 600;
+  font-size: 15px;
   margin-bottom: 5px;
 }
 

--- a/assets/dashboard/careeropportunity/less/careeropportunity.less
+++ b/assets/dashboard/careeropportunity/less/careeropportunity.less
@@ -1,5 +1,5 @@
 .headings {
-    font-weight:600;
-    font-size:15px;
-    margin-bottom: 5px;
+  font-weight:600;
+  font-size:15px;
+  margin-bottom: 5px;
 }

--- a/assets/dashboard/careeropportunity/less/careeropportunity.less
+++ b/assets/dashboard/careeropportunity/less/careeropportunity.less
@@ -1,5 +1,5 @@
 .headings {
-  font-weight:600;
-  font-size:15px;
+  font-weight: 600;
+  font-size: 15px;
   margin-bottom: 5px;
 }

--- a/assets/dashboard/core/less/dropzone.less
+++ b/assets/dashboard/core/less/dropzone.less
@@ -2,6 +2,7 @@
 .dropzone {
   border: 0;
 }
+
 .dz-message:hover {
-  color: #004B80;
+  color: #004b80;
 }

--- a/assets/dashboard/core/less/main.less
+++ b/assets/dashboard/core/less/main.less
@@ -13,92 +13,95 @@
 /* Generics */
 
 html, body {
-    font-family: 'Open Sans';
+  font-family: 'Open Sans';
 }
 
 h1,h2 {
-    color: @orange;
+  color: @orange;
 }
+
 h3, h4 {
-    margin-top: 0px;
-    margin-bottom: 15px;
+  margin-top: 0;
+  margin-bottom: 15px;
 }
 
 ul {
-    margin: 0px;
-    padding: 0px;
+  margin: 0;
+  padding: 0;
 }
 
 
 .center-text {
-    text-align: center;
+  text-align: center;
 }
 
 
 /* Color classes */
 
 .orange {
-    color: @orange;
+  color: @orange;
 }
+
 .blue {
-    color: @blue;
+  color: @blue;
 }
 .red { color: red; }
 
 /* Navbars */
 
 #online-logo {
-    height: 35px;
-    width: 140px;
-    margin-top: 10px;
-    margin-bottom: 12px;
+  height: 35px;
+  width: 140px;
+  margin-top: 10px;
+  margin-bottom: 12px;
 }
 
 nav#dashboard_main_nav {
-    box-sizing: border-box;
-    background-color: @blue;
-    position: fixed;
-    height: 57px;
-    z-index: 20;
-    width: 100%;
+  box-sizing: border-box;
+  background-color: @blue;
+  position: fixed;
+  height: 57px;
+  z-index: 20;
+  width: 100%;
 }
 
 .sidebar-center {
-    width: 220px;
-    text-align: center;
-    display: inline-block;
+  width: 220px;
+  text-align: center;
+  display: inline-block;
 }
 
 .sidebar {
-    h1,h2,h3,h4,h5,h6 {
-        color: #000;
-    }
+  h1,h2,h3,h4,h5,h6 {
+    color: #000;
+  }
 }
 
 #sidebar_toggle {
-    height: 57px;
-    margin-right: 25px;
-    font-size: 20px;
-    color: #fff;
-    line-height: 57px;
-    vertical-align: middle;
-    cursor: pointer
+  height: 57px;
+  margin-right: 25px;
+  font-size: 20px;
+  color: #fff;
+  line-height: 57px;
+  vertical-align: middle;
+  cursor: pointer
 }
+
 #sidebar_toggle:hover {
-    color: #ddd;
+  color: #ddd;
 }
 
 
 #sidebar_toggle {
-    display: inline-block;
+  display: inline-block;
 }
 
 .topspacing {
-    padding-top: 60px;
+  padding-top: 60px;
 }
 
 .sidebar {
-    margin-top: -15px;
+  margin-top: -15px;
 }
 
 .errorlist {
@@ -110,64 +113,63 @@ nav#dashboard_main_nav {
 /* Main content area */
 
 .content {
-    padding: 15px;
-    z-index: 1;
+  padding: 15px;
+  z-index: 1;
+  display: block;
 
-    display: block;
-
-    .main-content {
-        z-index: 2;
-        padding-bottom: 200px;
-    }
+  .main-content {
+    z-index: 2;
+    padding-bottom: 200px;
+  }
 
 }
 
 .content-header {
+  background-color: @header-bg;
+  z-index: 10;
 
-
-
-    background-color: @header-bg;
-    z-index: 10;
-    h2 {
-        margin: 0px;
-        padding-left: 15px;
-        padding-top: 15px;
-        margin-bottom: 15px;
-    }
+  h2 {
+    margin: 0;
+    padding-left: 15px;
+    padding-top: 15px;
+    margin-bottom: 15px;
+  }
 }
 
 /* BOOTSTRAP OVERRIDES */
 
 ol.breadcrumb {
-    border-radius: 0px;
-    background-color: @header-bg;
-    border-bottom: 1px solid #ddd;
-    margin-bottom: 0px;
+  border-radius: 0;
+  background-color: @header-bg;
+  border-bottom: 1px solid #ddd;
+  margin-bottom: 0;
 }
 
 /* Panel  */
 
 .panel {
-    border-radius: 0px;
-    border: 0px;
-    box-shadow: 0px 0px 0px;
+  border-radius: 0;
+  border: 0;
+  box-shadow: 0 0 0;
 }
+
 .panel-heading {
-    border-radius: 0px;
+  border-radius: 0;
 }
+
 .content {
-    .panel {
-        margin-left: -15px;
-        margin-right: -15px;
-    }
+  .panel {
+    margin-left: -15px;
+    margin-right: -15px;
+  }
 }
 
 h3.panel-title {
-    font-size: 15px;
+  font-size: 15px;
 }
 
 tr, td, th {
-    border-top: 0px;
+  border-top: 0;
 }
 
 /* GENERAL TEMPLATE CODE BELOW */
@@ -178,6 +180,7 @@ tr, td, th {
  *   License: Open source - MIT
  *           Please visit http://opensource.org/licenses/MIT for more information
 !*/
+
 /*
     Core: General style
 ----------------------------
@@ -190,27 +193,33 @@ body {
   min-height: 100%;
   height: 100%;
 }
+
 /* Layouts */
 .wrapper {
   min-height: 100%;
 }
+
 .wrapper:before,
 .wrapper:after {
   display: table;
   content: " ";
 }
+
 .wrapper:after {
   clear: both;
 }
+
 /* Define 2 column template */
 .right-side,
 .left-side {
   display: block;
 }
+
 /*right side - contins main content*/
 .right-side {
   margin-left: 220px;
 }
+
 /*left side - contains sidebar*/
 .left-side {
   position: fixed;
@@ -220,19 +229,23 @@ body {
   background-color: @sidebar-bg;
   overflow-y: auto;
 }
+
 @media screen and (min-width: 992px) {
   /*Right side strech mode*/
   .right-side.strech {
     margin-left: 0;
   }
+
   .right-side.strech > .content-header {
-    margin-top: 0px;
+    margin-top: 0;
   }
+
   /* Left side collapse */
   .left-side.collapse-left {
     left: -220px;
   }
 }
+
 /*Give content full width on xs screens*/
 @media screen and (max-width: 992px) {
   .right-side {
@@ -240,6 +253,7 @@ body {
     height: 100%;
   }
 }
+
 /*
     By default the layout is not fixed but if you add the class .fixed to the body element
     the sidebar and the navbar will automatically become poisitioned fixed
@@ -249,18 +263,22 @@ body.fixed .left-side,
 body.fixed .navbar {
   position: fixed;
 }
+
 body.fixed .navbar {
   left: 0;
   right: 0;
 }
+
 body.fixed .wrapper {
   margin-top: 50px;
 }
+
 /* Content */
 .content {
   padding: 20px 15px;
   background: @dash-bg;
 }
+
 /* Utility */
 
 /* Page Header */
@@ -268,78 +286,95 @@ body.fixed .wrapper {
   margin: 10px 0 20px 0;
   font-size: 22px;
 }
+
 .page-header > small {
   color: #666;
   display: block;
   margin-top: 5px;
 }
+
 /* All images should be responsive */
 img {
   max-width: 100% !important;
 }
+
 /* 10px padding and margins */
 .pad {
   padding: 10px;
 }
+
 .margin {
   margin: 10px;
 }
+
 /* Display inline */
 .inline {
   display: inline;
   width: auto;
 }
+
 /*Hide elements by display none only*/
 .hide {
   display: none !important;
 }
+
 /* Remove borders */
 .no-border {
-  border: 0px !important;
+  border: 0 !important;
 }
+
 /* Remove padding */
 .no-padding {
-  padding: 0px !important;
+  padding: 0 !important;
 }
+
 /* Remove margins */
 .no-margin {
-  margin: 0px !important;
+  margin: 0 !important;
 }
+
 /* Remove box shadow */
 .no-shadow {
   box-shadow: none!important;
 }
+
 /* Don't display when printing */
 @media print {
   .no-print {
     display: none;
   }
+
   .left-side,
   .header,
   .content-header {
     display: none;
   }
+
   .right-side {
     margin: 0;
   }
 }
+
 /* Remove border radius */
 .flat {
   -webkit-border-radius: 0 !important;
   -moz-border-radius: 0 !important;
   border-radius: 0 !important;
 }
+
 .border-radius-none {
   -webkit-border-radius: 0 !important;
   -moz-border-radius: 0 !important;
   border-radius: 0 !important;
 }
+
 /* _fix for sparkline tooltip */
 .jqstooltip {
   padding: 5px!important;
   width: auto!important;
   height: auto!important;
 }
+
 /*
     Component: Sidebar
 --------------------------
@@ -347,12 +382,14 @@ img {
 .sidebar {
   margin-bottom: 5px;
 }
+
 .sidebar .sidebar-form input:focus {
   -webkit-box-shadow: none;
   -moz-box-shadow: none;
   box-shadow: none;
   border-color: transparent!important;
 }
+
 .sidebar .sidebar-menu {
   list-style: none;
   margin: 0;
@@ -361,65 +398,78 @@ img {
   a {
     color: #000;
   }
+
   a:hover {
     color: #444;
     text-decoration: none;
   }
 }
+
 .sidebar .sidebar-menu > li {
   margin: 0;
   padding: 0;
 }
+
 .sidebar .sidebar-menu > li > a {
   padding: 5px 5px 5px 15px;
   display: block;
 }
+
 .sidebar .sidebar-menu > li > a:hover {
   background-color: #ddd;
   text-decoration: none;
 }
+
 .sidebar .sidebar-menu > li > a:active,
 .sidebar .sidebar-menu > li > a:focus {
-    outline: none;
-    text-decoration: none;
-    border: 0px;
+  outline: none;
+  text-decoration: none;
+  border: 0;
 }
+
 .sidebar .sidebar-menu > li > a > .fa,
 .sidebar .sidebar-menu > li > a > .glyphicon,
 .sidebar .sidebar-menu > li > a > .ion {
   width: 20px;
   padding-right: 5px;
 }
+
 .sidebar .sidebar-menu .treeview-menu {
   display: none;
   list-style: none;
   padding: 0;
   margin: 0;
 }
+
 .sidebar .sidebar-menu .treeview-menu > li {
   margin: 0;
 }
+
 .sidebar .sidebar-menu .treeview-menu > li > a {
   padding: 3px 5px 3px 15px;
   display: block;
   font-size: 13px;
-  margin: 0px 0px;
+  margin: 0 0;
 }
+
 .sidebar .sidebar-menu .treeview-menu > li:hover {
   background-color: #e6e6e6;
 }
+
 .sidebar .sidebar-menu .treeview-menu > li > a:active,
 .sidebar .sidebar-menu .treeview-menu > li > a:focus {
-    outline: none;
-    text-decoration: none;
-    border: 0px;
+  outline: none;
+  text-decoration: none;
+  border: 0;
 }
+
 .sidebar .sidebar-menu .treeview-menu > li > a > .fa,
 .sidebar .sidebar-menu .treeview-menu > li > a > .glyphicon,
 .sidebar .sidebar-menu .treeview-menu > li > a > .ion {
   width: 20px;
   padding-right: 5px;
 }
+
 /*
  * Off Canvas
  * --------------------------------------------------
@@ -429,32 +479,40 @@ img {
   .relative {
     position: relative;
   }
+
   .row-offcanvas-right .sidebar-offcanvas {
     right: -220px;
   }
+
   .row-offcanvas-left .left-side {
     left: -220px;
   }
+
   .row-offcanvas-right.active {
     right: 220px;
   }
+
   .row-offcanvas-left.active .right-side {
     margin-left: 220px;
     width: 100%;
   }
+
   .row-offcanvas-left.active .left-side {
-    left: 0px;
+    left: 0;
   }
+
   body.fixed .sidebar-offcanvas {
     margin-top: 50px;
     left: -220px;
   }
+
   body.fixed .row-offcanvas-left.active .navbar {
     left: 220px !important;
     right: 0;
   }
+
   body.fixed .row-offcanvas-left.active .sidebar-offcanvas {
-    left: 0px;
+    left: 0;
   }
 }
 

--- a/assets/dashboard/core/less/main.less
+++ b/assets/dashboard/core/less/main.less
@@ -9,11 +9,10 @@
 @orange: #ee7810;
 @blue: #004b80;
 
-
 /* Generics */
 
 html, body {
-  font-family: 'Open Sans';
+  font-family: 'Open Sans', sans-serif;
 }
 
 h1,h2 {
@@ -30,11 +29,9 @@ ul {
   padding: 0;
 }
 
-
 .center-text {
   text-align: center;
 }
-
 
 /* Color classes */
 
@@ -72,36 +69,31 @@ nav#dashboard_main_nav {
 }
 
 .sidebar {
+  margin-top: -15px;
+  margin-bottom: 5px;
+
   h1,h2,h3,h4,h5,h6 {
     color: #000;
   }
 }
 
 #sidebar_toggle {
+  display: inline-block;
   height: 57px;
   margin-right: 25px;
   font-size: 20px;
   color: #fff;
   line-height: 57px;
   vertical-align: middle;
-  cursor: pointer
+  cursor: pointer;
 }
 
 #sidebar_toggle:hover {
   color: #ddd;
 }
 
-
-#sidebar_toggle {
-  display: inline-block;
-}
-
 .topspacing {
   padding-top: 60px;
-}
-
-.sidebar {
-  margin-top: -15px;
 }
 
 .errorlist {
@@ -113,9 +105,10 @@ nav#dashboard_main_nav {
 /* Main content area */
 
 .content {
-  padding: 15px;
+  padding: 20px 15px;
   z-index: 1;
   display: block;
+  background: @dash-bg;
 
   .main-content {
     z-index: 2;
@@ -185,9 +178,10 @@ tr, td, th {
     Core: General style
 ----------------------------
 */
-html,
-body {
-  overflow-x: hidden!important;
+
+/* stylelint-disable-next-line no-duplicate-selectors */
+html, body {
+  overflow-x: hidden !important;
   -webkit-font-smoothing: antialiased;
   background-color: @dash-bg;
   min-height: 100%;
@@ -199,13 +193,13 @@ body {
   min-height: 100%;
 }
 
-.wrapper:before,
-.wrapper:after {
+.wrapper::before,
+.wrapper::after {
   display: table;
   content: " ";
 }
 
-.wrapper:after {
+.wrapper::after {
   clear: both;
 }
 
@@ -273,12 +267,6 @@ body.fixed .wrapper {
   margin-top: 50px;
 }
 
-/* Content */
-.content {
-  padding: 20px 15px;
-  background: @dash-bg;
-}
-
 /* Utility */
 
 /* Page Header */
@@ -335,7 +323,7 @@ img {
 
 /* Remove box shadow */
 .no-shadow {
-  box-shadow: none!important;
+  box-shadow: none !important;
 }
 
 /* Don't display when printing */
@@ -370,24 +358,21 @@ img {
 
 /* _fix for sparkline tooltip */
 .jqstooltip {
-  padding: 5px!important;
-  width: auto!important;
-  height: auto!important;
+  padding: 5px !important;
+  width: auto !important;
+  height: auto !important;
 }
 
 /*
     Component: Sidebar
 --------------------------
 */
-.sidebar {
-  margin-bottom: 5px;
-}
 
 .sidebar .sidebar-form input:focus {
   -webkit-box-shadow: none;
   -moz-box-shadow: none;
   box-shadow: none;
-  border-color: transparent!important;
+  border-color: transparent !important;
 }
 
 .sidebar .sidebar-menu {

--- a/assets/dashboard/core/less/main.less
+++ b/assets/dashboard/core/less/main.less
@@ -102,6 +102,26 @@ nav#dashboard_main_nav {
   font-weight: bold;
 }
 
+/* Panel  */
+
+.panel {
+  border-radius: 0;
+  border: 0;
+  box-shadow: 0 0 0;
+}
+
+.panel-heading {
+  border-radius: 0;
+}
+
+h3.panel-title {
+  font-size: 15px;
+}
+
+tr, td, th {
+  border-top: 0;
+}
+
 /* Main content area */
 
 .content {
@@ -115,6 +135,10 @@ nav#dashboard_main_nav {
     padding-bottom: 200px;
   }
 
+  .panel {
+    margin-left: -15px;
+    margin-right: -15px;
+  }
 }
 
 .content-header {
@@ -136,33 +160,6 @@ ol.breadcrumb {
   background-color: @header-bg;
   border-bottom: 1px solid #ddd;
   margin-bottom: 0;
-}
-
-/* Panel  */
-
-.panel {
-  border-radius: 0;
-  border: 0;
-  box-shadow: 0 0 0;
-}
-
-.panel-heading {
-  border-radius: 0;
-}
-
-.content {
-  .panel {
-    margin-left: -15px;
-    margin-right: -15px;
-  }
-}
-
-h3.panel-title {
-  font-size: 15px;
-}
-
-tr, td, th {
-  border-top: 0;
 }
 
 /* GENERAL TEMPLATE CODE BELOW */
@@ -380,24 +377,24 @@ img {
   margin: 0;
   padding: 0;
 
+  & > li {
+    margin: 0;
+    padding: 0;
+  }
+
   a {
     color: #000;
+  }
+
+  & > li > a {
+    padding: 5px 5px 5px 15px;
+    display: block;
   }
 
   a:hover {
     color: #444;
     text-decoration: none;
   }
-}
-
-.sidebar .sidebar-menu > li {
-  margin: 0;
-  padding: 0;
-}
-
-.sidebar .sidebar-menu > li > a {
-  padding: 5px 5px 5px 15px;
-  display: block;
 }
 
 .sidebar .sidebar-menu > li > a:hover {

--- a/assets/dashboard/events/less/events.less
+++ b/assets/dashboard/events/less/events.less
@@ -15,7 +15,6 @@ table.attendees > tbody > tr > td > a > i.checked {
   .row {
     margin: 10px 0;
   }
-
 }
 
 #attendance {

--- a/assets/dashboard/events/less/events.less
+++ b/assets/dashboard/events/less/events.less
@@ -1,25 +1,25 @@
 table.attendees > tbody > tr > td > a > i {
-    color: red;
+  color: red;
 }
 
 table.attendees > tbody > tr > td > a > i.checked {
-    color: green;
+  color: green;
 }
 
 // Forms for editing
 .edit-form {
-    textarea, input[type="text"], input[type="email"], input[type="url"], input[type="number"] {
-        margin-bottom: 7px;
-    }
+  textarea, input[type="text"], input[type="email"], input[type="url"], input[type="number"] {
+    margin-bottom: 7px;
+  }
 
-    .row {
-        margin: 10px 0;
-    }
+  .row {
+    margin: 10px 0;
+  }
 
 }
 
 #attendance {
-    select[multiple] {
-        height: 425px;
-    }
+  select[multiple] {
+    height: 425px;
+  }
 }

--- a/assets/dashboard/groups/less/groups.less
+++ b/assets/dashboard/groups/less/groups.less
@@ -1,5 +1,4 @@
 #group_users_available {
-  scroll: auto;
   height: 100px;
   width: 300px;
 }

--- a/assets/dashboard/groups/less/groups.less
+++ b/assets/dashboard/groups/less/groups.less
@@ -1,5 +1,5 @@
 #group_users_available {
-    scroll: auto;
-    height: 100px;
-    width: 300px;
+  scroll: auto;
+  height: 100px;
+  width: 300px;
 }

--- a/assets/dashboard/marks/less/marks.less
+++ b/assets/dashboard/marks/less/marks.less
@@ -1,30 +1,30 @@
 .marks_table_splitter {
-	border-right: 1px solid #dddddd;
+  border-right: 1px solid #ddd;
 }
 
 .twitter-typeahead {
-    width: 100%;
+  width: 100%;
 }
 
 .tt-suggestions {
-    margin-top: -1px;
-    width: 300px;
-    border: 1px solid #66afe9;
-    border-radius: 4px;
-    box-shadow: inset 0 1px 1px rgba(0,0,0,0.075), 0 0 8px rgba(102, 175, 266, 0.6);
-    background-color: #fff;
+  margin-top: -1px;
+  width: 300px;
+  border: 1px solid #66afe9;
+  border-radius: 4px;
+  box-shadow: inset 0 1px 1px rgba(0,0,0,0.075), 0 0 8px rgba(102, 175, 266, 0.6);
+  background-color: #fff;
 
-    .user-meta h4 {
-        font-size: 14px;
-        padding-left: 5px;
-        line-height: 20px;
-        margin-top: 5px;
-        margin-bottom: 5px;
-    }
+  .user-meta h4 {
+    font-size: 14px;
+    padding-left: 5px;
+    line-height: 20px;
+    margin-top: 5px;
+    margin-bottom: 5px;
+  }
 
-    .user-meta h4:hover {
-        background-color: #eee;
-    }
+  .user-meta h4:hover {
+    background-color: #eee;
+  }
 }
 
 .tt-hint { display: none; }

--- a/assets/dashboard/marks/less/marks.less
+++ b/assets/dashboard/marks/less/marks.less
@@ -11,7 +11,7 @@
   width: 300px;
   border: 1px solid #66afe9;
   border-radius: 4px;
-  box-shadow: inset 0 1px 1px rgba(0,0,0,0.075), 0 0 8px rgba(102, 175, 266, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 266, 0.6);
   background-color: #fff;
 
   .user-meta h4 {

--- a/assets/dashboard/posters/less/posters.less
+++ b/assets/dashboard/posters/less/posters.less
@@ -1,23 +1,23 @@
 .form-group
 {
-    padding-bottom: 30px;
+  padding-bottom: 30px;
 }
 
 #id_description{
-    height: 130px;
+  height: 130px;
 }
 
 .event-hero-title, h5{
-    font-weight: bold;
-    font-size: 1.5em;
+  font-weight: bold;
+  font-size: 1.5em;
 }
 
 .event-hero-large-text {
-    padding: 20px 5px;
-    font-size: 1.1em;
+  padding: 20px 5px;
+  font-size: 1.1em;
 }
 
 .event-hero-meta .row {
-    border-bottom: 1px solid rgba(0,0,0,0.1);
-    margin-bottom: 15px;
+  border-bottom: 1px solid rgba(0,0,0,0.1);
+  margin-bottom: 15px;
 }

--- a/assets/dashboard/posters/less/posters.less
+++ b/assets/dashboard/posters/less/posters.less
@@ -1,13 +1,12 @@
-.form-group
-{
+.form-group {
   padding-bottom: 30px;
 }
 
-#id_description{
+#id_description {
   height: 130px;
 }
 
-.event-hero-title, h5{
+.event-hero-title, h5 {
   font-weight: bold;
   font-size: 1.5em;
 }
@@ -18,6 +17,6 @@
 }
 
 .event-hero-meta .row {
-  border-bottom: 1px solid rgba(0,0,0,0.1);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
   margin-bottom: 15px;
 }

--- a/assets/events/archive/less/event_archive.less
+++ b/assets/events/archive/less/event_archive.less
@@ -1,90 +1,107 @@
 @import "~common/less/colors.less";
 
 #filter {
-    background: @baby-blue-medium;
-    padding: 10px;
-    color: #FFF;
-    margin-bottom: 20px;
-    float: right;
-    input[type="text"] {
-        width: 100%;
-    }
-}
-#events {
-    #filter .input-group {
-        margin-bottom: 10px;
-        float: left;
-        input {
-            font-size: 12px;
-            border-radius: 15px;
-        }
-    }
-    .ingress {
-      margin-bottom: 10px;
-      line-height: 1.625em;
-    }
-    article {
-        margin-bottom: 40px;
-        padding-bottom: 30px;
-        /*border-bottom: 1px dotted #ccc;*/
-        /*position: relative;*/
+  background: @baby-blue-medium;
+  padding: 10px;
+  color: #fff;
+  margin-bottom: 20px;
+  float: right;
 
-        button {
-            width: 100%;
-            margin: 2px 0 0 0;
-            border-radius: 0px 0px 0px 0px;
-        }
-        img {
-            width: 100%;
-        }
-        .content {
-            /*position: absolute;
+  input[type="text"] {
+    width: 100%;
+  }
+}
+
+#events {
+  #filter .input-group {
+    margin-bottom: 10px;
+    float: left;
+
+    input {
+      font-size: 12px;
+      border-radius: 15px;
+    }
+  }
+
+  .ingress {
+    margin-bottom: 10px;
+    line-height: 1.625em;
+  }
+
+  article {
+    margin-bottom: 40px;
+    padding-bottom: 30px;
+
+    /*border-bottom: 1px dotted #ccc;*/
+
+    /*position: relative;*/
+
+    button {
+      width: 100%;
+      margin: 2px 0 0 0;
+      border-radius: 0 0 0 0;
+    }
+
+    img {
+      width: 100%;
+    }
+
+    .content {
+      /*position: absolute;
       top: 0;
       left: 260px;*/
-        }
-        h1 {
-            font-size: 20px;
-            font-weight: 400;
-            color: #ee7810;
-            margin-top: 0;
-        }
-        span {
-            margin: 0 8px 0 0;
-            font-size: 18px;
-            color: #5bc0de;
-            /*color: #888;*/
-
-            text-transform: uppercase;
-            font-weight: 400;
-            color: #ee7810;
-            float: right;
-        }
-        .meta {
-            padding: 5px 0 0 0;
-            width: 100%;
-            border-top: 1px dotted #ccc;
-            font-size: 11px;
-            font-weight: normal;
-            /*text-align: left;*/
-
-            p {
-                color: #aaa;
-            }
-        }
-        @media (max-width: 989px) {
-            h1 {
-                font-size: 18px;
-            }
-            span {
-                float: left;
-                font-size: 14px;
-                margin-bottom: 10px;
-            }
-        }
-        @media (max-width: 767px) {
-            h1 {
-                margin-top: 15px;
-            }
-        }
     }
+
+    h1 {
+      font-size: 20px;
+      font-weight: 400;
+      color: #ee7810;
+      margin-top: 0;
+    }
+
+    span {
+      margin: 0 8px 0 0;
+      font-size: 18px;
+      color: #5bc0de;
+
+      /*color: #888;*/
+
+      text-transform: uppercase;
+      font-weight: 400;
+      color: #ee7810;
+      float: right;
+    }
+
+    .meta {
+      padding: 5px 0 0 0;
+      width: 100%;
+      border-top: 1px dotted #ccc;
+      font-size: 11px;
+      font-weight: normal;
+
+      /*text-align: left;*/
+
+      p {
+        color: #aaa;
+      }
+    }
+
+    @media (max-width: 989px) {
+      h1 {
+        font-size: 18px;
+      }
+
+      span {
+        float: left;
+        font-size: 14px;
+        margin-bottom: 10px;
+      }
+    }
+
+    @media (max-width: 767px) {
+      h1 {
+        margin-top: 15px;
+      }
+    }
+  }
 }

--- a/assets/events/archive/less/event_archive.less
+++ b/assets/events/archive/less/event_archive.less
@@ -62,10 +62,6 @@
     span {
       margin: 0 8px 0 0;
       font-size: 18px;
-      color: #5bc0de;
-
-      /*color: #888;*/
-
       text-transform: uppercase;
       font-weight: 400;
       color: #ee7810;

--- a/assets/events/details/less/event_details.less
+++ b/assets/events/details/less/event_details.less
@@ -1,221 +1,272 @@
 @import "~common/less/colors.less";
 
 section#event-details {
-    .event-details-single-image{
-      position: relative;
-    }
-    .event-details-image-credits{
-      position: absolute;
-      bottom: 0;
-      padding: 3px 7px;
-      background-color: rgba(0, 0, 0, 0.57);
-      color: white;
-      margin: 0;
-    }
-    .row-space {
-        margin-bottom: 30px;
-        @media screen and (max-width: 767px) {
-            margin-bottom: 0px;
-        }
-    }
-    .event-hero {
-        color: #FFF;
-        .event-hero-duration {
-            background-color: @arrkom-color;
-            font-weight: 300;
-            font-size: 20px;
-            text-align: center;
-            padding: 20px;
-            @media screen and (max-width: 767px) {
-                padding: 0px;
-                margin-bottom: 0px;
-            }
-            .start-day {
-                width: 100%;
-                display: block;
-                font-size: 28px;
-                color: @arrkom-color;
-                font-weight: 600;
-                margin-bottom: 10px;
-                .start-day-number {
-                    padding: 7px;
-                    background: white;
-                }
-            }
-            .start-month {
-                width: 100%;
-                display: block;
-                font-weight: 300;
-                font-size: 20px;
-                text-transform: uppercase;
-                .start-month-text {
-                    padding: 9px;
-                }
-            }
-            .start-year {
-                width: 100%;
-                font-weight: 300;
-                font-size: 14px;
-            }
-        }
-    }
-    .event-hero-meta {
-        color: #FFF;
-        background-color: #49A0CC;
-        padding: 20px;
-        @media screen and (max-width: 767px) {
-            padding-top: 20px;
-            padding-bottom: 0px;
-        }
-        text-align:center;
-        .event-hero-meta-info {
-            padding-bottom: 50px;
-            @media screen and (max-width: 767px) {
-                padding-bottom: 20px;
-            }
-            .event-hero-title {
-                font-size: 14px;
-                font-weight: 600;
-                /*color:#FFE5BD;*/
+  .event-details-single-image{
+    position: relative;
+  }
 
-                color: #FFD2A5;
-                /*color:#FF5A42;*/
-                /*color:#AEE50B;*/
-                /*color:#B0E59F;*/
-                /*color:#a1d40a;*/
+  .event-details-image-credits{
+    position: absolute;
+    bottom: 0;
+    padding: 3px 7px;
+    background-color: rgba(0, 0, 0, 0.57);
+    color: white;
+    margin: 0;
+  }
 
-                text-transform: uppercase;
-            }
-            .event-hero-large-text {
-                font-size: 28px;
-                font-weight: 300;
-                .break {
-                    width: 100%;
-                    display: block;
-                    margin-bottom: -15px;
-                }
-                .date-small {
-                    font-size: 13px;
-                }
-            }
-            .event-hero-small-text {
-                font-weight: 300;
-                font-size: 20px;
-                margin-bottom: 9px;
-            }
-        }
+  .row-space {
+    margin-bottom: 30px;
+
+    @media screen and (max-width: 767px) {
+      margin-bottom: 0;
     }
-    .event-status {
-        color: white;
-        background: #EE974F;
-        padding: 20px;
+  }
+
+  .event-hero {
+    color: #fff;
+
+    .event-hero-duration {
+      background-color: @arrkom-color;
+      font-weight: 300;
+      font-size: 20px;
+      text-align: center;
+      padding: 20px;
+
+      @media screen and (max-width: 767px) {
+        padding: 0;
+        margin-bottom: 0;
+      }
+
+      .start-day {
+        width: 100%;
+        display: block;
+        font-size: 28px;
+        color: @arrkom-color;
+        font-weight: 600;
+        margin-bottom: 10px;
+
+        .start-day-number {
+          padding: 7px;
+          background: white;
+        }
+      }
+
+      .start-month {
+        width: 100%;
+        display: block;
         font-weight: 300;
-        text-align: center;
-        .btn {
-            /*border-color: rgba(0, 0, 0, 0);*/
-            border-radius: 2px;
-        }
-        .event-status-region {
-            margin-bottom: 20px;
-        }
-        .status-text {
-            font-size: 18px;
-        }
-        .status-rules {
-            .status-rules-heading {
-                font-size: 12px;
-                font-weight: 600;
-                text-transform: uppercase;
-            }
-            span {
-                margin-right: 5px;
-            }
-            li {
-                list-style-type: none;
-            }
-        }
-        .extras{
-            margin: 0 0 11px 0;
-            .extras-text{
-                font-size: 1.1em;
-                font-weight: 400;
-            }
-            .extras-choice{
-                width: auto;
-                margin-left: auto;
-                margin-right: auto;
-                border-radius: 2px;
-                border: none;
-            }
-        }
-        p {
-            color: white;
-        }
-    }
-    @media (min-width: 992px) {
-        .event-status-container {
-            float: right;
-        }
-        .event-status-companies-container {
-            float: right;
-            clear: right;
-        }
-    }
-    .event-status-extra {
-        padding: 10px 20px 0px 20px;
-        text-align: center;
-        /*background:#FF8874;*/
+        font-size: 20px;
+        text-transform: uppercase;
 
-        background: #ffBe8b;
-        color: white;
-        p {
-            color: white;
+        .start-month-text {
+          padding: 9px;
         }
+      }
+
+      .start-year {
+        width: 100%;
+        font-weight: 300;
+        font-size: 14px;
+      }
     }
-    .event-status-companies {
-        .title {
-            font-size: 22px;
-            font-weight: 300;
-            margin-bottom: 20px;
-            padding-bottom: 10px;
-            border-bottom: 1px solid #EBEBEB;
+  }
+
+  .event-hero-meta {
+    color: #fff;
+    background-color: #49a0cc;
+    padding: 20px;
+
+    @media screen and (max-width: 767px) {
+      padding-top: 20px;
+      padding-bottom: 0;
+    }
+
+    text-align:center;
+
+    .event-hero-meta-info {
+      padding-bottom: 50px;
+
+      @media screen and (max-width: 767px) {
+        padding-bottom: 20px;
+      }
+
+      .event-hero-title {
+        font-size: 14px;
+        font-weight: 600;
+
+        /*color:#FFE5BD;*/
+
+        color: #ffd2a5;
+
+        /*color:#FF5A42;*/
+
+        /*color:#AEE50B;*/
+
+        /*color:#B0E59F;*/
+
+        /*color:#a1d40a;*/
+
+        text-transform: uppercase;
+      }
+
+      .event-hero-large-text {
+        font-size: 28px;
+        font-weight: 300;
+
+        .break {
+          width: 100%;
+          display: block;
+          margin-bottom: -15px;
         }
-        .heading {
-            .title {
-                float: left;
-                font-weight: 300;
-                line-height: 65px;
-                font-size: 20px;
-                margin: 0;
-                border: none;
-            }
-            .image {
-                float: right;
-            }
+
+        .date-small {
+          font-size: 13px;
         }
+      }
+
+      .event-hero-small-text {
+        font-weight: 300;
+        font-size: 20px;
+        margin-bottom: 9px;
+      }
     }
-    .event-access {
-        padding: 10px;
-        margin-bottom: 20px;
-        background: #D6EAFF;
-        text-align: center;
-        .access-title {
-            color: @heading;
-            font-size: 15px;
-            font-weight: 300;
-            text-align: center;
-        }
-        .label-info {
-            line-height: 21px;
-        }
+  }
+
+  .event-status {
+    color: white;
+    background: #ee974f;
+    padding: 20px;
+    font-weight: 300;
+    text-align: center;
+
+    .btn {
+      /*border-color: rgba(0, 0, 0, 0);*/
+      border-radius: 2px;
     }
-    .payment-price-tag {
-        margin-bottom: 10px;
+
+    .event-status-region {
+      margin-bottom: 20px;
     }
-    .payment-button {
-        margin-bottom: 10px;
+
+    .status-text {
+      font-size: 18px;
     }
-    .event-image {
-      width: 100%;
+
+    .status-rules {
+      .status-rules-heading {
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+      }
+
+      span {
+        margin-right: 5px;
+      }
+
+      li {
+        list-style-type: none;
+      }
     }
+
+    .extras{
+      margin: 0 0 11px 0;
+
+      .extras-text{
+        font-size: 1.1em;
+        font-weight: 400;
+      }
+
+      .extras-choice{
+        width: auto;
+        margin-left: auto;
+        margin-right: auto;
+        border-radius: 2px;
+        border: none;
+      }
+    }
+
+    p {
+      color: white;
+    }
+  }
+
+  @media (min-width: 992px) {
+    .event-status-container {
+      float: right;
+    }
+
+    .event-status-companies-container {
+      float: right;
+      clear: right;
+    }
+  }
+
+  .event-status-extra {
+    padding: 10px 20px 0 20px;
+    text-align: center;
+
+    /*background:#FF8874;*/
+
+    background: #ffbe8b;
+    color: white;
+
+    p {
+      color: white;
+    }
+  }
+
+  .event-status-companies {
+    .title {
+      font-size: 22px;
+      font-weight: 300;
+      margin-bottom: 20px;
+      padding-bottom: 10px;
+      border-bottom: 1px solid #ebebeb;
+    }
+
+    .heading {
+      .title {
+        float: left;
+        font-weight: 300;
+        line-height: 65px;
+        font-size: 20px;
+        margin: 0;
+        border: none;
+      }
+
+      .image {
+        float: right;
+      }
+    }
+  }
+
+  .event-access {
+    padding: 10px;
+    margin-bottom: 20px;
+    background: #d6eaff;
+    text-align: center;
+
+    .access-title {
+      color: @heading;
+      font-size: 15px;
+      font-weight: 300;
+      text-align: center;
+    }
+
+    .label-info {
+      line-height: 21px;
+    }
+  }
+
+  .payment-price-tag {
+    margin-bottom: 10px;
+  }
+
+  .payment-button {
+    margin-bottom: 10px;
+  }
+
+  .event-image {
+    width: 100%;
+  }
 }

--- a/assets/events/details/less/event_details.less
+++ b/assets/events/details/less/event_details.less
@@ -1,11 +1,11 @@
 @import "~common/less/colors.less";
 
 section#event-details {
-  .event-details-single-image{
+  .event-details-single-image {
     position: relative;
   }
 
-  .event-details-image-credits{
+  .event-details-image-credits {
     position: absolute;
     bottom: 0;
     padding: 3px 7px;
@@ -81,7 +81,7 @@ section#event-details {
       padding-bottom: 0;
     }
 
-    text-align:center;
+    text-align: center;
 
     .event-hero-meta-info {
       padding-bottom: 50px;
@@ -168,15 +168,15 @@ section#event-details {
       }
     }
 
-    .extras{
+    .extras {
       margin: 0 0 11px 0;
 
-      .extras-text{
+      .extras-text {
         font-size: 1.1em;
         font-weight: 400;
       }
 
-      .extras-choice{
+      .extras-choice {
         width: auto;
         margin-left: auto;
         margin-right: auto;

--- a/assets/feedback/less/feedback.less
+++ b/assets/feedback/less/feedback.less
@@ -3,156 +3,167 @@
 
 
 .feedback-answer-label label {
-    font-size:20px;
-    margin-top:10px;
+  font-size:20px;
+  margin-top:10px;
 }
 
 #feedbackanswer {
-    h2 {
-        text-transform: uppercase;
-    }
+  h2 {
+    text-transform: uppercase;
+  }
 }
 
 #feedback{
-    label {
-        display: block;
-        clear: both;
+  label {
+    display: block;
+    clear: both;
+  }
+
+  ul {
+    margin-left: 0;
+    padding-left: 0;
+  }
+
+  li {
+    list-style: none;
+    float: left;
+    margin-left: 0;
+  }
+
+  select {
+    width: 50%;
+  }
+
+  div{ /*TODO, create clearfix mixin*/
+    *zoom: 1;
+
+    &:before,
+    &:after {
+      display: table;
+      content: "";
     }
 
-    ul {
-        margin-left: 0px;
-        padding-left: 0px;
+    &:after {
+      clear: both;
     }
-    li {
-        list-style: none;
-        float: left;
-        margin-left: 0px;
-    }
-    select {
-        width: 50%;
-    }
-    div{ /*TODO, create clearfix mixin*/
-        *zoom: 1;
-        &:before,
-        &:after {
-            display: table;
-            content: "";
-        }
-        &:after {
-            clear: both;
-        }
-    }
+  }
 }
 
 .control-label {
-    font-size:18px;
+  font-size:18px;
 }
 
 .barChartText {
-    stroke:@heading;
-    fill:@heading;
-    font-size:20px;
+  stroke:@heading;
+  fill:@heading;
+  font-size:20px;
 }
 
 #feedback-results
 {
-    .rating-chart
+  .rating-chart
     {
-        margin-bottom: 25px;
-        margin-left: -10px;
-    }
-    .panel-heading
-    {
-        font-weight: 600;
-        color: #004b80;
-    }
-    .answer:hover
-    {
-        cursor: pointer;
-        //border-style:outset;
-    }
-    .answer:hover .icon
-    {
-        visibility:visible;
-    }
+    margin-bottom: 25px;
+    margin-left: -10px;
+  }
 
-    .icon
+  .panel-heading
     {
-        visibility: hidden;
-        color: red;
-        padding-right: 10px;
-    }
+    font-weight: 600;
+    color: #004b80;
+  }
+
+  .answer:hover
+    {
+    cursor: pointer;
+    //border-style:outset;
+  }
+
+  .answer:hover .icon
+    {
+    visibility:visible;
+  }
+
+  .icon
+    {
+    visibility: hidden;
+    color: red;
+    padding-right: 10px;
+  }
 
 }
 
 .errorlist
 {
-    color: red;
-    margin-bottom: 30px;
+  color: red;
+  margin-bottom: 30px;
 }
 
 .whitespaceFix:nth-child(even)
 {
-    float: right;
+  float: right;
 }
 
 .infonumber
 {
-    font-size: 14px;
-    font-weight: 600;
-    color: #004b80;
-    float: right;
+  font-size: 14px;
+  font-weight: 600;
+  color: #004b80;
+  float: right;
 }
 
 @media (max-width:1000px) {
-
-    #feedback{
-        textarea{
-            width: 100%;
-        }
-        select{
-            width: 100%;
-        }
+  #feedback{
+    textarea{
+      width: 100%;
     }
+
+    select{
+      width: 100%;
+    }
+  }
 }
 
 
 .rating-wrapper {
-    .br-widget {
-        height: 52px;
+  .br-widget {
+    height: 52px;
+  }
+
+  .br-widget {
+    a {
+      display: block;
+      width: 35px;
+      height: 35px;
+      float: left;
+      background-color: #e3e3e3;
+      margin: 2px;
+      text-decoration: none;
+      font-size: 16px;
+      font-weight: 400;
+      line-height: 2.2;
+      text-align: center;
+      color: #b6b6b6;
     }
-    .br-widget {
-        a {
-            display: block;
-            width: 35px;
-            height: 35px;
-            float: left;
-            background-color: #e3e3e3;
-            margin: 2px;
-            text-decoration: none;
-            font-size: 16px;
-            font-weight: 400;
-            line-height: 2.2;
-            text-align: center;
-            color: #b6b6b6;
-        }
-        a.br-active, a.br-selected {
-            background-color: #59a6d6;
-            color: white;
-        }
+
+    a.br-active, a.br-selected {
+      background-color: #59a6d6;
+      color: white;
     }
+  }
 }
+
 @media screen and(max-width: @media-desktop-min) {
-    .br-widget {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        flex-direction: row;
-    }
+  .br-widget {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: row;
+  }
 }
 
 .rating-wrapper .br-widget a.br-active,
 .rating-wrapper .br-widget a.br-selected {
-    background-color: #59a6d6;
-    color: white;
+  background-color: #59a6d6;
+  color: white;
 }

--- a/assets/feedback/less/feedback.less
+++ b/assets/feedback/less/feedback.less
@@ -1,10 +1,9 @@
 @import "~common/less/responsive-variables.less";
 @import "~common/less/colors.less";
 
-
 .feedback-answer-label label {
-  font-size:20px;
-  margin-top:10px;
+  font-size: 20px;
+  margin-top: 10px;
 }
 
 #feedbackanswer {
@@ -13,7 +12,7 @@
   }
 }
 
-#feedback{
+#feedback {
   label {
     display: block;
     clear: both;
@@ -34,103 +33,90 @@
     width: 50%;
   }
 
-  div{ /*TODO, create clearfix mixin*/
+  div { /*TODO, create clearfix mixin*/
     *zoom: 1;
 
-    &:before,
-    &:after {
+    &::before,
+    &::after {
       display: table;
       content: "";
     }
 
-    &:after {
+    &::after {
       clear: both;
     }
   }
 }
 
 .control-label {
-  font-size:18px;
+  font-size: 18px;
 }
 
 .barChartText {
-  stroke:@heading;
-  fill:@heading;
-  font-size:20px;
+  stroke: @heading;
+  fill: @heading;
+  font-size: 20px;
 }
 
-#feedback-results
-{
-  .rating-chart
-    {
+#feedback-results {
+  .rating-chart {
     margin-bottom: 25px;
     margin-left: -10px;
   }
 
-  .panel-heading
-    {
+  .panel-heading {
     font-weight: 600;
     color: #004b80;
   }
 
-  .answer:hover
-    {
-    cursor: pointer;
-    //border-style:outset;
-  }
-
-  .answer:hover .icon
-    {
-    visibility:visible;
-  }
-
-  .icon
-    {
+  .icon {
     visibility: hidden;
     color: red;
     padding-right: 10px;
   }
 
+  .answer:hover {
+    cursor: pointer;
+    //border-style:outset;
+  }
+
+  .answer:hover .icon {
+    visibility: visible;
+  }
 }
 
-.errorlist
-{
+.errorlist {
   color: red;
   margin-bottom: 30px;
 }
 
-.whitespaceFix:nth-child(even)
-{
+.whitespaceFix:nth-child(even) {
   float: right;
 }
 
-.infonumber
-{
+.infonumber {
   font-size: 14px;
   font-weight: 600;
   color: #004b80;
   float: right;
 }
 
-@media (max-width:1000px) {
-  #feedback{
-    textarea{
+@media (max-width: 1000px) {
+  #feedback {
+    textarea {
       width: 100%;
     }
 
-    select{
+    select {
       width: 100%;
     }
   }
 }
 
-
 .rating-wrapper {
   .br-widget {
     height: 52px;
-  }
 
-  .br-widget {
     a {
       display: block;
       width: 35px;

--- a/assets/feedback/less/feedback.less
+++ b/assets/feedback/less/feedback.less
@@ -147,9 +147,3 @@
     flex-direction: row;
   }
 }
-
-.rating-wrapper .br-widget a.br-active,
-.rating-wrapper .br-widget a.br-selected {
-  background-color: #59a6d6;
-  color: white;
-}

--- a/assets/genfors/less/genfors.less
+++ b/assets/genfors/less/genfors.less
@@ -1,29 +1,33 @@
 @import "~bootstrap/less/variables.less";
 
 #generalforsamling {
-    span.label {
-        padding-top: 3px;
-        padding-bottom: 3px;
-        padding-left: 5px;
-        padding-right: 5px;
-    }
+  span.label {
+    padding-top: 3px;
+    padding-bottom: 3px;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
 
-    #stemmer > ul > li {
-        margin-left: -15px;
-    }
-    p#bg-danger {
-        color: @btn-danger-color;
-        background-color: @btn-danger-bg;
-        border-radius: 5px;
-        padding: 5px;
-    }
-    .panel-bottom {
-        padding: 0px;
-    }
-    .p-blank {
-        margin-top: 50px;
-    }
-    .avsluttede-saker {
-        white-space: nowrap;
-    }
+  #stemmer > ul > li {
+    margin-left: -15px;
+  }
+
+  p#bg-danger {
+    color: @btn-danger-color;
+    background-color: @btn-danger-bg;
+    border-radius: 5px;
+    padding: 5px;
+  }
+
+  .panel-bottom {
+    padding: 0;
+  }
+
+  .p-blank {
+    margin-top: 50px;
+  }
+
+  .avsluttede-saker {
+    white-space: nowrap;
+  }
 }

--- a/assets/hobbygroups/less/hobbygroups.less
+++ b/assets/hobbygroups/less/hobbygroups.less
@@ -1,7 +1,3 @@
-/* Vars */
-
-/* HobbyGroups */
-
 #hobbygroups {
   .hobbydescription {
     margin-bottom: 20px;

--- a/assets/hobbygroups/less/hobbygroups.less
+++ b/assets/hobbygroups/less/hobbygroups.less
@@ -1,20 +1,23 @@
 /* Vars */
+
 /* HobbyGroups */
 
 #hobbygroups {
-    .hobbydescription {
-        margin-bottom: 20px;
-    }
-    img {
-        margin-bottom: 20px;
-        width: 100%;
-        height: auto;
-    }
-    h3 {
-        margin-top: 0px;
-    }
+  .hobbydescription {
+    margin-bottom: 20px;
+  }
+
+  img {
+    margin-bottom: 20px;
+    width: 100%;
+    height: auto;
+  }
+
+  h3 {
+    margin-top: 0;
+  }
 }
 
 #introduction {
-    margin-bottom: 40px;
+  margin-bottom: 40px;
 }

--- a/assets/mailinglists/less/mailinglists.less
+++ b/assets/mailinglists/less/mailinglists.less
@@ -1,22 +1,23 @@
 #map {
-    text-align: center;
-    margin: 10px 0 15px 0;
-    width: 100%;
-    min-width: 300px;
-    max-width: 700px;
+  text-align: center;
+  margin: 10px 0 15px 0;
+  width: 100%;
+  min-width: 300px;
+  max-width: 700px;
 }
 
 #mailinglist-items {
-    width: 100%;
+  width: 100%;
 
-    .mailinglist {
-        margin-bottom: 25px;
+  .mailinglist {
+    margin-bottom: 25px;
 
-        .title {
-			cursor: pointer;
-            font-weight: bold;
-    	}
-    	.members {
-    	}
+    .title {
+      cursor: pointer;
+      font-weight: bold;
     }
+
+    .members {
+    }
+  }
 }

--- a/assets/mailinglists/less/mailinglists.less
+++ b/assets/mailinglists/less/mailinglists.less
@@ -16,8 +16,5 @@
       cursor: pointer;
       font-weight: bold;
     }
-
-    .members {
-    }
   }
 }

--- a/assets/profiles/less/profiles.less
+++ b/assets/profiles/less/profiles.less
@@ -276,54 +276,61 @@ section#user-search {
     margin-bottom: 20px;
   }
 
-  /* all links */
+  .sidebar .nav {
+    /* all links */
+    & > li > a {
+      color: #999;
+      padding: 4px 20px;
+      font-size: 13px;
+      font-weight: 400;
+    }
 
-  .sidebar .nav>li>a {
-    color: #999;
-    padding: 4px 20px;
-    font-size: 13px;
-    font-weight: 400;
-  }
+    & > .active > a {
+      color: @baby-blue;
+      text-decoration: none;
+      background-color: transparent;
+      border-left-color: @baby-blue;
+      font-weight: 700;
+    }
 
-  /* nested links */
+    /* active & hover links */
+    & > li > a:hover, & > li > a:focus {
+      color: @baby-blue;
+      text-decoration: none;
+      background-color: transparent;
+      border-left-color: @baby-blue;
+    }
 
-  .sidebar .nav .nav>li>a {
-    padding-top: 1px;
-    padding-bottom: 1px;
-    padding-left: 30px;
-    font-size: 12px;
-  }
+    /* hide inactive nested list */
+    ul.nav {
+      display: none;
+    }
 
-  /* active & hover links */
+    /* nested links */
+    .nav > li > a {
+      padding-top: 1px;
+      padding-bottom: 1px;
+      padding-left: 30px;
+      font-size: 12px;
+    }
 
-  .sidebar .nav>.active>a, .sidebar .nav>li>a:hover, .sidebar .nav>li>a:focus {
-    color: @baby-blue;
-    text-decoration: none;
-    background-color: transparent;
-    border-left-color: @baby-blue;
-  }
+    /* all active links */
+    & > .active {
+      &:hover > a, &:focus > a {
+        font-weight: 700;
+      }
 
-  /* all active links */
+      /* show active nested list */
+      & > ul.nav {
+        display: block;
+      }
+    }
 
-  .sidebar .nav>.active>a, .sidebar .nav>.active:hover>a, .sidebar .nav>.active:focus>a {
-    font-weight: 700;
-  }
-
-  /* nested active links */
-
-  .sidebar .nav .nav>.active>a, .sidebar .nav .nav>.active:hover>a, .sidebar .nav .nav>.active:focus>a {
-    font-weight: 500;
-  }
-
-  /* hide inactive nested list */
-
-  .sidebar .nav ul.nav {
-    display: none;
-  }
-
-  /* show active nested list */
-
-  .sidebar .nav>.active>ul.nav {
-    display: block;
+    /* nested active links */
+    .nav > .active {
+      a, &:hover a, &:focus a {
+        font-weight: 500;
+      }
+    }
   }
 }

--- a/assets/profiles/less/profiles.less
+++ b/assets/profiles/less/profiles.less
@@ -10,264 +10,318 @@
 @image-width-with-padding: 238px;
 
 .word-break {
-    word-break: normal;
+  word-break: normal;
 }
+
 input.hidden-input {
-    display: none;
+  display: none;
 }
+
 .hidden-input {
-    display: none;
+  display: none;
 }
+
 #allergies {
-    height: 50px;
+  height: 50px;
 }
+
 #bio {
-    height: 340px;
-    .bio;
+  height: 340px;
+  .bio;
 }
+
 #compiled {
-    margin-bottom: 10px;
+  margin-bottom: 10px;
 }
+
 #gender {
-    margin-bottom: 8px;
+  margin-bottom: 8px;
 }
+
 .bio {
-    overflow-y: auto;
-    white-space: pre-wrap;
+  overflow-y: auto;
+  white-space: pre-wrap;
 }
+
 i.btn-icon {
-    .pull-left;
-    margin-top: 4px;
+  .pull-left;
+
+  margin-top: 4px;
 }
+
 button > i.btn-icon {
-    margin-left: 10px;
+  margin-left: 10px;
 }
+
 label > i.btn-icon {
-    margin-left: 22px;
+  margin-left: 22px;
 }
+
 #paddingtop {
-    padding-top: 20px;
+  padding-top: 20px;
 }
+
 .header-inline {
-    display: inline-block;
-    padding-right: 10px;
+  display: inline-block;
+  padding-right: 10px;
 }
+
 .glyphicon-info-sign {
-    font-size: 14px;
+  font-size: 14px;
 }
+
 #privacy-help, #image-help {
-    cursor: pointer;
+  cursor: pointer;
 }
+
 .privacybox {
-    background-color: @baby-blue;
-    color: #fff;
-    width: 250px;
-    height: 75px;
-    line-height: 75px;
-    text-align: center;
-    margin: 0px 20px 20px 0px;
-    padding: 0px 5px 5px 0px;
-    font-size: 1.5em;
-    border-style: solid;
-    border-width: 1px;
-    border-radius: 4px;
+  background-color: @baby-blue;
+  color: #fff;
+  width: 250px;
+  height: 75px;
+  line-height: 75px;
+  text-align: center;
+  margin: 0 20px 20px 0;
+  padding: 0 5px 5px 0;
+  font-size: 1.5em;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 4px;
 
-    /* Make text non-selectable */
+  /* Make text non-selectable */
 
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: -moz-none;
-    -ms-user-select: none;
-    user-select: none;
-    span {
-        display: inline-block;
-        vertical-align: middle;
-        color: 111;
-        line-height: normal;
-    }
-    &.on {
-        .button-variant(@btn-success-color;
-        @btn-success-bg;
-        @btn-success-border);
-    }
-    &.off {
-        .button-variant(@btn-warning-color;
-        @btn-warning-bg;
-        @btn-warning-border);
-    }
-    input[type="checkbox"] {
-        display: none;
-    }
-}
-.privacybox:hover {
-    cursor: pointer;
-}
-.panel-heading:hover {
-    cursor: pointer;
-}
-.mark, .application {
-    padding-top: 10px;
-}
-.markheader, .applicationheader {
-    font-weight: bold;
-    font-size: 17px;
-    padding-bottom: 5px;
-}
-.markbody, .applicationbody {
-    background-color: white;
-    padding-left: 10px;
-}
-.markbody .inline .row-fluid [class*="span"] {
-    min-height: 15px;
-}
-.panel-heading {
-    padding: 1px 15px;
-}
-.marks.on {
-    width: 100%;
-    .btn;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: -moz-none;
+  -ms-user-select: none;
+  user-select: none;
+
+  span {
+    display: inline-block;
+    vertical-align: middle;
+    color: 111;
+    line-height: normal;
+  }
+
+  &.on {
     .button-variant(@btn-success-color;
     @btn-success-bg;
     @btn-success-border);
-}
-.marks.on:after {
-    content: "Jeg har godtatt prikkereglene og er inneforstått med hva dette betyr."
-}
-.marks.off {
-    width: 100%;
-    .btn;
+  }
+
+  &.off {
     .button-variant(@btn-warning-color;
     @btn-warning-bg;
     @btn-warning-border);
+  }
+
+  input[type="checkbox"] {
+    display: none;
+  }
 }
+
+.privacybox:hover {
+  cursor: pointer;
+}
+
+.panel-heading:hover {
+  cursor: pointer;
+}
+
+.mark, .application {
+  padding-top: 10px;
+}
+
+.markheader, .applicationheader {
+  font-weight: bold;
+  font-size: 17px;
+  padding-bottom: 5px;
+}
+
+.markbody, .applicationbody {
+  background-color: white;
+  padding-left: 10px;
+}
+.markbody .inline .row-fluid [class*="span"] {
+  min-height: 15px;
+}
+
+.panel-heading {
+  padding: 1px 15px;
+}
+
+.marks.on {
+  width: 100%;
+  .btn;
+  .button-variant(@btn-success-color;
+  @btn-success-bg;
+  @btn-success-border);
+}
+
+.marks.on:after {
+  content: "Jeg har godtatt prikkereglene og er inneforstått med hva dette betyr."
+}
+
+.marks.off {
+  width: 100%;
+  .btn;
+  .button-variant(@btn-warning-color;
+  @btn-warning-bg;
+  @btn-warning-border);
+}
+
 .marks.off:after {
-    content: "Jeg godtar prikkereglene og er inneforstått med hva dette betyr."
+  content: "Jeg godtar prikkereglene og er inneforstått med hva dette betyr."
 }
+
 textarea, input[type="text"], input[type="email"], input[type="url"], input[type="number"] {
-    .form-control;
-    margin-bottom: 7px;
+  .form-control;
+
+  margin-bottom: 7px;
 }
+
 textarea {
-    resize: vertical;
+  resize: vertical;
 }
+
 @media all and (max-width: @screen-sm-max) {
-    .privacybox {
-        width: 100%;
-    }
-    .attribute-list [class^='col-'] {
-        margin-bottom: 10px;
-    }
-    .img-thumbnail {
-        margin-top: 20px;
-        float: left !important;
-    }
-    .official-link {
-        float: left !important;
-    }
-    .dashboard-image {
-        float: right !important;
-    }
+  .privacybox {
+    width: 100%;
+  }
+  .attribute-list [class^='col-'] {
+    margin-bottom: 10px;
+  }
+
+  .img-thumbnail {
+    margin-top: 20px;
+    float: left !important;
+  }
+
+  .official-link {
+    float: left !important;
+  }
+
+  .dashboard-image {
+    float: right !important;
+  }
 }
+
 @media all and (min-width: @screen-sm-max) {
-    .attribute-list {
-        margin-bottom: 20px;
-    }
-    .privacybox {
-        width: 200px;
-    }
+  .attribute-list {
+    margin-bottom: 20px;
+  }
+
+  .privacybox {
+    width: 200px;
+  }
 }
+
 .email-row div p {
   position: relative;
   top: 6px;
 }
+
 #email {
-    div.emails {
-        div.row {
-            padding: 7px 0;
-            border-bottom: 1px solid #eeeeee;
-        }
+  div.emails {
+    div.row {
+      padding: 7px 0;
+      border-bottom: 1px solid #eee;
     }
-    div.new-email {
-        padding: 7px 0;
-    }
+  }
+
+  div.new-email {
+    padding: 7px 0;
+  }
 }
+
 .delete-position {
-    float: left;
-    cursor: pointer;
-    margin-right: 10px;
-    padding-top: 2px;
-    line-height: 12px;
+  float: left;
+  cursor: pointer;
+  margin-right: 10px;
+  padding-top: 2px;
+  line-height: 12px;
 }
+
 .position p {
-    margin-bottom: 0px;
+  margin-bottom: 0;
 }
 // Public profile
 #zip-code {
-    display: inline;
-    float: left;
+  display: inline;
+  float: left;
 }
+
 /* Find users
 ------------------------------------------------- */
 
 section#user-search {
-    .profile-picture {
-        padding-left: 0px;
-    }
-    .profile-name {
-        margin-bottom: 10px;
-        font-size: 17px;
-        font-weight: 600;
-    }
-    /* sidebar */
+  .profile-picture {
+    padding-left: 0;
+  }
 
-    .sidebar {
-        padding-left: 20px;
-        margin-top: 20px;
-        margin-bottom: 20px;
-    }
-    /* all links */
+  .profile-name {
+    margin-bottom: 10px;
+    font-size: 17px;
+    font-weight: 600;
+  }
 
-    .sidebar .nav>li>a {
-        color: #999;
-        padding: 4px 20px;
-        font-size: 13px;
-        font-weight: 400;
-    }
-    /* nested links */
+  /* sidebar */
 
-    .sidebar .nav .nav>li>a {
-        padding-top: 1px;
-        padding-bottom: 1px;
-        padding-left: 30px;
-        font-size: 12px;
-    }
-    /* active & hover links */
+  .sidebar {
+    padding-left: 20px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
 
-    .sidebar .nav>.active>a, .sidebar .nav>li>a:hover, .sidebar .nav>li>a:focus {
-        color: @baby-blue;
-        text-decoration: none;
-        background-color: transparent;
-        border-left-color: @baby-blue;
-    }
-    /* all active links */
+  /* all links */
 
-    .sidebar .nav>.active>a, .sidebar .nav>.active:hover>a, .sidebar .nav>.active:focus>a {
-        font-weight: 700;
-    }
-    /* nested active links */
+  .sidebar .nav>li>a {
+    color: #999;
+    padding: 4px 20px;
+    font-size: 13px;
+    font-weight: 400;
+  }
 
-    .sidebar .nav .nav>.active>a, .sidebar .nav .nav>.active:hover>a, .sidebar .nav .nav>.active:focus>a {
-        font-weight: 500;
-    }
-    /* hide inactive nested list */
+  /* nested links */
 
-    .sidebar .nav ul.nav {
-        display: none;
-    }
-    /* show active nested list */
+  .sidebar .nav .nav>li>a {
+    padding-top: 1px;
+    padding-bottom: 1px;
+    padding-left: 30px;
+    font-size: 12px;
+  }
 
-    .sidebar .nav>.active>ul.nav {
-        display: block;
-    }
+  /* active & hover links */
+
+  .sidebar .nav>.active>a, .sidebar .nav>li>a:hover, .sidebar .nav>li>a:focus {
+    color: @baby-blue;
+    text-decoration: none;
+    background-color: transparent;
+    border-left-color: @baby-blue;
+  }
+
+  /* all active links */
+
+  .sidebar .nav>.active>a, .sidebar .nav>.active:hover>a, .sidebar .nav>.active:focus>a {
+    font-weight: 700;
+  }
+
+  /* nested active links */
+
+  .sidebar .nav .nav>.active>a, .sidebar .nav .nav>.active:hover>a, .sidebar .nav .nav>.active:focus>a {
+    font-weight: 500;
+  }
+
+  /* hide inactive nested list */
+
+  .sidebar .nav ul.nav {
+    display: none;
+  }
+
+  /* show active nested list */
+
+  .sidebar .nav>.active>ul.nav {
+    display: block;
+  }
 }

--- a/assets/profiles/less/profiles.less
+++ b/assets/profiles/less/profiles.less
@@ -143,6 +143,7 @@ label > i.btn-icon {
   background-color: white;
   padding-left: 10px;
 }
+
 .markbody .inline .row-fluid [class*="span"] {
   min-height: 15px;
 }
@@ -159,8 +160,8 @@ label > i.btn-icon {
   @btn-success-border);
 }
 
-.marks.on:after {
-  content: "Jeg har godtatt prikkereglene og er inneforstått med hva dette betyr."
+.marks.on::after {
+  content: "Jeg har godtatt prikkereglene og er inneforstått med hva dette betyr.";
 }
 
 .marks.off {
@@ -171,8 +172,8 @@ label > i.btn-icon {
   @btn-warning-border);
 }
 
-.marks.off:after {
-  content: "Jeg godtar prikkereglene og er inneforstått med hva dette betyr."
+.marks.off::after {
+  content: "Jeg godtar prikkereglene og er inneforstått med hva dette betyr.";
 }
 
 textarea, input[type="text"], input[type="email"], input[type="url"], input[type="number"] {

--- a/assets/profiles/less/profiles.less
+++ b/assets/profiles/less/profiles.less
@@ -25,11 +25,6 @@ input.hidden-input {
   height: 50px;
 }
 
-#bio {
-  height: 340px;
-  .bio;
-}
-
 #compiled {
   margin-bottom: 10px;
 }
@@ -41,6 +36,11 @@ input.hidden-input {
 .bio {
   overflow-y: auto;
   white-space: pre-wrap;
+}
+
+#bio {
+  height: 340px;
+  .bio;
 }
 
 i.btn-icon {
@@ -125,10 +125,6 @@ label > i.btn-icon {
   cursor: pointer;
 }
 
-.panel-heading:hover {
-  cursor: pointer;
-}
-
 .mark, .application {
   padding-top: 10px;
 }
@@ -150,6 +146,10 @@ label > i.btn-icon {
 
 .panel-heading {
   padding: 1px 15px;
+}
+
+.panel-heading:hover {
+  cursor: pointer;
 }
 
 .marks.on {
@@ -218,6 +218,10 @@ textarea {
   }
 }
 
+.position p {
+  margin-bottom: 0;
+}
+
 .email-row div p {
   position: relative;
   top: 6px;
@@ -244,9 +248,6 @@ textarea {
   line-height: 12px;
 }
 
-.position p {
-  margin-bottom: 0;
-}
 // Public profile
 #zip-code {
   display: inline;

--- a/assets/profiles/less/typeahead.less
+++ b/assets/profiles/less/typeahead.less
@@ -16,8 +16,8 @@
   position: relative;
 
   img {
-    width:75px;
-    height:75px;
+    width: 75px;
+    height: 75px;
     position: absolute;
     top: 7px;
     left: 0;
@@ -35,7 +35,7 @@
     display: inline-block;
 
     .phone {
-      font-size:13px;
+      font-size: 13px;
     }
   }
 
@@ -73,5 +73,5 @@
 }
 
 .twitter-typeahead {
-  display:block !important;
+  display: block !important;
 }

--- a/assets/profiles/less/typeahead.less
+++ b/assets/profiles/less/typeahead.less
@@ -8,7 +8,7 @@
 }
 
 .tt-suggestion {
-  padding: 3px 0px;
+  padding: 3px 0;
   font-size: 18px;
   line-height: 24px;
   cursor: pointer;
@@ -20,11 +20,13 @@
     height:75px;
     position: absolute;
     top: 7px;
-    left: 0px;
+    left: 0;
+
     &[src=''] {
       display: none;
     }
   }
+
   .user-meta {
     position: absolute;
     top: 24px;
@@ -42,6 +44,7 @@
     background-color: #0097cf;
   }
 }
+
 .typeahead,
 .tt-query,
 .tt-hint {
@@ -52,8 +55,8 @@
   line-height: 30px;
   border: 2px solid #ccc;
   -webkit-border-radius: 8px;
-     -moz-border-radius: 8px;
-          border-radius: 8px;
+  -moz-border-radius: 8px;
+  border-radius: 8px;
   outline: none;
 }
 

--- a/assets/resourcecenter/less/resourcecenter.less
+++ b/assets/resourcecenter/less/resourcecenter.less
@@ -1,16 +1,19 @@
 /* Vars */
+
 /* ResourceCenter */
 
 #resourcecenter {
-    .resourcedescription {
-        margin-bottom: 20px;
-    }
-    img {
-        margin-bottom: 20px;
-        width: 100%;
-        height: auto;
-    }
-    h3 {
-        margin-top: 0px;
-    }
+  .resourcedescription {
+    margin-bottom: 20px;
+  }
+
+  img {
+    margin-bottom: 20px;
+    width: 100%;
+    height: auto;
+  }
+
+  h3 {
+    margin-top: 0;
+  }
 }

--- a/assets/resourcecenter/less/resourcecenter.less
+++ b/assets/resourcecenter/less/resourcecenter.less
@@ -1,7 +1,3 @@
-/* Vars */
-
-/* ResourceCenter */
-
 #resourcecenter {
   .resourcedescription {
     margin-bottom: 20px;

--- a/assets/sso/less/sso.less
+++ b/assets/sso/less/sso.less
@@ -2,12 +2,14 @@
   width: 480px;
   margin: 0 auto;
 }
+
 #sso-panel {
   border: 1px solid #004b80;
   background-color: #eee;
   margin-top: 60px;
   box-shadow: 0 6px 10px 0 rgba(0,0,0,0.15), 0 6px 10px 0 rgba(0,0,0,0.11);
 }
+
 #sso-panel-header {
   background-color: #004b80;
   padding: 20px;
@@ -17,11 +19,12 @@
     font-size: 30px;
     vertical-align: middle;
     color: #fff;
-    margin-top: 0px;
-    padding: 0px;
-    margin-bottom: 0px;
+    margin-top: 0;
+    padding: 0;
+    margin-bottom: 0;
   }
 }
+
 #sso-panel-body {
   h4 {
     margin-top: 5px;
@@ -29,8 +32,10 @@
     font-size: 16px;
     line-height: 16px;
   }
+
   padding: 20px 20px 15px 20px;
 }
+
 #sso-authorization-form {
   background-color: #fff;
   padding: 15px;

--- a/assets/sso/less/sso.less
+++ b/assets/sso/less/sso.less
@@ -7,7 +7,7 @@
   border: 1px solid #004b80;
   background-color: #eee;
   margin-top: 60px;
-  box-shadow: 0 6px 10px 0 rgba(0,0,0,0.15), 0 6px 10px 0 rgba(0,0,0,0.11);
+  box-shadow: 0 6px 10px 0 rgba(0, 0, 0, 0.15), 0 6px 10px 0 rgba(0, 0, 0, 0.11);
 }
 
 #sso-panel-header {

--- a/assets/webshop/less/webshop.less
+++ b/assets/webshop/less/webshop.less
@@ -1,68 +1,75 @@
 /* Vars */
+
 /* ResourceCenter */
 
 #webshop {
-    .itemdescription {
-        margin-bottom: 20px;
-    }
-    .item-bg{
-        margin-bottom: 20px;
-        height: 100px;
-        width: 100px;
-        background-repeat: no-repeat;
-        background-size: cover;
-        border-radius: 3px;
-    }
-    .order-total{
-        font-weight: bold;
-    }
-    .product-name{
-        font-weight: bold;
-        font-size: 30px;
-    }
-    .product-price{
-        font-weight: bold;
-        font-size: 20px;
-        margin-bottom: 20px;
-    }
-    .product-stock {
-        font-size: 18px;
-        margin-bottom: 20px;
-    }
+  .itemdescription {
+    margin-bottom: 20px;
+  }
 
-    .item-img {
-        margin-bottom: 20px;
-        width: 100%;
-        max-width: 100px;
-        max-height: 100px;
-        height: auto;
-    }
-    h3 {
-        margin-top: 0px;
-    }
+  .item-bg{
+    margin-bottom: 20px;
+    height: 100px;
+    width: 100px;
+    background-repeat: no-repeat;
+    background-size: cover;
+    border-radius: 3px;
+  }
 
-    #carousel-product {
-        margin-bottom: 20px;
-    }
+  .order-total{
+    font-weight: bold;
+  }
 
-    .description {
-        margin-top: 20px;
-    }
+  .product-name{
+    font-weight: bold;
+    font-size: 30px;
+  }
 
-    .order-form {
-        max-width: 180px;
-    }
+  .product-price{
+    font-weight: bold;
+    font-size: 20px;
+    margin-bottom: 20px;
+  }
 
-    .short {
-        font-size: 16px;
-    }
+  .product-stock {
+    font-size: 18px;
+    margin-bottom: 20px;
+  }
+
+  .item-img {
+    margin-bottom: 20px;
+    width: 100%;
+    max-width: 100px;
+    max-height: 100px;
+    height: auto;
+  }
+
+  h3 {
+    margin-top: 0;
+  }
+
+  #carousel-product {
+    margin-bottom: 20px;
+  }
+
+  .description {
+    margin-top: 20px;
+  }
+
+  .order-form {
+    max-width: 180px;
+  }
+
+  .short {
+    font-size: 16px;
+  }
 }
 
 #webshop-image-list {
-    img.image-selected {
-            border: 2px solid black;
-            margin: -2px;
-            -webkit-filter: brightness(50%);
-                    filter: brightness(50%);
-    }
+  img.image-selected {
+    border: 2px solid black;
+    margin: -2px;
+    -webkit-filter: brightness(50%);
+    filter: brightness(50%);
+  }
 }

--- a/assets/webshop/less/webshop.less
+++ b/assets/webshop/less/webshop.less
@@ -7,7 +7,7 @@
     margin-bottom: 20px;
   }
 
-  .item-bg{
+  .item-bg {
     margin-bottom: 20px;
     height: 100px;
     width: 100px;
@@ -16,16 +16,16 @@
     border-radius: 3px;
   }
 
-  .order-total{
+  .order-total {
     font-weight: bold;
   }
 
-  .product-name{
+  .product-name {
     font-weight: bold;
     font-size: 30px;
   }
 
-  .product-price{
+  .product-price {
     font-weight: bold;
     font-size: 20px;
     margin-bottom: 20px;

--- a/assets/wiki/less/wiki.less
+++ b/assets/wiki/less/wiki.less
@@ -1,103 +1,120 @@
 @import "~common/less/colors.less";
 
 #wiki {
-    // OW4 and django-wiki have different Bootstrap versions which screwed up modals
-    .modal {
-        z-index: 1050;
+  // OW4 and django-wiki have different Bootstrap versions which screwed up modals
+  .modal {
+    z-index: 1050;
+  }
+
+  .modal-backdrop {
+    z-index: 0;
+  }
+
+  .page-header {
+    margin-top: 0;
+  }
+
+  .wiki-article table {
+    border: 1px solid #bbb;
+    padding: 4px;
+  }
+
+  .wiki-article table th {
+    font-weight: bold;
+    border: 1px solid #bbb;
+    padding: 4px;
+    background-color: #ccc;
+  }
+
+  .wiki-article table td {
+    border: 1px solid #bbb;
+    padding: 4px;
+  }
+
+  #id_content {
+    resize: both;
+    height: 600px;
+  }
+
+  #article-menu {
+    border-bottom: none;
+    margin-bottom: 8px;
+
+    li {
+      padding-top: 0;
+
+      a {
+        padding-bottom: 9px;
+      }
     }
-    .modal-backdrop {
-        z-index: 0;
+  }
+
+  #topbar {
+    border-bottom: 1px solid #eee;
+    margin-bottom: 12px;
+
+    #article-breadcrumbs > div.pull-left {
+      margin-left: 0 !important;
+      margin-right: 10px;
     }
 
-    .page-header {
-        margin-top: 0px;
+    #article-breadcrumbs > div.pull-left, form {
+      margin-bottom: 9px;
     }
-    .wiki-article table {
-        border: 1px solid #bbb;
-        padding: 4px;
+
+    .breadcrumb {
+      margin-bottom: 8px;
+      margin-right: 10px;
     }
-    .wiki-article table th {
-        font-weight: bold;
-        border: 1px solid #bbb;
-        padding: 4px;
-        background-color: #ccc;
+  }
+
+  .wiki-article {
+    pre * {
+      margin: 0;
+      padding: 0;
+      font-size: 1em;
+      font-weight: normal;
+      font-style: normal;
     }
-    .wiki-article table td {
-        border: 1px solid #bbb;
-        padding: 4px;
+    .pln { color: #000 }
+
+    @media screen {
+      .str { color: #080 }
+      .kwd { color: #008 }
+      .com { color: #800 }
+      .typ { color: #606 }
+      .lit { color: #066 }
+      .pun, .opn, .clo { color: #660 }
+      .tag { color: #008 }
+      .atn { color: #606 }
+      .atv { color: #080 }
+      .dec, .var { color: #606 }
+      .fun { color: red }
     }
-    #id_content {
-        resize: both;
-        height: 600px;
+
+    @media print, projection {
+      .str { color: #060 }
+      .kwd { color: #006; font-weight: bold }
+      .com { color: #600; font-style: italic }
+      .typ { color: #404; font-weight: bold }
+      .lit { color: #044 }
+      .pun, .opn, .clo { color: #440 }
+      .tag { color: #006; font-weight: bold }
+      .atn { color: #404 }
+      .atv { color: #060 }
     }
-    #article-menu {
-        border-bottom: none;
-        margin-bottom: 8px;
-        li {
-            padding-top: 0px;
-            a {
-                padding-bottom: 9px;
-            }
-        }
+
+    pre.prettyprint {
+      background-color: #eee;
+      font-family: Consolas,Menlo,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New,monospace,serif;
+      margin-bottom: 10px;
+      padding: 5px;
+      width: auto;
+      border: 0;
     }
-    #topbar {
-        border-bottom: 1px solid #EEEEEE;
-        margin-bottom: 12px;
-        #article-breadcrumbs > div.pull-left {
-            margin-left: 0px !important;
-            margin-right: 10px;
-        }
-        #article-breadcrumbs > div.pull-left, form {
-            margin-bottom: 9px;
-        }
-        .breadcrumb {
-            margin-bottom: 8px;
-            margin-right: 10px;
-        }
-    }
-    .wiki-article {
-        pre * {
-            margin: 0;
-            padding: 0;
-            font-size: 1em;
-            font-weight: normal;
-            font-style: normal;
-        }
-        .pln { color: #000 }
-        @media screen {
-          .str { color: #080 }
-          .kwd { color: #008 }
-          .com { color: #800 }
-          .typ { color: #606 }
-          .lit { color: #066 }
-          .pun, .opn, .clo { color: #660 }
-          .tag { color: #008 }
-          .atn { color: #606 }
-          .atv { color: #080 }
-          .dec, .var { color: #606 }
-          .fun { color: red }
-        }
-        @media print, projection {
-          .str { color: #060 }
-          .kwd { color: #006; font-weight: bold }
-          .com { color: #600; font-style: italic }
-          .typ { color: #404; font-weight: bold }
-          .lit { color: #044 }
-          .pun, .opn, .clo { color: #440 }
-          .tag { color: #006; font-weight: bold }
-          .atn { color: #404 }
-          .atv { color: #060 }
-        }
-        pre.prettyprint {
-            background-color: #EEEEEE;
-            font-family: Consolas,Menlo,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New,monospace,serif;
-            margin-bottom: 10px;
-            padding: 5px;
-            width: auto;
-            border: 0px;
-        }
-    }
-    h1 {
-        color: @heading;
-    }
+  }
+
+  h1 {
+    color: @heading;
+  }
 }

--- a/assets/wiki/less/wiki.less
+++ b/assets/wiki/less/wiki.less
@@ -76,37 +76,53 @@
       font-weight: normal;
       font-style: normal;
     }
-    .pln { color: #000 }
+    .pln { color: #000; }
 
     @media screen {
-      .str { color: #080 }
-      .kwd { color: #008 }
-      .com { color: #800 }
-      .typ { color: #606 }
-      .lit { color: #066 }
-      .pun, .opn, .clo { color: #660 }
-      .tag { color: #008 }
-      .atn { color: #606 }
-      .atv { color: #080 }
-      .dec, .var { color: #606 }
-      .fun { color: red }
+      .str { color: #080; }
+      .kwd { color: #008; }
+      .com { color: #800; }
+      .typ { color: #606; }
+      .lit { color: #066; }
+      .pun, .opn, .clo { color: #660; }
+      .tag { color: #008; }
+      .atn { color: #606; }
+      .atv { color: #080; }
+      .dec, .var { color: #606; }
+      .fun { color: red; }
     }
 
     @media print, projection {
-      .str { color: #060 }
-      .kwd { color: #006; font-weight: bold }
-      .com { color: #600; font-style: italic }
-      .typ { color: #404; font-weight: bold }
-      .lit { color: #044 }
-      .pun, .opn, .clo { color: #440 }
-      .tag { color: #006; font-weight: bold }
-      .atn { color: #404 }
-      .atv { color: #060 }
+      .str { color: #060; }
+
+      .kwd {
+        color: #006;
+        font-weight: bold;
+      }
+
+      .com {
+        color: #600;
+        font-style: italic;
+      }
+
+      .typ {
+        color: #404;
+        font-weight: bold;
+      }
+      .lit { color: #044; }
+      .pun, .opn, .clo { color: #440; }
+
+      .tag {
+        color: #006;
+        font-weight: bold;
+      }
+      .atn { color: #404; }
+      .atv { color: #060; }
     }
 
     pre.prettyprint {
       background-color: #eee;
-      font-family: Consolas,Menlo,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New,monospace,serif;
+      font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
       margin-bottom: 10px;
       padding: 5px;
       width: auto;


### PR DESCRIPTION
## What kind of a pull request is this?

- [x] One of those big old ones that inflate your "contributors" stats


## Code Checklist

- [x] The code follows dotkom code style
- [x] The code is ready to be merged


## (Possible) Breaking Changes

Stylelint considers [no-descending-specificity](https://stylelint.io/user-guide/rules/no-descending-specificity/) to be a mandatory error rule, as selectors with varying specificity can overlap, meaning the order of the styles ends up deciding what rule applies. While the entire rule exists to prevent edge cases, we _might_ have abused this edge case in our style, meaning that fixing the rule may break some styling. 


## Description of changes

Ran an automatic `stylelint --fix` through `yarn lint-less`, which surprisingly doesn't cover a whole lot of rules you'd think would be easily automated. A lot of manual work to fix the remaining rules, later realizing that no-descending-specificity could break some styling (read above). Can't easily test that locally, but I did do my best in terms of double-checking that selectors are the same, just different places (or different level of nesting). 