### PR TITLE
Only load payment js if event has payment. Fix #1921

### DIFF
--- a/templates/events/details.html
+++ b/templates/events/details.html
@@ -22,9 +22,11 @@
         var all_extras = [{% for e in attendance_event.extras.all %}"{{e}}", {%endfor%}];
     </script>
 
-    <script src="{{ STATIC_URL }}js/libs/jquery.cookie.js"></script>
-    <script src="https://checkout.stripe.com/checkout.js"></script>
-    <script src="{{ STATIC_URL }}js/payment.js"></script>
+    {% if payment and not place_on_wait_list and not user_paid or payment and payment.payment_type == 1 %}
+      <script src="{{ STATIC_URL }}js/libs/jquery.cookie.js"></script>
+      <script src="https://checkout.stripe.com/checkout.js"></script>
+      <script src="{{ STATIC_URL }}js/payment.js"></script>
+    {% endif %}
 
     {% render_bundle 'eventsDetails' 'js' %}
 {% endblock %}


### PR DESCRIPTION
## What kind of a pull request is this?

- [x] QA / Code Review


## Code Checklist

- [ ] The code follows dotkom code style 
- [x] The code passes the defined tests
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible

## Description of changes

It's not the most beautiful of fixes, but it should do the job. It will stop _every_ event on our page to cause the visitor to load a Stripe.js snippet, as well as try to execute some custom JS which fails 100% of the time if there is no event. It will also reduce errors sent to Sentry by quite a bit because of this.