### PR TITLE
Fix #1919. Use python nonzero method rather than 'is not None'

### DIFF
--- a/apps/events/tests/api_tests.py
+++ b/apps/events/tests/api_tests.py
@@ -224,3 +224,17 @@ class AttendAPITestCase(APITestCase):
         self.assertFalse(self.attendees[0].attended)
         self.assertFalse(self.attendees[1].attended)
         self.assertEqual(response.json()['attend_status'], 41)
+
+    def test_save_rfid_give_no_username_gives_useful_error_message(self):
+        self.attendee1.user.rfid = None
+        self.attendee1.user.save()
+
+        response = self.client.post(self.url, {
+            'event': self.event.id,
+            'rfid': self.attendee1.user.rfid,
+        }, **self.headers)
+
+        self.refresh_attendees()
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(self.attendees[0].attended)
+        self.assertEqual(response.json()['attend_status'], 41)

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -402,6 +402,10 @@ class AttendViewSet(views.APIView):
         username = request.data.get('username')
         waitlist_approved = request.data.get('approved')
 
+        if not (username or rfid):
+            return Response({'message': 'Mangler både RFID og brukernavn. Vennligst prøv igjen.',
+                             'attend_status': 41}, status=status.HTTP_400_BAD_REQUEST)
+
         # If attendee has typed in username to bind a new card to their user
         if username is not None and rfid is not None:
             try:
@@ -443,11 +447,6 @@ class AttendViewSet(views.APIView):
                 return Response({'message': 'Brukernavnet finnes ikke. Husk at det er et online.ntnu.no brukernavn! '
                                             '(Prøv igjen, eller scan nytt kort for å avbryte.)', 'attend_status': 50},
                                 status=status.HTTP_400_BAD_REQUEST)
-
-            # If RFID is empty string or the likes.
-            elif not rfid:
-                return Response({'message': 'RFID-en er ugyldig. Ble kortet scannet korrekt? Prøv igjen.',
-                                 'attend_status': 41}, status=status.HTTP_400_BAD_REQUEST)
 
             # If attendee tried to attend by card, but card isn't tied to a user
             else:

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -414,7 +414,7 @@ class AttendViewSet(views.APIView):
                                 status=status.HTTP_400_BAD_REQUEST)
         try:
             # If attendee is trying to attend by username
-            if rfid is None:
+            if not rfid:
                 attendee = Attendee.objects.get(event=event, user__username=username)
             else:
                 attendee = Attendee.objects.get(event=event, user__rfid=rfid)
@@ -443,6 +443,10 @@ class AttendViewSet(views.APIView):
                 return Response({'message': 'Brukernavnet finnes ikke. Husk at det er et online.ntnu.no brukernavn! '
                                             '(Prøv igjen, eller scan nytt kort for å avbryte.)', 'attend_status': 50},
                                 status=status.HTTP_400_BAD_REQUEST)
+
+            elif not rfid:
+                return Response({'message': 'RFID-en er ugyldig. Ble kortet scannet korrekt? Prøv igjen.',
+                                 'attend_status': 41}, status=status.HTTP_400_BAD_REQUEST)
 
             # If attendee tried to attend by card, but card isn't tied to a user
             else:

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -444,6 +444,7 @@ class AttendViewSet(views.APIView):
                                             '(Prøv igjen, eller scan nytt kort for å avbryte.)', 'attend_status': 50},
                                 status=status.HTTP_400_BAD_REQUEST)
 
+            # If RFID is empty string or the likes.
             elif not rfid:
                 return Response({'message': 'RFID-en er ugyldig. Ble kortet scannet korrekt? Prøv igjen.',
                                  'attend_status': 41}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## What kind of a pull request is this?

- [x] QA / Code Review


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [x] I have added tests for the code I added
- [x] I have provided documentation for the code I added
- [x] The code is ready to be merged
    - Depending on the below todos.


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
    - [x] The changes might require changes in third party applications (dotkom/regme)

## Description of changes

Use python nonzero method rather than checking if the input actually is None. It might actually be empty string, which is not None. [Read more](https://stackoverflow.com/questions/7816363/if-a-vs-if-a-is-not-none)

```
>>> a = ''

# Check that the variable is not none, so that we can proceed knowing that the input actually is not None
>>> bool(a is not None)
True

# But what if a is '' (empty string) instead? That should probably also halt execution.
>>> bool(a)
False
``` 