### PR TITLE
Create minimal webpack-stats file for Django tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -56,6 +56,7 @@ pipeline:
     secrets: [codecov_token]
     when:
       event: push
+    group: testing
     commands:
       - tox -e tests
       - pip install codecov --quiet

--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,5 @@ setuptools-*.zip
 # django-webpack-loader
 bundles/
 webpack-stats.json
+webpack-stats-test.json
 .drone-secrets.yml*

--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -87,7 +87,11 @@ OAUTH2_PROVIDER_APPLICATION_MODEL = 'sso.Client'
 
 WEBPACK_LOADER = {
     'DEFAULT': {
-        'BUNDLE_DIR_NAME': 'webpack/'  # end with slash
+        'BUNDLE_DIR_NAME': 'webpack/',  # end with slash
+        'STATS_FILE': os.path.join(
+            PROJECT_ROOT_DIRECTORY,
+            config('OW4_WEBPACK_LOADER_STATS_FILE', default='webpack-stats.json')
+        )
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "js-cookie": "^2.1.3",
     "masonry-layout": "^4.1.1",
     "moment": "^2.16.0",
+    "null-loader": "^0.1.1",
     "picturefill": "^3.0.2",
     "postcss-loader": "^2.0.6",
     "react": "^15.3.0",
@@ -76,6 +77,7 @@
   "scripts": {
     "build": "webpack",
     "build:prod": "webpack --config webpack.production.config.js",
+    "build:test": "webpack --config webpack.test.config.js",
     "dev": "node webpack.server.js",
     "start": "npm run dev",
     "test": "jest",

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ setenv =
     DATABASE_URL = sqlite:///db.db
     DJANGO_SETTINGS_MODULE = onlineweb4.settings
     PYTHONPATH = {toxinidir}:{toxinidir}
+    OW4_WEBPACK_LOADER_STATS_FILE = webpack-stats-test.json
 commands =
     npm run build:test
     py.test --cov=apps --cov-report xml

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     isort: isort
     flake8: flake8
             pyflakes
+whitelist_externals = npm
 commands =
     isort: isort -rc -c apps middleware scripts utils
     flake8: flake8 apps middleware scripts utils
@@ -25,4 +26,5 @@ setenv =
     DJANGO_SETTINGS_MODULE = onlineweb4.settings
     PYTHONPATH = {toxinidir}:{toxinidir}
 commands =
+    npm run build:test
     py.test --cov=apps --cov-report xml

--- a/webpack-extra-resolve.json
+++ b/webpack-extra-resolve.json
@@ -1,1 +1,0 @@
-{"paths": ["/usr/local/lib/python3.6/site-packages/wiki/static"]}

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -1,0 +1,15 @@
+const config = require('./webpack.config.js');
+
+
+/*
+  View tests that use templates require a valid webpack-stats.json file, so instead
+  of running a full build we just run a minimum build that generates this file.
+*/
+config.module.rules = [
+  {
+    test: /\.js$/,
+    loader: 'null-loader',
+  },
+];
+
+module.exports = config;

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -1,4 +1,6 @@
 const config = require('./webpack.config.js');
+const BundleTracker = require('webpack-bundle-tracker');
+const CommonsChunkPlugin = require('webpack/lib/optimize/CommonsChunkPlugin');
 
 
 /*
@@ -11,5 +13,11 @@ config.module.rules = [
     loader: 'null-loader',
   },
 ];
+
+config.plugins = [
+  // Needed because otherwise the common entry is not created
+  new CommonsChunkPlugin({ names: ['common'] }),
+  new BundleTracker({ filename: './webpack-stats-test.json' }),
+]
 
 module.exports = config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4719,6 +4719,10 @@ nth-check@~1.0.1:
   dependencies:
     boolbase "~1.0.0"
 
+null-loader@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-0.1.1.tgz#17be9abfcd3ff0e1512f6fc4afcb1f5039378fae"
+
 num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"


### PR DESCRIPTION
We use django-webpack-loader in our views to import webpack bundles (generated css, js etc files). 
This is done by using a webpack-stats file which is created after a successful webpack build.
Django-webpack-loader still runs when we run our Django view tests we had to build webpack before runnings tests. Since webpack and python tests are the slowest part of our build this was pretty unfortunate. 

This PR adds support for generating a dummy webpack-stats file which we can use while runnings view tests. 
This is done by overwriting all webpack loaders(basically the part of webpack that transforms code) with a null-loader. This loader does nothing and therefore is much faster than running a normal build. 
