### PR TITLE
Use yarn in Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,7 +16,7 @@ pipeline:
       event: push
     commands:
       - cp onlineweb4/settings/example-local.py onlineweb4/settings/local.py
-      - npm install --depth=0 --quiet
+      - yarn install --pure-lockfile
       - pip install tox
 
   npm-build:

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,6 +12,7 @@ pipeline:
 
   setup:
     image: registry.online.ntnu.no/dotkom/onlineweb4-testbase
+    pull: true
     when:
       event: push
     commands:

--- a/Dockerfile.testbase
+++ b/Dockerfile.testbase
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.4
 MAINTAINER dotkom@online.ntnu.no
 
 # Install deps

--- a/Dockerfile.testbase
+++ b/Dockerfile.testbase
@@ -6,6 +6,7 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
     apt-get remove -y curl && apt-get install -y --no-install-recommends \
     nodejs libjpeg-dev ghostscript && \
     npm install -g less && \
+    npm install -g yarn && \
     pip install tox
 
 # Clean up

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = tests, flake8, isort
 skipsdist = True
 
 [testenv]
-basepython = python3.5
+basepython = python3
 deps =
     isort: isort
     flake8: flake8


### PR DESCRIPTION
Since yarn can use our lockfile this avoids the 1min setup npm does, which brings our total build time down to 5min. 