### PR TITLE
Make extras option value in form be extras id

### DIFF
--- a/templates/events/extras.html
+++ b/templates/events/extras.html
@@ -6,7 +6,7 @@
           <option value="" disabled selected>Velg et alternativ</option>
         {% endif %}
         {% for choice in attendance_event.extras.all %}
-            <option value="{{ forloop.counter0 }}" 
+            <option value="{{ choice.id }}"
               {%if attendee.extras == choice %}
                 selected="selected">
                 Valgt ekstra: {{choice}}


### PR DESCRIPTION
Rather than a custom counter

## What kind of a pull request is this?

- [x] Bugfix
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
    - :warning: People already on the page to select extras will have to reload the page, since the id changes. They will get the "ugyldig valg" text first time, and then they can select again and it will work.
        - There is no way around this, other than supporting both methods at the same time, but that won't actually work since both identifiers are number within the same range, so it's impossible to figure out which selector to use.

## Description of changes

Make back end code be less dependent on front end template logic.
