### PR TITLE
Fix wiki's css and js not being included anymore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ django-recaptcha==1.3.1         # Google ReCaptcha
 django-oauth-toolkit==1.0.0    # OAuth2 authentication support
 django-watson==1.4.4            # Indexed model search lib
 django-reversion==2.0.11        # Model version history with middleware hooks to all post_save signals
-django-guardian==1.4.9          # Per Object permissions framework
+git+https://github.com/dotkom/django-guardian.git@1b184d5377200ab4ad59b343ae8af9a863124510#egg=django-guardian==1.4.9.1          # Per Object permissions framework
 django-taggit==0.22.1           # Generic multi-model tagging library
 django-taggit-serializer==0.1.5 # REST Framework serializers for Django-taggit
 APScheduler==3.4.0              # Scheduler

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,6 @@
 {% load render_bundle from webpack_loader %}
 {% load raven %}
+ {% load sekizai_tags %}
 
 <!DOCTYPE html>
 <html>
@@ -22,6 +23,7 @@
     {% render_bundle 'core' 'css' %}
     {% block scripts %}
     {% endblock %}
+    {% render_block "css" %}
     {% block apple-webapp %}{% endblock %}
 </head>
 <body>
@@ -236,6 +238,7 @@
         {% render_bundle 'common' 'js' %}
         {% render_bundle 'core' 'js' %}
     {% endblock %}
+    {% render_block "js" %}
 
     {% if GOOGLE_ANALYTICS_KEY %}
         <script type="text/javascript">

--- a/templates/wiki/base.html
+++ b/templates/wiki/base.html
@@ -1,7 +1,6 @@
 {% extends 'base.html' %}
 
 {% load static %}
-{% load sekizai_tags %}
 {% load i18n wiki_tags %}
 {% load render_bundle from webpack_loader %}
 
@@ -16,14 +15,12 @@
     <script src="{% static "wiki/bootstrap/js/bootstrap.min.js" %}"></script>
     {% render_bundle 'wiki' 'js' %}
 {% endblock %}
-{% render_block "js" %}
 
 {% block styles %}
     {{ block.super }}
      <link href="{{ STATIC_URL }}wiki/bootstrap/css/wiki-bootstrap.min.css" rel="stylesheet">
     {% render_bundle 'wiki' 'css' %}
 {% endblock %}
-{% render_block "css" %}
 
 {% block content %}
     <section id="wiki">


### PR DESCRIPTION
This was actually really annoying to debug. 

The reason django-wiki's js and css wasn't added is that using render_block in included templates simply doesn't work. So I had to move it back to the base template which caused our tests to fail.

sekizai is helpful and checks if the required context processor has been added to Django. 
A context processor modifies the current context(variables sent to template) for all requests. 
The problem was that the context sent to sekizai seemed like complete bogus only containing {'True': True} etc. It wasn't clear where and what modified the context, but after I while I noticed that guardian was always in the stacktrace. We used guardian to check if the user has required permission otherwise it throws a 403. 

After looking through guardian's source code in the local environment I found that it used RequestContext when throwing 403, which is a deprecated way to create context in Django. 
What I found out later was that I actually fixed this in guardian last summer and had completely forgotten. 
Since guardian hasn't had a release since june I added our fork back to requirements.txt. 

tl;dr: I fixed this last summer