### PR TITLE
Make sure `None` is converted to JSON `null`

### DIFF
--- a/apps/events/tests/api_tests.py
+++ b/apps/events/tests/api_tests.py
@@ -214,7 +214,7 @@ class AttendAPITestCase(OAuth2TestCase):
         response = self.client.post(self.url, json.dumps({
             'event': self.event.id,
             'rfid': self.attendee1.user.rfid,
-        }), **self.headers, content_type='application/json')
+        }), content_type='application/json', **self.headers)
 
         self.refresh_attendees()
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/apps/events/tests/api_tests.py
+++ b/apps/events/tests/api_tests.py
@@ -1,3 +1,5 @@
+import json
+
 from django.core.urlresolvers import reverse
 from django_dynamic_fixture import G
 from rest_framework import status
@@ -209,10 +211,10 @@ class AttendAPITestCase(OAuth2TestCase):
         self.attendee1.user.rfid = None
         self.attendee1.user.save()
 
-        response = self.client.post(self.url, {
+        response = self.client.post(self.url, json.dumps({
             'event': self.event.id,
             'rfid': self.attendee1.user.rfid,
-        }, **self.headers)
+        }), **self.headers, content_type='application/json')
 
         self.refresh_attendees()
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
This test could fail some times (tested on python3.6 and python3.5) because `None` was converted to the string `"None"` rather than the JSON `null` type.

The API expects JSON input, so it's fair to assume that the API tests work with JSON data as well. (Django does a nice job of converting it though, but it seems like it failed for an unknown reason some times -- considering that the actual implementation pull request passed tests…