### PR TITLE
Chore/requirements

### DIFF
--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,2 +1,2 @@
-psycopg2==2.7.3.2                   # Postgres adapter
-uWSGI==2.0.15                     # Used as a http server in production
+psycopg2==2.7.4                   # Postgres adapter
+uWSGI==2.0.17                     # Used as a http server in production

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -4,10 +4,10 @@ factory-boy>=1.1.3
 lettuce>=0.2.20
 nose-cov>=1.6
 flake8==3.5.0
-isort==4.2.15
-freezegun==0.3.9
+isort==4.3.4
+freezegun==0.3.10
 
 # py.test
-pytest==3.3.0
+pytest==3.4.2
 pytest-cov==2.5.1
 pytest-django==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,31 +1,31 @@
-Django==1.11.8
+Django==1.11.11
 Pillow==4.3.0                   # PIL fork (Python Imaging Library)
 django-tastypie==0.14.0         # API v0
-djangorestframework==3.7.3      # API v1
+djangorestframework==3.7.7      # API v1
 django-filter==1.1.0            # Filtering for DRF
 # python-memcached==1.57          # Memcache. Used by Mailinglists to fetch from Sympa.
 # Upstream is missing Python 3 patches
 git+https://github.com/JelteF/python-memcached@patch-1#egg=python-memcached==1.58
 markdown2==2.3.5                # textarea text formatting
 pytz                            # Timezone lib
-stripe==1.75.1                  # Stripe payment
-icalendar==4.0.0               # iCalendar generation
-google-api-python-client==1.6.4
+stripe==1.79.1                  # Stripe payment
+icalendar==4.0.1                # iCalendar generation
+google-api-python-client==1.6.5
 
 # third party deps
 django-filebrowser==3.9.1       # File uploading
 git+https://github.com/dotKom/django-chunks.git@e6bf109d4fd286964024c140ac1b8f3d86713540#egg=django-chunks==0.4
-django-crispy-forms==1.7.0      # nice forms
+django-crispy-forms==1.7.2      # nice forms
 django-extensions==1.9.7        # nice extra commands for debugging, etc
 django-dynamic-fixture==1.9.5   # Dynamic fixtures for models
-django-recaptcha==1.3.1         # Google ReCaptcha
+django-recaptcha==1.4.0         # Google ReCaptcha
 django-oauth-toolkit==1.0.0    # OAuth2 authentication support
-django-watson==1.4.4            # Indexed model search lib
-django-reversion==2.0.11        # Model version history with middleware hooks to all post_save signals
+django-watson==1.5.2            # Indexed model search lib
+django-reversion==2.0.13        # Model version history with middleware hooks to all post_save signals
 git+https://github.com/dotkom/django-guardian.git@1b184d5377200ab4ad59b343ae8af9a863124510#egg=django-guardian==1.4.9.1          # Per Object permissions framework
-django-taggit==0.22.1           # Generic multi-model tagging library
+django-taggit==0.22.2           # Generic multi-model tagging library
 django-taggit-serializer==0.1.5 # REST Framework serializers for Django-taggit
-APScheduler==3.4.0              # Scheduler
+APScheduler==3.5.1              # Scheduler
 feedme==1.9.5
 git+https://github.com/dotKom/redwine.git@0690807537fcbeeacde9c40b0e45549e0d216a96#egg=redwine==1.2.4.1
 reportlab==3.4.0
@@ -33,12 +33,12 @@ pdfdocument==3.2
 Unidecode==0.04.21               # Translates every unicode symbol to the closest ascii. online_mail_usernames
 django-markdown-deux==1.0.5
 django-formset-js==0.5.0        # used to dynamically create new formsets
-django-cors-headers==2.1.0      # Enable CORS for Nibble
+django-cors-headers==2.2.0      # Enable CORS for Nibble
 django-datetime-widget==0.9.3   # Datetime widget for forms
-django-webpack-loader==0.5.0    # Integration with webpack
-dj-database-url==0.4.2          # Allows to configure databases using URLs
+django-webpack-loader==0.6.0    # Integration with webpack
+dj-database-url==0.5.0          # Allows to configure databases using URLs
 python-decouple==3.1            # Configuration and settings management
-django-oidc-provider==0.5.2     # OpenID Connect Provider
+django-oidc-provider==0.5.3     # OpenID Connect Provider
 docutils==0.14                  # Allows django-admindocs to generate documentation
 
 #test tools
@@ -49,13 +49,11 @@ nose==1.3.7                     # We use this test runner locally
 requests[security]==2.18.4
 
 # Wiki
-wiki==0.3
+wiki==0.3.1
 
 # Django 1.9 support
 sorl-thumbnail>12.2
 django-appconf>=1.0
-django-mptt==0.8.7
-django-sekizai==0.10.0
 
 # non-pip
 # imagemagick                   # From package repository. Tested with version == 8:6.7.7.10.
@@ -63,6 +61,6 @@ django-sekizai==0.10.0
 # libpq-dev						# From package repository.
 
 # Monitoring
-raven==6.3.0
+raven==6.6.0
 
-django-js-reverse==0.7.3
+django-js-reverse==0.8.1


### PR DESCRIPTION
Requirements bumps. I left out the major version bumps like Pillow, unidecode and some others, simply due to not having time to test them thoroughly. See #1977 for a diff.

Supersedes and closes #2010.