### PR TITLE
Fix inconsistent permission checking in events

### DIFF
--- a/apps/events/tests/utils.py
+++ b/apps/events/tests/utils.py
@@ -10,9 +10,10 @@ from ..models import TYPE_CHOICES, AttendanceEvent, Attendee, Event
 from ..utils import get_organizer_by_event_type
 
 
-def generate_event(event_type=TYPE_CHOICES[1][0]):
-    event = G(Event, event_type=event_type,
-              organizer=get_organizer_by_event_type(event_type))
+def generate_event(event_type=TYPE_CHOICES[1][0], organizer=None):
+    if organizer is None:
+        organizer = get_organizer_by_event_type(event_type)
+    event = G(Event, event_type=event_type, organizer=organizer)
     G(AttendanceEvent, event=event)
     return event
 

--- a/apps/events/tests/view_tests.py
+++ b/apps/events/tests/view_tests.py
@@ -14,14 +14,15 @@ from apps.authentication.models import AllowedUsername
 from apps.payment.models import PaymentDelay
 
 from ..models import TYPE_CHOICES, AttendanceEvent, Event, Extras, GroupRestriction
-from .utils import (add_payment_delay, add_to_arrkom, add_to_trikom, attend_user_to_event,
-                    generate_attendee, generate_event, generate_payment, generate_user,
-                    pay_for_event)
+from .utils import (add_payment_delay, add_to_arrkom, add_to_bedkom, add_to_trikom,
+                    attend_user_to_event, generate_attendee, generate_event, generate_payment,
+                    generate_user, pay_for_event)
 
 
 class EventsTestMixin:
     def setUp(self):
         G(Group, pk=1, name="arrKom")
+        G(Group, pk=3, name="bedKom")
         G(Group, pk=8, name="triKom")
         G(Group, pk=12, name="Komiteer")
 
@@ -557,6 +558,17 @@ class EventMailParticipates(EventsTestMixin, TestCase):
 
         self.assertInMessages(
             'Du har ikke tilgang til å vise denne siden.', response)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_get_own_social_event_as_bedkom(self):
+        add_to_bedkom(self.user)
+        bedkom = Group.objects.get(name__iexact='bedkom')
+        event = generate_event(TYPE_CHOICES[0][0], organizer=bedkom)
+        url = reverse('event_mail_participants', args=(event.id,))
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.context['event'], event)
         self.assertEqual(len(mail.outbox), 0)
 
     def test_get_as_arrkom(self):


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [x] I have added tests for the code I added
- [x] The code is ready to be merged
- [ ] I have provided documentation for the code I added

## Description of changes

This adds a previously breaking test and fixes the issue behind it. If a committee created an event of a type not belonging to that committee, such as bedkom creating a social event, members of that comittee would not be able to export lists for that event, or send mails about the event.