### PR TITLE
Add an IsLoading-component for lengthy cross-domain requests

### DIFF
--- a/assets/core/LoadingComponent/IsLoading.js
+++ b/assets/core/LoadingComponent/IsLoading.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import Transition from 'react-transition-group/Transition';
+
+import style from './style.less'; // eslint-disable-line no-unused-vars
+
+const duration = 400;
+
+const defaultStyle = {
+  transition: `opacity ${duration}ms ease-in-out`,
+  opacity: 0,
+};
+
+const transitionStyles = {
+  entering: { opacity: 0 },
+  entered: { opacity: 1 },
+};
+
+class IsLoading extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      show: false,
+    };
+    this.registerListeners();
+  }
+
+  registerBeforeUnloadListener() {
+    window.addEventListener(
+      'beforeunload',
+      (event) => {
+        if (this.state.show) {
+          // Basic support is set by modifying the returnValue in-place rather than returning.
+          // Doing both covers all bases.
+          // Some browsers overrides the custom message.
+          // eslint-disable-next-line no-param-reassign
+          event.returnValue = 'Onlinewebben utfører en spørring som kan ta litt tid. Det er viktig at du forblir på siden under denne prosessen for å hindre tap av data.';
+          return event.returnValue;
+        }
+        return event.returnValue;
+      });
+  }
+
+  registerOW4Listeners() {
+    document.addEventListener('ow4-long-xhr-start',
+    () => this.setState({ show: true }));
+
+    document.addEventListener('ow4-long-xhr-end',
+    () => this.setState({ show: false }));
+  }
+
+  registerListeners() {
+    this.registerOW4Listeners();
+    this.registerBeforeUnloadListener();
+  }
+
+  render() {
+    return (
+      <Transition
+        in={this.state.show}
+        timeout={duration}
+        appear
+        mountOnEnter
+        unmountOnExit
+      >
+        {state => (
+          <div
+            className="isloading__component"
+            style={{
+              ...defaultStyle,
+              ...transitionStyles[state],
+            }}
+          >
+            <div
+              className="alert alert-info alert-dismissible"
+              role="alert"
+            >
+              Onlinewebben gjør en spørring som kan ta litt tid.<br />
+              Det er viktig at du forblir på siden under denne prosessen for å hindre tap av data.
+              <button
+                className="close"
+                data-dismiss="alert"
+              >&times;</button>
+            </div>
+          </div>
+        )}
+      </Transition>
+    );
+  }
+}
+
+export default IsLoading;

--- a/assets/core/LoadingComponent/index.js
+++ b/assets/core/LoadingComponent/index.js
@@ -26,12 +26,33 @@ class IsLoading extends React.Component {
     this.registerListeners();
   }
 
-  registerListeners() {
+  registerBeforeUnloadListener() {
+    window.addEventListener(
+      'beforeunload',
+      (event) => {
+        if (this.state.show) {
+          // Basic support is set by modifying the returnValue in-place rather than returning.
+          // Doing both covers all bases.
+          // Some browsers overrides the custom message.
+          // eslint-disable-next-line no-param-reassign
+          event.returnValue = 'Onlinewebben utfører en spørring som kan ta litt tid. Det er viktig at du forblir på siden under denne prosessen for å hindre tap av data.';
+          return event.returnValue;
+        }
+        return event.returnValue;
+      });
+  }
+
+  registerOW4Listeners() {
     document.addEventListener('ow4-long-xhr-start',
     () => this.setState({ show: true }));
 
     document.addEventListener('ow4-long-xhr-end',
     () => this.setState({ show: false }));
+  }
+
+  registerListeners() {
+    this.registerOW4Listeners();
+    this.registerBeforeUnloadListener();
   }
 
   render() {

--- a/assets/core/LoadingComponent/index.js
+++ b/assets/core/LoadingComponent/index.js
@@ -1,8 +1,21 @@
 import React from 'react';
 import ReactDom from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
+import Transition from 'react-transition-group/Transition';
 
 import style from './style.less'; // eslint-disable-line no-unused-vars
+
+const duration = 400;
+
+const defaultStyle = {
+  transition: `opacity ${duration}ms ease-in-out`,
+  opacity: 0,
+};
+
+const transitionStyles = {
+  entering: { opacity: 0 },
+  entered: { opacity: 1 },
+};
 
 class IsLoading extends React.Component {
   constructor() {
@@ -23,14 +36,30 @@ class IsLoading extends React.Component {
 
   render() {
     return (
-      <div className="isloading__component">
-        {this.state.show && <div
-          className="alert alert-info"
-        >
-          Onlinewebben gjør en spørring som kan ta litt tid.<br />
-          Det er viktig at du forblir på siden under denne prosessen for å hindre tap av data.
-        </div>}
-      </div>
+      <Transition
+        in={this.state.show}
+        timeout={duration}
+        appear
+        mountOnEnter
+        unmountOnExit
+      >
+        {state => (
+          <div
+            className="isloading__component"
+            style={{
+              ...defaultStyle,
+              ...transitionStyles[state],
+            }}
+          >
+            <div
+              className="alert alert-info"
+            >
+              Onlinewebben gjør en spørring som kan ta litt tid.<br />
+              Det er viktig at du forblir på siden under denne prosessen for å hindre tap av data.
+            </div>
+          </div>
+        )}
+      </Transition>
     );
   }
 }

--- a/assets/core/LoadingComponent/index.js
+++ b/assets/core/LoadingComponent/index.js
@@ -52,10 +52,15 @@ class IsLoading extends React.Component {
             }}
           >
             <div
-              className="alert alert-info"
+              className="alert alert-info alert-dismissible"
+              role="alert"
             >
               Onlinewebben gjør en spørring som kan ta litt tid.<br />
               Det er viktig at du forblir på siden under denne prosessen for å hindre tap av data.
+              <button
+                className="close"
+                data-dismiss="alert"
+              >&times;</button>
             </div>
           </div>
         )}

--- a/assets/core/LoadingComponent/index.js
+++ b/assets/core/LoadingComponent/index.js
@@ -1,95 +1,8 @@
 import React from 'react';
 import ReactDom from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
-import Transition from 'react-transition-group/Transition';
 
-import style from './style.less'; // eslint-disable-line no-unused-vars
-
-const duration = 400;
-
-const defaultStyle = {
-  transition: `opacity ${duration}ms ease-in-out`,
-  opacity: 0,
-};
-
-const transitionStyles = {
-  entering: { opacity: 0 },
-  entered: { opacity: 1 },
-};
-
-class IsLoading extends React.Component {
-  constructor() {
-    super();
-    this.state = {
-      show: false,
-    };
-    this.registerListeners();
-  }
-
-  registerBeforeUnloadListener() {
-    window.addEventListener(
-      'beforeunload',
-      (event) => {
-        if (this.state.show) {
-          // Basic support is set by modifying the returnValue in-place rather than returning.
-          // Doing both covers all bases.
-          // Some browsers overrides the custom message.
-          // eslint-disable-next-line no-param-reassign
-          event.returnValue = 'Onlinewebben utfører en spørring som kan ta litt tid. Det er viktig at du forblir på siden under denne prosessen for å hindre tap av data.';
-          return event.returnValue;
-        }
-        return event.returnValue;
-      });
-  }
-
-  registerOW4Listeners() {
-    document.addEventListener('ow4-long-xhr-start',
-    () => this.setState({ show: true }));
-
-    document.addEventListener('ow4-long-xhr-end',
-    () => this.setState({ show: false }));
-  }
-
-  registerListeners() {
-    this.registerOW4Listeners();
-    this.registerBeforeUnloadListener();
-  }
-
-  render() {
-    return (
-      <Transition
-        in={this.state.show}
-        timeout={duration}
-        appear
-        mountOnEnter
-        unmountOnExit
-      >
-        {state => (
-          <div
-            className="isloading__component"
-            style={{
-              ...defaultStyle,
-              ...transitionStyles[state],
-            }}
-          >
-            <div
-              className="alert alert-info alert-dismissible"
-              role="alert"
-            >
-              Onlinewebben gjør en spørring som kan ta litt tid.<br />
-              Det er viktig at du forblir på siden under denne prosessen for å hindre tap av data.
-              <button
-                className="close"
-                data-dismiss="alert"
-              >&times;</button>
-            </div>
-          </div>
-        )}
-      </Transition>
-    );
-  }
-}
-
+import IsLoading from './IsLoading';
 
 const connect = (IsLoadingComponent) => {
   ReactDom.render(
@@ -103,10 +16,7 @@ const connect = (IsLoadingComponent) => {
 connect(IsLoading);
 
 if (module.hot) {
-  module.hot.accept('./index.js', () => {
+  module.hot.accept('./IsLoading', () => {
     connect(IsLoading);
   });
 }
-
-
-export default IsLoading;

--- a/assets/core/LoadingComponent/index.js
+++ b/assets/core/LoadingComponent/index.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import ReactDom from 'react-dom';
+import { AppContainer } from 'react-hot-loader';
+
+import style from './style.less'; // eslint-disable-line no-unused-vars
+
+class IsLoading extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      show: false,
+    };
+    this.registerListeners();
+  }
+
+  registerListeners() {
+    document.addEventListener('ow4-long-xhr-start',
+    () => this.setState({ show: true }));
+
+    document.addEventListener('ow4-long-xhr-end',
+    () => this.setState({ show: false }));
+  }
+
+  render() {
+    return (
+      <div className="isloading__component">
+        {this.state.show && <div
+          className="alert alert-info"
+        >
+          Onlinewebben gjør en spørring som kan ta litt tid.<br />
+          Det er viktig at du forblir på siden under denne prosessen for å hindre tap av data.
+        </div>}
+      </div>
+    );
+  }
+}
+
+
+const connect = (IsLoadingComponent) => {
+  ReactDom.render(
+    <AppContainer>
+      <IsLoadingComponent />
+    </AppContainer>,
+    document.getElementById('isloading-component'),
+  );
+};
+
+connect(IsLoading);
+
+if (module.hot) {
+  module.hot.accept('./index.js', () => {
+    connect(IsLoading);
+  });
+}
+
+
+export default IsLoading;

--- a/assets/core/LoadingComponent/style.less
+++ b/assets/core/LoadingComponent/style.less
@@ -1,0 +1,8 @@
+.isloading__component {
+  position: fixed;
+  bottom: 5rem;
+  right: 5rem;
+  z-index: 5;
+  min-width: 15%;
+  max-width: 25%;
+}

--- a/assets/core/LoadingComponent/style.less
+++ b/assets/core/LoadingComponent/style.less
@@ -5,4 +5,10 @@
   z-index: 5;
   min-width: 15%;
   max-width: 25%;
+
+  @media only screen and (max-width: 768px) {
+    left: 2.5rem;
+    right: 2.5rem;
+    max-width: 90%;
+  }
 }

--- a/assets/profiles/profiles.js
+++ b/assets/profiles/profiles.js
@@ -210,12 +210,18 @@ $(document).ready(() => {
   });
 
   const toggleSubscription = (list) => {
+    // Dispatch event allowing IsLoading component to show.
+    document.dispatchEvent(new Event('ow4-long-xhr-start'));
+
     const listID = $(`#toggle_${list}`);
     $.ajax({
       method: 'POST',
       url: `toggle_${list}/`,
       data: {},
       success(data) {
+        // Tell IsLoading-component that request ended.
+        document.dispatchEvent(new Event('ow4-long-xhr-end'));
+
         const res = JSON.parse(data);
         if (res.state === true) {
           listID.removeClass('btn-success');
@@ -228,6 +234,9 @@ $(document).ready(() => {
         }
       },
       error() {
+        // Tell IsLoading-component that request ended.
+        document.dispatchEvent(new Event('ow4-long-xhr-end'));
+
         setStatusMessage('Det oppstod en uventet feil under endring.', 'alert-danger');
       },
       crossDomain: false,

--- a/files/static/js/saldo.js
+++ b/files/static/js/saldo.js
@@ -24,6 +24,8 @@ var setupButton = function(data){
         key: data['stripe_public_key'],
         image: '/static/img/online_stripe_logo.png',
         token: function(token) {
+            // Dispatch event allowing IsLoading component to show.
+            document.dispatchEvent(new Event('ow4-long-xhr-start'));
             $.ajax({
                 type:"POST",
                 url:"/payment/saldo/",
@@ -33,9 +35,15 @@ var setupButton = function(data){
                 },
                 //Reloads the page on error or success to show the message and update the site content.
                 success: function(){
+                    // Tell IsLoading-component that request ended.
+                    document.dispatchEvent(new Event('ow4-long-xhr-end'));
+
                     location.reload();
                 },
                 error: function(result){
+                    // Tell IsLoading-component that request ended.
+                    document.dispatchEvent(new Event('ow4-long-xhr-end'));
+
                     location.reload();
                 }
             });

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-markdown": "^2.5.0",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
+    "react-transition-group": "^2.3.1",
     "remarkable": "^1.6.2",
     "showdown": "^1.5.5",
     "spin.js": "^2.3.2",

--- a/templates/base.html
+++ b/templates/base.html
@@ -146,6 +146,7 @@
 
     {% block content %}{% endblock %}
 
+    <div class="container" id="isloading-component"></div>
     <section id="footer">
         <div class="container">
             <div class="row">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,7 @@ const webpackConfig = {
     core: [
       'react-hot-loader/patch',
       './assets/core/index',
+      './assets/core/LoadingComponent/index',
     ],
     contact: [
       './assets/contact/index',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2024,6 +2024,10 @@ dom-helpers@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
+dom-helpers@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
+
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
@@ -5479,6 +5483,14 @@ prop-types@^15.5.4:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
+prop-types@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 proxy-addr@~1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.3.tgz#dc97502f5722e888467b3fa2297a7b1ff47df074"
@@ -5673,6 +5685,14 @@ react-test-renderer@^15.4.1:
   dependencies:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
+
+react-transition-group@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.3.1.tgz#31d611b33e143a5e0f2d94c348e026a0f3b474b6"
+  dependencies:
+    dom-helpers "^3.3.1"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.1"
 
 react@^15.3.0:
   version "15.4.2"


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
    - CI does not, though. Seems unrelated since I haven't changed any backend code.
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible

## Description of changes

Adds a component which tells the user that the server is processing their request. This can be used when we require (or expect) the user to stay on the page after having done an action, if we do a request and want to report back to the user. Examples of such actions are payments and g suite-related actions, which contact a third-party service.

The component registers some eventListeners which makes it easy to dispatch the actions from vanilla JS as well.

This PR implements the actions for (un)subscribing to the mailing lists as well as the "saldo" function on my profile.

Fixes #1794.

## Screenshot(s) if appropriate

![image](https://user-images.githubusercontent.com/5422571/40128099-20e391a0-5931-11e8-927a-0143b40f5b51.png)

Showcasing the popup message.

---

![image](https://user-images.githubusercontent.com/5422571/40128406-d0dd744a-5931-11e8-8d03-53de9253ae39.png)

Message location in a full HD browser

---

![image](https://user-images.githubusercontent.com/5422571/40128196-5272e752-5931-11e8-9c7d-cc33fd6d63c1.png)

Message on a phone