### PR TITLE
Fix/dataporten registration update user

### DIFF
--- a/apps/dataporten/study/tasks.py
+++ b/apps/dataporten/study/tasks.py
@@ -6,11 +6,9 @@ import requests
 from django.utils import timezone
 from django.utils.http import urlencode
 
-
 from apps.approval.models import MembershipApproval
 from apps.approval.views import get_expiry_date
-from apps.authentication.models import get_length_of_field_of_study
-from apps.authentication.models import AllowedUsername
+from apps.authentication.models import AllowedUsername, get_length_of_field_of_study
 from apps.dataporten.study.utils import get_field_of_study, get_group_id, get_study, get_year
 
 logger = logging.getLogger(__name__)

--- a/apps/dataporten/study/tasks.py
+++ b/apps/dataporten/study/tasks.py
@@ -59,3 +59,8 @@ def find_user_study_and_update(user, groups):
             started_date=started_date,
         )
         return True, study_name, study_year
+
+
+def set_ntnu_username(user, username):
+    user.ntnu_username = username
+    user.save()

--- a/apps/dataporten/study/tests/task_tests.py
+++ b/apps/dataporten/study/tests/task_tests.py
@@ -7,7 +7,8 @@ from django_dynamic_fixture import G
 
 from apps.approval.models import MembershipApproval
 from apps.authentication.models import OnlineUser
-from apps.dataporten.study.tasks import fetch_groups_information, find_user_study_and_update
+from apps.dataporten.study.tasks import (fetch_groups_information, find_user_study_and_update,
+                                         set_ntnu_username)
 
 from .course_test_data import (INFORMATICS_BACHELOR_STUDY_PROGRAMME,
                                INFORMATICS_MASTER_STUDY_PROGRAMME, ITGK_ACTIVE, PVS_ACTIVE,
@@ -64,3 +65,10 @@ class StudyUpdatingTestCase(TestCase):
         self.assertTrue(application.processed)
 
         self.assertEqual(len(mail.outbox), 0)
+
+
+class UserUpdatingTestCase(TestCase):
+    def test_set_ntnu_username(self):
+        user = G(OnlineUser)
+        set_ntnu_username(user, "testname")
+        self.assertEqual(user.ntnu_username, "testname")

--- a/apps/dataporten/views.py
+++ b/apps/dataporten/views.py
@@ -8,7 +8,8 @@ from django.shortcuts import redirect
 from oic import rndstr
 from oic.oauth2 import AuthorizationResponse, ResponseError
 
-from apps.dataporten.study.tasks import fetch_groups_information, find_user_study_and_update, set_ntnu_username
+from apps.dataporten.study.tasks import (fetch_groups_information, find_user_study_and_update,
+                                         set_ntnu_username)
 
 from .client import client_setup
 

--- a/apps/dataporten/views.py
+++ b/apps/dataporten/views.py
@@ -121,21 +121,15 @@ def study_callback(request):
         )
         return redirect('profiles_active', active_tab='membership')
     elif not request.user.ntnu_username:
-        try:
-            set_ntnu_username(request.user, ntnu_username_dataporten)
-        except IntegrityError:
-            messages.error(
-                request,
-                'En bruker er allerede knyttet til denne NTNU-kontoen. '
-                'Dersom du har glemt passordet til din andre bruker kan du bruke "glemt passord"-funksjonen.'
-            )
-            return redirect('profiles_active', active_tab='membership')
-            # @ToDo: Register email address. Maybe store it, but ask user to confirm? -> resend auth email
+        pass
+        # @ToDo: Register email address. Maybe store it, but ask user to confirm? -> resend auth email
 
     # Getting information about study of the user
     groups = fetch_groups_information(access_token)
 
     try:
+        if not request.user.ntnu_username:
+            set_ntnu_username(request.user, ntnu_username_dataporten)
         studies_informatics, study_name, study_year = find_user_study_and_update(request.user, groups)
     except IntegrityError:
         messages.error(


### PR DESCRIPTION
## What kind of a pull request is this?
Fixes an issue with the dataporten integration. New users would not have their memberships or profiles altered when their applications where approved.

This also adds ntnu_username to account automatically when applying for membership

## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [x] I have added tests for the code I added
- [x] I have provided documentation for the code I added
- [x] The code is ready to be merged
