### PR TITLE
Show allergies in dashboard event attendees

### DIFF
--- a/templates/events/dashboard/details/attendees.html
+++ b/templates/events/dashboard/details/attendees.html
@@ -33,6 +33,8 @@
                                     <th>Møtt</th>
                                 {% if event.attendance_event.has_extras %}
                                     <th>Extra</th>
+                                {% else %}
+                                    <th>Allergier</th>
                                 {% endif %}
                                 <th>Fjern</th>
                             </tr>
@@ -66,6 +68,10 @@
                                 {% if event.attendance_event.has_extras %}
                                 <td>
                                     {% if attendee.extras %}{{ attendee.extras }}{% else %}-{% endif %}
+                                </td>
+                                {% else %}
+                                <td>
+                                    {% if attendee.user.allergies %}{{ attendee.user.allergies }}{% else %}-{% endif %}
                                 </td>
                                 {% endif %}
                                 <td>


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged

## Description of changes

As described in #1707, events in the dashboard did not show an attendees allergies if the event did not have extras. This is because allergies are only listed in the extras tab, which makes it easy for those who order food to account for allergies based on the meal each attendee has chosen.

My solution for events without extras is to display allergies in the same place instead.
This changes nothing in the behavior for events with extras.

The possible drawback is that it can be a little bit more confusing to use?

