### PR TITLE
Added settings to not escape mailto links in markdown from chunks

### DIFF
--- a/onlineweb4/settings/__init__.py
+++ b/onlineweb4/settings/__init__.py
@@ -10,6 +10,7 @@ from onlineweb4.settings.logging import *
 from onlineweb4.settings.raven import *
 from onlineweb4.settings.rest_framework import *
 from onlineweb4.settings.stripe import *
+from onlineweb4.settings.markdown import *
 
 try:
     from onlineweb4.settings.local import *

--- a/onlineweb4/settings/markdown.py
+++ b/onlineweb4/settings/markdown.py
@@ -1,0 +1,8 @@
+MARKDOWN_DEUX_STYLES = {
+    'default': {
+        "extras": {
+            "code-friendly": None,
+        },
+        "safe_mode": False,
+    }
+}


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->

## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged

## Description of changes

Fixes #1855 

[default settings](https://github.com/trentm/django-markdown-deux/blob/master/lib/markdown_deux/conf/settings.py) for `django-markdown-deux` is to escape mailto links.

This change lets markdown render `unsafe` elements.
