### PR TITLE
Fixed issue #2112

### DIFF
--- a/apps/authentication/models.py
+++ b/apps/authentication/models.py
@@ -69,15 +69,13 @@ def get_length_of_field_of_study(field_of_study):
     """
     Returns length of a field of study
     """
-    if field_of_study == 0 or field_of_study == 100:  # others
+    if field_of_study == 0 or field_of_study == 100 or field_of_study == 40:  # others or social
         return 0
     # dont return a bachelor student as 4th or 5th grade
     elif field_of_study == 1:  # bachelor
         return 3
     elif 10 <= field_of_study <= 30:  # 10-30 is considered master
         return 2
-    elif field_of_study == 40:  # social
-        return 1
     elif field_of_study == 80:  # phd
         return 99
     elif field_of_study == 90:  # international

--- a/apps/authentication/tests.py
+++ b/apps/authentication/tests.py
@@ -93,12 +93,12 @@ class AuthenticationTest(TestCase):
     def testSocial(self):
         self.user.started_date = self.now.date()
         self.user.field_of_study = 40
-        self.assertEqual(1, self.user.year)
+        self.assertEqual(0, self.user.year)
 
-    def testTwoYearSocialShouldNotBePossible(self):
+    def testSocialYearIncrementShouldNotBePossible(self):
         self.user.started_date = self.now.date() - timedelta(days=365)
         self.user.field_of_study = 40
-        self.assertEqual(1, self.user.year)
+        self.assertEqual(0, self.user.year)
 
     def testEmailPrimaryOnCreation(self):
         email = G(Email, user=self.user, email="test@test.com")


### PR DESCRIPTION
This is a pull request to fix the bug where social members could sign up for events not meant for them
The fix is the same as the proposed fix

- QA / Code Review

## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [x] I have added tests for the code I added
- [x] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
<!-- this means that other people can use this code without having to do/change anything -->
- [ ] I have updated the build configuration
- [ ] These changes requires changes to configuration in production <!-- E.g. an API token -->
    - [ ] I have applied the required changes in production
    - [ ] I cannot apply the required changes in production before this is deployed.


## Description of changes
Made get_length_of_field_of_study return 0 instead of 1 for social members
Updated the tests for social members to test for year 0 instead of year 1

## Screenshot(s) if appropriate

<!-- provide screenshots (before and after) if doing design changes -->
![image](https://user-images.githubusercontent.com/17146935/45776702-f8f65200-bc53-11e8-9fdd-63d6f7db24eb.png)
