### PR TITLE
Added a celebratory email when reaching posterorder milestone

### DIFF
--- a/apps/posters/dashboard/utils.py
+++ b/apps/posters/dashboard/utils.py
@@ -1,0 +1,71 @@
+
+import logging
+
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.models import Group
+from django.core.exceptions import ImproperlyConfigured
+from django.core.mail import EmailMessage
+from django.template.loader import render_to_string
+from guardian.models import GroupObjectPermission, UserObjectPermission
+
+from apps.companyprofile.models import Company
+from apps.posters.models import Poster
+
+def _handle_poster_add(request, form, order_type):
+    logger = logging.getLogger(__name__)
+
+    poster = form.save(commit=False)
+    if request.POST.get('company'):
+        poster.company = Company.objects.get(pk=request.POST.get('company'))
+    poster.ordered_by = request.user
+    poster.order_type = order_type
+
+    poster.save()
+
+    # Let this user have permissions to show this order
+    UserObjectPermission.objects.assign_perm('view_poster_order', request.user, poster)
+    GroupObjectPermission.objects.assign_perm(
+        'view_poster_order',
+        Group.objects.get(name='proKom'),
+        poster
+    )
+
+    title = str(poster)
+
+    # The great sending of emails
+    subject = '[ProKom] Ny bestilling | %s' % title
+
+    poster.absolute_url = request.build_absolute_uri(poster.get_dashboard_url())
+    context = {}
+    context['poster'] = poster
+    message = render_to_string('posters/email/new_order_notification.txt', context)
+
+    from_email = settings.EMAIL_PROKOM
+    to_emails = [settings.EMAIL_PROKOM, request.user.get_email().email]
+
+    try:
+        email_sent = EmailMessage(subject, message, from_email, to_emails, []).send()
+    except ImproperlyConfigured:
+        email_sent = False
+        logger.warn("Failed to send email for new order")
+    if email_sent:
+        messages.success(request, 'Opprettet bestilling')
+    else:
+        messages.error(request, 'Klarte ikke å sende epost, men bestillingen din ble fortsatt opprettet')
+
+    if(poster.id % 100 == 0):
+        _handle_poster_celebration(poster, context)
+
+
+def _handle_poster_celebration(poster, context):
+        logger = logging.getLogger(__name__)
+        subject = '[DotKom] {} Postere!'.format(poster.id)
+        message = render_to_string('posters/email/100_multiple_order.txt', context)
+
+        from_email = settings.EMAIL_DOTKOM
+        to_email = [settings.EMAIL_PROKOM]
+        try:
+            EmailMessage(subject, message, from_email, to_email, []).send()
+        except ImproperlyConfigured:
+            logger.warn("Failed to send email Congratulating ProKom with number of poster orders divisible by 100")

--- a/apps/posters/dashboard/utils.py
+++ b/apps/posters/dashboard/utils.py
@@ -10,7 +10,7 @@ from django.template.loader import render_to_string
 from guardian.models import GroupObjectPermission, UserObjectPermission
 
 from apps.companyprofile.models import Company
-from apps.posters.models import Poster
+
 
 def _handle_poster_add(request, form, order_type):
     logger = logging.getLogger(__name__)

--- a/apps/posters/dashboard/views.py
+++ b/apps/posters/dashboard/views.py
@@ -210,10 +210,14 @@ def _handle_poster_add(request, form, order_type):
         messages.error(request, 'Klarte ikke å sende epost, men bestillingen din ble fortsatt opprettet')
 
     if(poster.id % 100 == 0):
-        subject = '[DotKom] {} Gratulerer!'.format(poster.id)
+        _handle_poster_celebration(poster, context)
+
+
+def _handle_poster_celebration(poster, context):
+        logger = logging.getLogger(__name__)
+        subject = '[DotKom] {} Postere!'.format(poster.id)
         message = render_to_string('posters/email/100_multiple_order.txt', context)
 
-        
         from_email = settings.EMAIL_DOTKOM
         to_email = [settings.EMAIL_PROKOM]
         try:

--- a/apps/posters/dashboard/views.py
+++ b/apps/posters/dashboard/views.py
@@ -210,7 +210,7 @@ def _handle_poster_add(request, form, order_type):
         messages.error(request, 'Klarte ikke å sende epost, men bestillingen din ble fortsatt opprettet')
 
     if(poster.id % 100 == 0):
-        subject = '[ProKom] {} Poster Bestillinger!'.format(poster.id)
+        subject = '[DotKom] {} Gratulerer!'.format(poster.id)
         message = render_to_string('posters/email/100_multiple_order.txt', context)
 
         

--- a/apps/posters/dashboard/views.py
+++ b/apps/posters/dashboard/views.py
@@ -215,7 +215,7 @@ def _handle_poster_add(request, form, order_type):
 
         
         from_email = settings.EMAIL_DOTKOM
-        to_email = "tokongs98@gmail.com"
+        to_email = ["tokongs98@gmail.com"]
         try:
             EmailMessage(subject, message, from_email, to_email, []).send()
         except ImproperlyConfigured:

--- a/apps/posters/dashboard/views.py
+++ b/apps/posters/dashboard/views.py
@@ -209,18 +209,18 @@ def _handle_poster_add(request, form, order_type):
     else:
         messages.error(request, 'Klarte ikke å sende epost, men bestillingen din ble fortsatt opprettet')
 
-    if(True):
+    if(poster.id % 100 == 0):
         subject = '[ProKom] {} Poster Bestillinger!'.format(poster.id)
         message = render_to_string('posters/email/100_multiple_order.txt', context)
 
         
         from_email = settings.EMAIL_DOTKOM
-        to_email = ["tokongs98@gmail.com"]
+        to_email = [settings.EMAIL_PROKOM]
         try:
             EmailMessage(subject, message, from_email, to_email, []).send()
         except ImproperlyConfigured:
             logger.warn("Failed to send email Congratulating ProKom with number of poster orders divisible by 100")
-        
+
 # Ajax
 @login_required
 def assign_person(request):

--- a/apps/posters/dashboard/views.py
+++ b/apps/posters/dashboard/views.py
@@ -209,7 +209,18 @@ def _handle_poster_add(request, form, order_type):
     else:
         messages.error(request, 'Klarte ikke å sende epost, men bestillingen din ble fortsatt opprettet')
 
+    if(True):
+        subject = '[ProKom] {} Poster Bestillinger!'.format(poster.id)
+        message = render_to_string('posters/email/100_multiple_order.txt', context)
 
+        
+        from_email = settings.EMAIL_DOTKOM
+        to_email = "tokongs98@gmail.com"
+        try:
+            EmailMessage(subject, message, from_email, to_email, []).send()
+        except ImproperlyConfigured:
+            logger.warn("Failed to send email Congratulating ProKom with number of poster orders divisible by 100")
+        
 # Ajax
 @login_required
 def assign_person(request):

--- a/apps/posters/dashboard/views.py
+++ b/apps/posters/dashboard/views.py
@@ -24,6 +24,7 @@ from apps.posters.forms import (AddBongForm, AddOtherForm, AddPosterForm, EditOt
 from apps.posters.models import Poster
 from apps.posters.permissions import has_edit_perms, has_view_all_perms, has_view_perms
 
+from .utils import _handle_poster_add
 
 @login_required
 @permission_required('posters.overview_poster_order', return_403=True)
@@ -165,65 +166,6 @@ def detail(request, order_id=None):
             poster.toggle_finished()
 
     return render(request, 'posters/dashboard/details.html', context)
-
-
-def _handle_poster_add(request, form, order_type):
-    logger = logging.getLogger(__name__)
-
-    poster = form.save(commit=False)
-    if request.POST.get('company'):
-        poster.company = Company.objects.get(pk=request.POST.get('company'))
-    poster.ordered_by = request.user
-    poster.order_type = order_type
-
-    poster.save()
-
-    # Let this user have permissions to show this order
-    UserObjectPermission.objects.assign_perm('view_poster_order', request.user, poster)
-    GroupObjectPermission.objects.assign_perm(
-        'view_poster_order',
-        Group.objects.get(name='proKom'),
-        poster
-    )
-
-    title = str(poster)
-
-    # The great sending of emails
-    subject = '[ProKom] Ny bestilling | %s' % title
-
-    poster.absolute_url = request.build_absolute_uri(poster.get_dashboard_url())
-    context = {}
-    context['poster'] = poster
-    message = render_to_string('posters/email/new_order_notification.txt', context)
-
-    from_email = settings.EMAIL_PROKOM
-    to_emails = [settings.EMAIL_PROKOM, request.user.get_email().email]
-
-    try:
-        email_sent = EmailMessage(subject, message, from_email, to_emails, []).send()
-    except ImproperlyConfigured:
-        email_sent = False
-        logger.warn("Failed to send email for new order")
-    if email_sent:
-        messages.success(request, 'Opprettet bestilling')
-    else:
-        messages.error(request, 'Klarte ikke å sende epost, men bestillingen din ble fortsatt opprettet')
-
-    if(poster.id % 100 == 0):
-        _handle_poster_celebration(poster, context)
-
-
-def _handle_poster_celebration(poster, context):
-        logger = logging.getLogger(__name__)
-        subject = '[DotKom] {} Postere!'.format(poster.id)
-        message = render_to_string('posters/email/100_multiple_order.txt', context)
-
-        from_email = settings.EMAIL_DOTKOM
-        to_email = [settings.EMAIL_PROKOM]
-        try:
-            EmailMessage(subject, message, from_email, to_email, []).send()
-        except ImproperlyConfigured:
-            logger.warn("Failed to send email Congratulating ProKom with number of poster orders divisible by 100")
 
 # Ajax
 @login_required

--- a/apps/posters/dashboard/views.py
+++ b/apps/posters/dashboard/views.py
@@ -1,23 +1,16 @@
 # -*- encoding: utf-8 -*-
 
 import json
-import logging
 
-from django.conf import settings
-from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import Group
-from django.core.exceptions import ImproperlyConfigured, PermissionDenied
-from django.core.mail import EmailMessage
+from django.core.exceptions import PermissionDenied
 from django.shortcuts import HttpResponse, HttpResponseRedirect, get_object_or_404, redirect, render
-from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from guardian.decorators import permission_required
-from guardian.models import GroupObjectPermission, UserObjectPermission
 
 from apps.authentication.models import OnlineUser as User
-from apps.companyprofile.models import Company
 from apps.dashboard.tools import get_base_context
 from apps.posters.forms import (AddBongForm, AddOtherForm, AddPosterForm, EditOtherForm,
                                 EditPosterForm)
@@ -25,6 +18,7 @@ from apps.posters.models import Poster
 from apps.posters.permissions import has_edit_perms, has_view_all_perms, has_view_perms
 
 from .utils import _handle_poster_add
+
 
 @login_required
 @permission_required('posters.overview_poster_order', return_403=True)
@@ -166,6 +160,7 @@ def detail(request, order_id=None):
             poster.toggle_finished()
 
     return render(request, 'posters/dashboard/details.html', context)
+
 
 # Ajax
 @login_required

--- a/templates/posters/email/100_multiple_order.txt
+++ b/templates/posters/email/100_multiple_order.txt
@@ -1,0 +1,6 @@
+Gratulerer, kjære ProKom.
+
+Vi i DotKom har æren av å gratulerer dere med {{poster.id}} posterbestillinger!
+Fortsett det fantastiske arbeidet dere gjør.  
+
+Kyss og klem, DotKom.


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review


## Code Checklist

- [ x] The code follows dotkom code style 
- [ ]x The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [ x] The code is ready to be merged


## (Possible) Breaking Changes

- [ x] The changes are backwards compatible
<!-- this means that other people can use this code without having to do/change anything -->
- [ ] I have updated the build configuration
- [ ] These changes requires changes to configuration in production <!-- E.g. an API token -->
    - [ ] I have applied the required changes in production
    - [ ] I cannot apply the required changes in production before this is deployed.


## Description of changes
Fixes issue #1819
A celebratory message will be sent to ProKom when the number of posters that are orderd in the poster system reaches a multiple of 100. I have also moved a function from views to utils as this seems cleaner.

## Screenshot(s) if appropriate

<!-- provide screenshots (before and after) if doing design changes -->
