### PR TITLE
Attendances logging and notifications

### DIFF
--- a/apps/events/dashboard/utils.py
+++ b/apps/events/dashboard/utils.py
@@ -111,7 +111,7 @@ def handle_remove_attendee(event, attendee_id, admin_user):
     if attendee.count() != 1:
         return 'Fant ingen påmeldte med oppgitt ID (%s).' % attendee_id
     attendee = attendee[0]
-    attendee.manually_unattend(admin_user)
+    attendee.unattend(admin_user)
     resp['message'] = '%s ble fjernet fra %s' % (attendee.user.get_full_name(), attendee.event)
     resp['attendees'] = []
     for number, a in enumerate(attendee.event.attending_attendees_qs):

--- a/apps/events/dashboard/utils.py
+++ b/apps/events/dashboard/utils.py
@@ -14,6 +14,7 @@ def _get_attendee(attendee_id):
 
 def event_ajax_handler(event, request):
     action = request.POST['action']
+    administrating_user = request.user
 
     if action == 'attended':
         attendee = _get_attendee(request.POST['attendee_id'])
@@ -30,7 +31,7 @@ def event_ajax_handler(event, request):
     elif action == 'add_attendee':
         return handle_add_attendee(event, request.POST['user_id'])
     elif action == 'remove_attendee':
-        return handle_remove_attendee(event, request.POST['attendee_id'])
+        return handle_remove_attendee(event, request.POST['attendee_id'], administrating_user)
     else:
         raise NotImplementedError
 
@@ -104,13 +105,13 @@ def handle_add_attendee(event, user_id):
     return resp
 
 
-def handle_remove_attendee(event, attendee_id):
+def handle_remove_attendee(event, attendee_id, admin_user):
     resp = {}
     attendee = Attendee.objects.filter(pk=attendee_id)
     if attendee.count() != 1:
         return 'Fant ingen påmeldte med oppgitt ID (%s).' % attendee_id
     attendee = attendee[0]
-    attendee.delete()
+    attendee.manually_unattend(admin_user)
     resp['message'] = '%s ble fjernet fra %s' % (attendee.user.get_full_name(), attendee.event)
     resp['attendees'] = []
     for number, a in enumerate(attendee.event.attending_attendees_qs):

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -875,13 +875,13 @@ class Attendee(models.Model):
                     (self.user.get_full_name(), self.event, admin_user, datetime.now()))
 
         # Notify responsible group if someone is unattended after deadline
-        if datetime.now() > self.event.unattend_deadline:
+        if datetime.now(self.event.unattend_deadline.tzinfo) >= self.event.unattend_deadline:
             subject = '[%s] %s har blitt avmeldt arrangementet av %s' % (self.event, self.user.get_full_name(),
                                                                          admin_user)
-            message = '%s har blitt avmeldt arrangementet "%s" av %s den %s' % (self.event, self.user.get_full_name(),
+            message = '%s har blitt avmeldt arrangementet "%s" av %s den %s' % (self.user.get_full_name(), self.event,
                                                                                 admin_user, datetime.now())
             from_email = self.event.event.feedback_mail()
-            EmailMessage(subject, message, from_email, from_email).send()
+            EmailMessage(subject, message, from_email, [from_email]).send()
 
         self.delete()
 

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -876,7 +876,8 @@ class Attendee(models.Model):
 
         # Notify responsible group if someone is unattended after deadline
         if datetime.now() > self.event.unattend_deadline:
-            subject = '[%s] %s har blitt avmeldt arrangementet av %s' % (self.event, self.user.get_full_name(), admin_user)
+            subject = '[%s] %s har blitt avmeldt arrangementet av %s' % (self.event, self.user.get_full_name(),
+                                                                         admin_user)
             message = '%s har blitt avmeldt arrangementet "%s" av %s den %s' % (self.event, self.user.get_full_name(),
                                                                                 admin_user, datetime.now())
             from_email = self.event.event.feedback_mail()

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -869,7 +869,8 @@ class Attendee(models.Model):
     def is_on_waitlist(self):
         return self in self.event.waitlist_qs
 
-    def manually_unattend(self, admin_user):
+    # Unattend user from event
+    def unattend(self, admin_user):
         logger = logging.getLogger(__name__)
         logger.info('User %s was removed from event "%s" by %s on %s' %
                     (self.user.get_full_name(), self.event, admin_user, datetime.now()))

--- a/templates/events/email/unattend.txt
+++ b/templates/events/email/unattend.txt
@@ -1,0 +1,1 @@
+{{ user }} (#{{ user_id }}) har blitt avmeldt arrangementet "{{ event }}" av {{ admin }} (#{{ admin_id }}) den {{ time }}.


### PR DESCRIPTION
## What kind of a pull request is this?
Improvement and better logging of removed attendees from events. 
#2128 

## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code is ready to be merged

## Description of changes
When a user is removed from an event after the deadline, the group who created it will get a notification by email that someone has been removed. This will also be in the logs.

The method implemented (unattend()) in the Attendee model is currently only used by dashboard.
Removal of attendees in the admin panel is already disabled, hence not requiring the method.