### PR TITLE
Send payment-reminder mail when signing up for a payed event

### DIFF
--- a/apps/events/tests/view_tests.py
+++ b/apps/events/tests/view_tests.py
@@ -11,7 +11,7 @@ from freezegun import freeze_time
 from rest_framework import status
 
 from apps.authentication.models import AllowedUsername
-from apps.payment.models import PaymentDelay
+from apps.payment.models import PaymentDelay, PaymentPrice
 
 from ..models import TYPE_CHOICES, AttendanceEvent, Event, Extras, GroupRestriction
 from .utils import (add_payment_delay, add_to_arrkom, add_to_bedkom, add_to_trikom,
@@ -336,7 +336,8 @@ class EventsAttend(EventsTestMixin, TestCase):
         G(AttendanceEvent, event=event,
             registration_start=timezone.now() - timedelta(days=1),
             registration_end=timezone.now() + timedelta(days=1))
-        generate_payment(event, payment_type=3, delay=timedelta(days=2))
+        self.event_payment = generate_payment(event, payment_type=3, delay=timedelta(days=2))
+        G(PaymentPrice, price=200, payment=self.event_payment)
         url = reverse('attend_event', args=(event.id,))
         # django-recatpcha magic when RECAPTCHA_TESTING=True
         form_params = {'g-recaptcha-response': 'PASSED'}

--- a/apps/events/utils.py
+++ b/apps/events/utils.py
@@ -336,10 +336,15 @@ def handle_attend_event_payment(event, user):
             # Send notification about payment to user by mail
             subject = '[%s] Husk å betale for og fullføre påmeldingen til arrangementet.' % event.title
 
+            if payment.price() is not None:
+                price = payment.price().price
+            else:
+                price = 0
+
             content = render_to_string('events/email/payment_reminder.txt', {
                 'event': event.title,
                 'time': payment.deadline.astimezone(tz('Europe/Oslo')).strftime("%-d %B %Y kl. %H:%M"),
-                'price': payment.price().price
+                'price': price
             })
 
             EmailMessage(subject, content, event.feedback_mail(), [user.get_email]).send()

--- a/apps/events/utils.py
+++ b/apps/events/utils.py
@@ -10,6 +10,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMessage, send_mail
 from django.core.signing import BadSignature, Signer
 from django.http import HttpResponse
+from django.template.loader import render_to_string
 from django.utils import timezone
 from filebrowser.settings import VERSIONS
 from pytz import timezone as tz
@@ -334,12 +335,14 @@ def handle_attend_event_payment(event, user):
 
             # Send notification about payment to user by mail
             subject = '[%s] Husk å betale for og fullføre påmeldingen til arrangementet.' % event.title
-            message = 'Du har meldt deg på "%s" som er et betalings arrangement. \nFor å fullføre påmeldingen, ' \
-                      'er du nødt til å gå inn på arrangementets side og klikke "betal". \n' \
-                      'Betalingen må gjennomføres innen den %s, og summen er på: %s kr.' % \
-                      (event.title, payment.deadline.astimezone(tz('Europe/Oslo')).strftime("%-d %B %Y kl. %H:%M"),
-                       payment.price().price)
-            EmailMessage(subject, message, event.feedback_mail(), [user.get_email]).send()
+
+            content = render_to_string('events/email/payment_reminder.txt', {
+                'event': event.title,
+                'time': payment.deadline.astimezone(tz('Europe/Oslo')).strftime("%-d %B %Y kl. %H:%M"),
+                'price': payment.price().price
+            })
+
+            EmailMessage(subject, content, event.feedback_mail(), [user.get_email]).send()
 
 
 def handle_mail_participants(event, _from_email, _to_email_value, subject, _message,

--- a/apps/events/utils.py
+++ b/apps/events/utils.py
@@ -336,15 +336,10 @@ def handle_attend_event_payment(event, user):
             # Send notification about payment to user by mail
             subject = '[%s] Husk å betale for og fullføre påmeldingen til arrangementet.' % event.title
 
-            if payment.price() is not None:
-                price = payment.price().price
-            else:
-                price = 0
-
             content = render_to_string('events/email/payment_reminder.txt', {
                 'event': event.title,
                 'time': payment.deadline.astimezone(tz('Europe/Oslo')).strftime("%-d %B %Y kl. %H:%M"),
-                'price': price
+                'price': payment.price().price
             })
 
             EmailMessage(subject, content, event.feedback_mail(), [user.get_email]).send()

--- a/templates/events/email/payment_reminder.txt
+++ b/templates/events/email/payment_reminder.txt
@@ -1,0 +1,5 @@
+Hei!
+
+Du har meldt deg på {{ event }} som er et betalings arrangement.
+For å fullføre påmeldingen, er du nødt til å gå inn på arrangementets side og klikke "betal".
+Betalingen må gjennomføres innen den {{ time }}, og summen er på: {{ price }} kr.


### PR DESCRIPTION
## What kind of a pull request is this?
Feature request #1885 


## Code Checklist
- [x] The code follows dotkom code style 
- [x] The code is ready to be merged

## Description of changes
Added notification email to the flow of signing up for a payed event. 
Users will now receive an email with details about the payment and deadline.