### PR TITLE
Set a max length for two fields in the form for adding career opportunities

### DIFF
--- a/apps/careeropportunity/forms.py
+++ b/apps/careeropportunity/forms.py
@@ -5,9 +5,9 @@ from apps.careeropportunity.models import CareerOpportunity
 
 class AddCareerOpportunityForm(forms.ModelForm):
 
-    title = forms.CharField(label='Tittel', required=True, widget=forms.TextInput(
+    title = forms.CharField(label='Tittel', required=True, max_length=100, widget=forms.TextInput(
         attrs={'placeholder': 'Tittel for karrieremuligheten'}))
-    ingress = forms.CharField(label='Ingress', required=True, widget=forms.Textarea(
+    ingress = forms.CharField(label='Ingress', required=True, max_length=250, widget=forms.Textarea(
         attrs={'placeholder': 'Kort ingress til karrieremuligheten (Max 250 tegn)'}))
     description = forms.CharField(label='Beskrivelse', required=True, widget=forms.Textarea(
         attrs={'placeholder': 'Detaljert beskrivelse av karrieremuligheten'}))


### PR DESCRIPTION

## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x ] The code follows dotkom code style 
- [x ] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [ x] The code is ready to be merged


## (Possible) Breaking Changes

- [ x] The changes are backwards compatible
<!-- this means that other people can use this code without having to do/change anything -->
- [ ] I have updated the build configuration
- [ ] These changes requires changes to configuration in production <!-- E.g. an API token -->
    - [ ] I have applied the required changes in production
    - [ ] I cannot apply the required changes in production before this is deployed.


## Description of changes
Issue #1956 calls for better feedback when creating a career opportunity in the dashboard, so I added a max length to the title field and the ingress field as I think that will mitigate the need for better feedback. I don't really see what other wrong data you could enter as the form is now.

## Screenshot(s) if appropriate

<!-- provide screenshots (before and after) if doing design changes -->
