### PR TITLE
Page size parameter for the rest api

### DIFF
--- a/onlineweb4/settings/rest_framework.py
+++ b/onlineweb4/settings/rest_framework.py
@@ -18,6 +18,6 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.BrowsableAPIRenderer',
         'rest_framework.renderers.AdminRenderer',
     ],
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'DEFAULT_PAGINATION_CLASS': 'utils.pagination.PageNumberPagination',
     'PAGE_SIZE': 10
 }

--- a/utils/pagination.py
+++ b/utils/pagination.py
@@ -4,7 +4,7 @@ from rest_framework.pagination import PageNumberPagination as RFPageNumberPagina
 class PageNumberPagination(RFPageNumberPagination):
     page_size = 10
     max_page_size = 80
-    
+
     def get_page_size(self, request):
         if ('page_size' in request.query_params) and request.query_params['page_size'].isnumeric():
             return min(self.max_page_size, int(request.query_params['page_size']))

--- a/utils/pagination.py
+++ b/utils/pagination.py
@@ -7,6 +7,6 @@ class PageNumberPagination(RFPageNumberPagination):
     max_page_size = 80
     
     def get_page_size(self, request):
-        if 'size' in request.query_params:
-            return min(self.max_page_size, int(request.query_params['size']))
+        if 'page_size' in request.query_params:
+            return min(self.max_page_size, int(request.query_params['page_size']))
         return self.page_size

--- a/utils/pagination.py
+++ b/utils/pagination.py
@@ -1,4 +1,3 @@
-import six
 from rest_framework.pagination import PageNumberPagination as RFPageNumberPagination
 
 

--- a/utils/pagination.py
+++ b/utils/pagination.py
@@ -1,0 +1,12 @@
+import six
+from rest_framework.pagination import PageNumberPagination as RFPageNumberPagination
+
+
+class PageNumberPagination(RFPageNumberPagination):
+    page_size = 10
+    max_page_size = 80
+    
+    def get_page_size(self, request):
+        if 'size' in request.query_params:
+            return min(self.max_page_size, int(request.query_params['size']))
+        return self.page_size

--- a/utils/pagination.py
+++ b/utils/pagination.py
@@ -6,6 +6,6 @@ class PageNumberPagination(RFPageNumberPagination):
     max_page_size = 80
     
     def get_page_size(self, request):
-        if 'page_size' in request.query_params:
+        if ('page_size' in request.query_params) and request.query_params['page_size'].isnumeric():
             return min(self.max_page_size, int(request.query_params['page_size']))
         return self.page_size


### PR DESCRIPTION
## What kind of a pull request is this?
- QA

## Code Checklist

- [x] The code follows dotkom code style 
- [ ] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
- [ ] I have updated the build configuration
- [ ] These changes requires changes to configuration in production <!-- E.g. an API token -->
    - [ ] I have applied the required changes in production
    - [ ] I cannot apply the required changes in production before this is deployed.


## Description of changes
Added a custom paginator for the rest api framework that allows a request to set a custom page size using the `page_size` parameter. This allows use to reduce the amount of api calls.
Also set the default paginator to the new custom one, but kept default page size to 10 in order to not break apps which might assume the default is always 10.
