### PR TITLE
Change poster so entire ordered committee can edit poster, and entire prokom

### DIFF
--- a/apps/posters/dashboard/utils.py
+++ b/apps/posters/dashboard/utils.py
@@ -22,12 +22,18 @@ def _handle_poster_add(request, form, order_type):
     poster.order_type = order_type
 
     poster.save()
+    ordered_committee = form.cleaned_data['ordered_committee']
 
     # Let this user have permissions to show this order
     UserObjectPermission.objects.assign_perm('view_poster_order', request.user, poster)
     GroupObjectPermission.objects.assign_perm(
         'view_poster_order',
         Group.objects.get(name='proKom'),
+        poster
+    )
+    GroupObjectPermission.objects.assign_perm(
+        'view_poster_order',
+        ordered_committee,
         poster
     )
 

--- a/apps/posters/permissions.py
+++ b/apps/posters/permissions.py
@@ -12,9 +12,13 @@ def has_view_perms(user, poster):
     return (
         user in Group.objects.get(name='dotKom').user_set.all() or
         user in Group.objects.get(name='proKom').user_set.all() or
+        user in poster.ordered_committee.user_set.all() or
         user == poster.ordered_by
     )
 
 
 def has_edit_perms(user, *args):
-    return user in Group.objects.get(name='proKom').user_set.all()
+    return (
+        user in Group.objects.get(name='proKom').user_set.all() or
+        user in args[0].ordered_committee.user_set.all()
+    )


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
<!-- this means that other people can use this code without having to do/change anything -->
- [ ] I have updated the build configuration
- [ ] These changes requires changes to configuration in production <!-- E.g. an API token -->
    - [ ] I have applied the required changes in production
    - [ ] I cannot apply the required changes in production before this is deployed.


## Description of changes
Changes the permissions of posters view in dashboard, so that entire ordered committee can see and edit a poster, and all of prokom can see and edit.

## Screenshot(s) if appropriate

<!-- provide screenshots (before and after) if doing design changes -->
