### PR TITLE
Fix paid event reminder email failing

### DIFF
--- a/apps/events/tests/utils.py
+++ b/apps/events/tests/utils.py
@@ -3,7 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from django_dynamic_fixture import G
 from guardian.shortcuts import assign_perm, get_perms_for_model
 
-from apps.authentication.models import OnlineUser
+from apps.authentication.models import Email, OnlineUser
 from apps.payment.models import Payment, PaymentDelay, PaymentRelation
 
 from ..models import TYPE_CHOICES, AttendanceEvent, Attendee, Event
@@ -60,7 +60,9 @@ def add_payment_delay(payment, user):
 
 
 def generate_user(username):
-    return G(OnlineUser, username=username, ntnu_username=username)
+    user = G(OnlineUser, username=username, ntnu_username=username)
+    G(Email, user=user)
+    return user
 
 
 def generate_attendee(event, username):

--- a/apps/events/utils.py
+++ b/apps/events/utils.py
@@ -344,7 +344,7 @@ def handle_attend_event_payment(event, user):
             'price': payment.price().price
         })
 
-        EmailMessage(subject, content, event.feedback_mail(), [user.get_email]).send()
+        EmailMessage(subject, content, event.feedback_mail(), [user.get_email().email]).send()
 
 
 def handle_mail_participants(event, _from_email, _to_email_value, subject, _message,


### PR DESCRIPTION
## What kind of a pull request is this?
Bugfix
- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
<!-- this means that other people can use this code without having to do/change anything -->
- [ ] I have updated the build configuration
- [ ] These changes requires changes to configuration in production <!-- E.g. an API token -->
    - [ ] I have applied the required changes in production
    - [ ] I cannot apply the required changes in production before this is deployed.


## Description of changes
Fixes `to` field of email reminding people to pay for paid events

## Screenshot(s) if appropriate
Logs from signing up to an event, look at the `to:` field, which is the fixed thing
Before:
<img width="990" alt="screenshot 2019-03-06 at 23 33 31" src="https://user-images.githubusercontent.com/36937807/53919263-cc02f380-4069-11e9-9bb0-5e270d971e5d.png">
After:
<img width="990" alt="screenshot 2019-03-06 at 23 33 18" src="https://user-images.githubusercontent.com/36937807/53919268-cf967a80-4069-11e9-8158-ec28dd935fea.png">

<!-- provide screenshots (before and after) if doing design changes -->
