### PR TITLE
Restrict attendee endpoint to only list attendees for event user can …

### DIFF
--- a/apps/events/filters.py
+++ b/apps/events/filters.py
@@ -1,5 +1,6 @@
 import django_filters
 from django_filters.filters import BaseInFilter, NumberFilter
+from guardian.shortcuts import get_objects_for_user
 
 from apps.events.models import Attendee, Event
 
@@ -15,6 +16,7 @@ class EventDateFilter(django_filters.FilterSet):
     event_end__lte = django_filters.DateTimeFilter(field_name='event_end', lookup_expr='lte')
     attendance_event__isnull = django_filters.BooleanFilter(field_name='attendance_event', lookup_expr='isnull')
     is_attendee = django_filters.BooleanFilter(field_name='attendance_event', method='filter_is_attendee')
+    can_change = django_filters.BooleanFilter(method='filter_can_change')
     event_type = EventTypeInFilter(field_name='event_type', lookup_expr='in')
 
     def filter_is_attendee(self, queryset, name, value):
@@ -31,6 +33,31 @@ class EventDateFilter(django_filters.FilterSet):
         if value:
             return queryset.filter(pk__in=attending_events)
         return queryset.all()
+
+    def filter_can_change(self, queryset, name, value):
+        """
+        Filter events based on if the user has permission to change them
+        """
+
+        """ If filter is set to False, don't filter """
+        if not value:
+            return queryset
+
+        user = self.request.user
+        """ User cannot attend events if they are not logged in """
+        if not user.is_authenticated:
+            return queryset.none()
+        """ Don't filter on this field if user is a superuser """
+        if user.is_superuser:
+            return queryset
+
+        allowed_events = get_objects_for_user(
+            user,
+            'events.change_event',
+            accept_global_perms=False,
+            klass=queryset
+        )
+        return allowed_events
 
     class Meta:
         model = Event

--- a/apps/events/tests/api_tests.py
+++ b/apps/events/tests/api_tests.py
@@ -89,12 +89,10 @@ class AttendAPITestCase(OAuth2TestCase):
             attendee.refresh_from_db()
             attendee.user.refresh_from_db()
 
-    """
     def test_missing_auth_returns_unauthorized(self):
         response = self.client.post(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-    """
 
     def test_missing_data_returns_bad_request(self):
         response = self.client.post(self.url, **self.headers)

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -470,6 +470,12 @@ class AttendViewSet(views.APIView):
     @staticmethod
     def _authorize_user(user, event_id):
         try:
+            if not event_id:
+                return Response({
+                    'message': 'Arrangementets id er ikke oppgitt',
+                    'attend_status': 42
+                    }, status=status.HTTP_400_BAD_REQUEST)
+
             event_object = Event.objects.get(pk=event_id)
             if not user.is_authenticated:
                 return Response({

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -17,8 +17,6 @@ from django.utils import timezone
 from django.utils.translation import ugettext as _
 # API v1
 from guardian.shortcuts import get_objects_for_user
-from oauth2_provider.contrib.rest_framework import OAuth2Authentication, TokenHasScope
-from apps.oidc_provider.authentication import OidcOauth2Auth
 from rest_framework import mixins, status, views, viewsets
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -33,6 +31,7 @@ from apps.events.serializers import (AttendanceEventSerializer, AttendeeSerializ
                                      CompanyEventSerializer, EventSerializer)
 from apps.events.utils import (handle_attend_event_payment, handle_attendance_event_detail,
                                handle_event_ajax, handle_event_payment, handle_mail_participants)
+from apps.oidc_provider.authentication import OidcOauth2Auth
 from apps.payment.models import Payment, PaymentDelay, PaymentRelation
 
 from .utils import EventCalendar
@@ -424,7 +423,7 @@ class CompanyEventViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mi
 
 class AttendViewSet(views.APIView):
     authentication_classes = [OidcOauth2Auth]
-    
+
     @staticmethod
     def _validate_attend_params(rfid, username):
         logger = logging.getLogger(__name__)

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -402,6 +402,8 @@ class AttendeeViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins
     filter_fields = ('event', 'attended',)
 
     def get_queryset(self):
+        if self.request.user.is_superuser:
+            return Attendee.objects.all()
         allowed_events = get_objects_for_user(
             self.request.user,
             'events.change_event',

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -396,6 +396,9 @@ class AttendanceEventViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin,
 
 class AttendeeViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.ListModelMixin):
     serializer_class = AttendeeSerializer
+    authentication_classes = [OAuth2Authentication]
+    permission_classes = [TokenHasScope]
+    required_scopes = ['regme.readwrite']
     filter_fields = ('event', 'attended',)
 
     @staticmethod

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -466,6 +466,12 @@ class AttendViewSet(views.APIView):
     @staticmethod
     def _authorize_user(user, event_id):
         try:
+            if not user.is_authenticated:
+                return Response({
+                    'message': 'Administerende bruker må være logget inn for å registrere oppmøte',
+                    'attend_status': 60
+                    }, status=status.HTTP_401_UNAUTHORIZED)
+
             if not event_id:
                 return Response({
                     'message': 'Arrangementets id er ikke oppgitt',
@@ -473,11 +479,6 @@ class AttendViewSet(views.APIView):
                     }, status=status.HTTP_400_BAD_REQUEST)
 
             event_object = Event.objects.get(pk=event_id)
-            if not user.is_authenticated:
-                return Response({
-                    'message': 'Administerende bruker må være logget inn for å registrere oppmøte',
-                    'attend_status': 60
-                    }, status=status.HTTP_401_UNAUTHORIZED)
             if not user.has_perm('events.change_event', event_object):
                 return Response({
                     'message': 'Administerende bruker har ikke rettigheter til å registrere oppmøte '

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -18,6 +18,7 @@ from django.utils.translation import ugettext as _
 # API v1
 from guardian.shortcuts import get_objects_for_user
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication, TokenHasScope
+from apps.oidc_provider.authentication import OidcOauth2Auth
 from rest_framework import mixins, status, views, viewsets
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -396,9 +397,9 @@ class AttendanceEventViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin,
 
 class AttendeeViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.ListModelMixin):
     serializer_class = AttendeeSerializer
-    authentication_classes = [OAuth2Authentication]
-    permission_classes = [TokenHasScope]
-    required_scopes = ['regme.readwrite']
+    authentication_classes = [OidcOauth2Auth]
+    #permission_classes = [TokenHasScope]
+    #required_scopes = ['regme.readwrite']
     filter_fields = ('event', 'attended',)
 
     @staticmethod
@@ -424,9 +425,9 @@ class CompanyEventViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mi
 
 
 class AttendViewSet(views.APIView):
-    authentication_classes = [OAuth2Authentication]
-    permission_classes = [TokenHasScope]
-    required_scopes = ['regme.readwrite']
+    authentication_classes = [OidcOauth2Auth]
+    #permission_classes = [TokenHasScope]
+    #required_scopes = ['regme.readwrite']
 
     @staticmethod
     def _validate_attend_params(rfid, username):

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -398,8 +398,6 @@ class AttendanceEventViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin,
 class AttendeeViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.ListModelMixin):
     serializer_class = AttendeeSerializer
     authentication_classes = [OidcOauth2Auth]
-    #permission_classes = [TokenHasScope]
-    #required_scopes = ['regme.readwrite']
     filter_fields = ('event', 'attended',)
 
     @staticmethod
@@ -426,9 +424,7 @@ class CompanyEventViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mi
 
 class AttendViewSet(views.APIView):
     authentication_classes = [OidcOauth2Auth]
-    #permission_classes = [TokenHasScope]
-    #required_scopes = ['regme.readwrite']
-
+    
     @staticmethod
     def _validate_attend_params(rfid, username):
         logger = logging.getLogger(__name__)


### PR DESCRIPTION
…change

## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

Applications depending on getting attendees without restrictions may break

## Description of changes

Restrict list of attendees to only show attendees for the events a user has access to change.

## Screenshot(s) if appropriate

<!-- provide screenshots (before and after) if doing design changes -->
