### PR TITLE
Fix typeerror on mail_participants.html

### DIFF
--- a/assets/events/details/less/event_details.less
+++ b/assets/events/details/less/event_details.less
@@ -274,7 +274,3 @@ section#event-details {
     text-align: center;
   }
 }
-
-#attendeesAmount {
-  font-size: 18px;
-}

--- a/assets/events/mail/index.js
+++ b/assets/events/mail/index.js
@@ -1,0 +1,1 @@
+import './less/mail_participants.less';

--- a/assets/events/mail/less/mail_participants.less
+++ b/assets/events/mail/less/mail_participants.less
@@ -1,0 +1,12 @@
+.attendees-amount {
+  font-size: 18px;
+}
+
+.send-mail-form {
+  margin-top: 30px;
+}
+
+.alert-warning {
+  padding: 10px;
+  text-align: center;
+}

--- a/templates/events/mail_participants.html
+++ b/templates/events/mail_participants.html
@@ -7,7 +7,6 @@ Send epost til påmeldte - Online
 
 {% block js %}
 	{{ block.super }}
-	{% render_bundle 'eventsDetails' 'js' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/events/mail_participants.html
+++ b/templates/events/mail_participants.html
@@ -7,6 +7,7 @@ Send epost til påmeldte - Online
 
 {% block js %}
 	{{ block.super }}
+	{% render_bundle 'eventsMail' %}
 {% endblock %}
 
 {% block content %}
@@ -19,7 +20,7 @@ Send epost til påmeldte - Online
                 </div>
             </div>
         </div>
-        <div class="row" id="attendeesAmount">
+        <div class="row attendees-amount">
             <div class="col-md-4">
 				Påmeldte: {{ all_attendees|length }}
             </div>
@@ -29,7 +30,7 @@ Send epost til påmeldte - Online
             <div class="col-md-4">
 				Påmeldte som ikke har betalt: {{ attendees_not_paid|length }}
         </div>
-        <div class="row" style="margin-top:30px">
+        <div class="row send-mail-form">
             <div class="col-md-6">
                 <h3>Send epost direkte</h3>
                 <form method="post" onsubmit="return confirm('Har du dobbeltsjekket informasjonen og vil sende denne eposten?');">
@@ -64,7 +65,7 @@ Send epost til påmeldte - Online
                         <label for="message">Melding</label>
                         <textarea id="message" name="message" class="form-control" rows="5"></textarea>
                     </div>
-                    <p style="padding:10px; text-align:center" class="alert-warning">Vi legger automatisk på signatur for deg, skriv BARE din beskjed.</p>
+                    <p class="alert-warning">Vi legger automatisk på signatur for deg, skriv BARE din beskjed.</p>
                     <input name="submit" class="btn btn-success" type="submit" value="Send" />
                 </form>
             </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,6 +79,9 @@ const webpackConfig = {
     eventsDetails: [
       './assets/events/details/index',
     ],
+    eventsMail: [
+      './assets/events/mail/index',
+    ],
     feedback: [
       './assets/feedback/index',
     ],


### PR DESCRIPTION
## What kind of a pull request is this?

Bugfix 
Fixes [this](https://sentry.io/organizations/dotkom/issues/930352354/?project=204971&referrer=alert_email)

## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible

## Description of changes
The template was loading an apparently unused script, which is used to choose extras on the eventdetailspage, and was trying to read some global variables that are set in `details.html`, but not in `mail_participants.html`, so moved the CSS rule from that package into a new one, and did other cleanup