### PR TITLE
Attach image to mail

### DIFF
--- a/apps/events/utils.py
+++ b/apps/events/utils.py
@@ -351,7 +351,7 @@ def handle_attend_event_payment(event, user):
         EmailMessage(subject, content, event.feedback_mail(), [user.get_email().email]).send()
 
 
-def handle_mail_participants(event, _from_email, _to_email_value, subject, _message,
+def handle_mail_participants(event, _from_email, _to_email_value, subject, _message, _image,
                              all_attendees, attendees_on_waitlist, attendees_not_paid):
     logger = logging.getLogger(__name__)
 
@@ -384,13 +384,13 @@ def handle_mail_participants(event, _from_email, _to_email_value, subject, _mess
     send_to_users = _to_email_options[_to_email_value][0]
 
     signature = '\n\nVennlig hilsen Linjeforeningen Online.\n(Denne eposten kan besvares til %s)' % from_email
-
     message = '%s%s' % (_message, signature)
 
     # Send mail
     try:
         email_addresses = [a.user.get_email().email for a in send_to_users]
-        _email_sent = EmailMessage(str(subject), str(message), from_email, [from_email], email_addresses).send()
+        _email_sent = EmailMessage(str(subject), str(message), from_email, [
+                                   from_email], email_addresses, attachments=_image).send()
         logger.info('Sent mail to %s for event "%s".' % (_to_email_options[_to_email_value][1], event))
         return _email_sent, all_attendees, attendees_on_waitlist, attendees_not_paid
     except ImproperlyConfigured as e:

--- a/apps/events/utils.py
+++ b/apps/events/utils.py
@@ -351,7 +351,7 @@ def handle_attend_event_payment(event, user):
         EmailMessage(subject, content, event.feedback_mail(), [user.get_email().email]).send()
 
 
-def handle_mail_participants(event, _from_email, _to_email_value, subject, _message, _image,
+def handle_mail_participants(event, _from_email, _to_email_value, subject, _message, _images,
                              all_attendees, attendees_on_waitlist, attendees_not_paid):
     logger = logging.getLogger(__name__)
 
@@ -385,12 +385,17 @@ def handle_mail_participants(event, _from_email, _to_email_value, subject, _mess
 
     signature = '\n\nVennlig hilsen Linjeforeningen Online.\n(Denne eposten kan besvares til %s)' % from_email
     message = '%s%s' % (_message, signature)
-
     # Send mail
     try:
         email_addresses = [a.user.get_email().email for a in send_to_users]
-        _email_sent = EmailMessage(str(subject), str(message), from_email, [
-                                   from_email], email_addresses, attachments=_image).send()
+        _email_sent = EmailMessage(
+            str(subject),
+            str(message),
+            from_email,
+            [from_email],
+            email_addresses,
+            attachments=(_images)
+        ).send()
         logger.info('Sent mail to %s for event "%s".' % (_to_email_options[_to_email_value][1], event))
         return _email_sent, all_attendees, attendees_on_waitlist, attendees_not_paid
     except ImproperlyConfigured as e:

--- a/apps/events/utils.py
+++ b/apps/events/utils.py
@@ -384,7 +384,9 @@ def handle_mail_participants(event, _from_email, _to_email_value, subject, _mess
     send_to_users = _to_email_options[_to_email_value][0]
 
     signature = '\n\nVennlig hilsen Linjeforeningen Online.\n(Denne eposten kan besvares til %s)' % from_email
+
     message = '%s%s' % (_message, signature)
+
     # Send mail
     try:
         email_addresses = [a.user.get_email().email for a in send_to_users]

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -331,9 +331,10 @@ def mail_participants(request, event_id):
     if request.method == 'POST':
         subject = request.POST.get('subject')
         message = request.POST.get('message')
+        image = request.POST.get('image')
 
         mail_sent = handle_mail_participants(event, request.POST.get('from_email'), request.POST.get('to_email'),
-                                             subject, message, all_attendees, attendees_on_waitlist, attendees_not_paid)
+                                             subject, message, image, all_attendees, attendees_on_waitlist, attendees_not_paid)
 
         if mail_sent:
             messages.success(request, _('Mailen ble sendt'))

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -332,8 +332,17 @@ def mail_participants(request, event_id):
         subject = request.POST.get('subject')
         message = request.POST.get('message')
         images = [(image.name, image.read(), image.content_type) for image in request.FILES.getlist('image')]
-        mail_sent = handle_mail_participants(event, request.POST.get('from_email'), request.POST.get('to_email'),
-                                             subject, message, images, all_attendees, attendees_on_waitlist, attendees_not_paid)
+        mail_sent = handle_mail_participants(
+            event,
+            request.POST.get('from_email'),
+            request.POST.get('to_email'),
+            subject,
+            message,
+            images,
+            all_attendees,
+            attendees_on_waitlist,
+            attendees_not_paid
+        )
 
         if mail_sent:
             messages.success(request, _('Mailen ble sendt'))

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -331,10 +331,9 @@ def mail_participants(request, event_id):
     if request.method == 'POST':
         subject = request.POST.get('subject')
         message = request.POST.get('message')
-        image = request.POST.get('image')
-
+        images = [(image.name, image.read(), image.content_type) for image in request.FILES.getlist('image')]
         mail_sent = handle_mail_participants(event, request.POST.get('from_email'), request.POST.get('to_email'),
-                                             subject, message, image, all_attendees, attendees_on_waitlist, attendees_not_paid)
+                                             subject, message, images, all_attendees, attendees_on_waitlist, attendees_not_paid)
 
         if mail_sent:
             messages.success(request, _('Mailen ble sendt'))

--- a/templates/events/mail_participants.html
+++ b/templates/events/mail_participants.html
@@ -67,7 +67,7 @@ Send epost til påmeldte - Online
                     </div>
                     <div class="form-group">
                         <label for="image">Bilder</label>
-                        <input type="file" id="image" name="image" accept="image/png, image/jpeg">
+                        <input type="file" name="image" accept="image/png, image/jpeg" multiple>
                     </div>
                     <p class="alert-warning">Vi legger automatisk på signatur for deg, skriv BARE din beskjed.</p>
                     <input name="submit" class="btn btn-success" type="submit" value="Send" />

--- a/templates/events/mail_participants.html
+++ b/templates/events/mail_participants.html
@@ -33,7 +33,7 @@ Send epost til påmeldte - Online
         <div class="row send-mail-form">
             <div class="col-md-6">
                 <h3>Send epost direkte</h3>
-                <form method="post" onsubmit="return confirm('Har du dobbeltsjekket informasjonen og vil sende denne eposten?');">
+                <form method="post" enctype="multipart/form-data" onsubmit="return confirm('Har du dobbeltsjekket informasjonen og vil sende denne eposten?');">
                     {% csrf_token %}
                     <div class="form-group">
                         <label for="to_email">Til epost</label>
@@ -64,6 +64,10 @@ Send epost til påmeldte - Online
                     <div class="form-group">
                         <label for="message">Melding</label>
                         <textarea id="message" name="message" class="form-control" rows="5"></textarea>
+                    </div>
+                    <div class="form-group">
+                        <label for="image">Bilder</label>
+                        <input type="file" id="image" name="image" accept="image/png, image/jpeg">
                     </div>
                     <p class="alert-warning">Vi legger automatisk på signatur for deg, skriv BARE din beskjed.</p>
                     <input name="submit" class="btn btn-success" type="submit" value="Send" />


### PR DESCRIPTION
## What kind of a pull request is this?
This pullrequest should implement Issue #2183. With this pullrequest i believe you should be able to add images as attachments and it should be attached to the mail. You're also able to choose multiple attachments. Not sure if its gonna be embeded or attached since i wasnt able to view the physical mail in the terminal, however i can see the image in raw text format at least. I havent added any max size or anything since idk what the limit should be
## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
<!-- this means that other people can use this code without having to do/change anything -->
- [ ] I have updated the build configuration
- [ ] These changes requires changes to configuration in production <!-- E.g. an API token -->
    - [ ] I have applied the required changes in production
    - [ ] I cannot apply the required changes in production before this is deployed.


## Description of changes
Adds an optional file upload input in the form for sending mail to all event participants such that you can send multiple images. 

## Screenshot(s) if appropriate
![yahoo](https://user-images.githubusercontent.com/41551253/54624748-4110f880-4a6e-11e9-8c68-b853f3b95dba.png)

<!-- provide screenshots (before and after) if doing design changes -->
