### PR TITLE
Add view for listing all wiki articles

### DIFF
--- a/onlineweb4/urls.py
+++ b/onlineweb4/urls.py
@@ -34,7 +34,8 @@ urlpatterns = [
 
     # Wiki
     url(r'^notify/', include('django_nyt.urls')),
-    url(r'^wiki/', include('wiki.urls'))
+    url(r'^wiki/', include('wiki.urls')),
+    url(r'^wiki-tree/', views.WikiTreeView.as_view(), name='wiki-tree', kwargs={'path': ''})
 ]
 
 

--- a/onlineweb4/views.py
+++ b/onlineweb4/views.py
@@ -6,7 +6,11 @@ from django.conf import settings
 from django.contrib import messages
 from django.core.mail import send_mail
 from django.shortcuts import redirect, render
+from django.utils.decorators import method_decorator
+from django.views.generic.base import TemplateView
 from onlineweb4.forms import ErrorForm
+from wiki.decorators import get_article
+from wiki.views.mixins import ArticleMixin
 
 
 def server_error(request):
@@ -30,3 +34,19 @@ def server_error(request):
             messages.error(request, 'Det oppstod en uventet feil under sending av feilmeldingen')
             return redirect('home')
     return render(request, '500.html', {'error_form': ErrorForm})
+
+class WikiTreeView(ArticleMixin, TemplateView):
+    template_name = 'wiki/tree.html'
+
+    @method_decorator(get_article(can_read=True))
+    def dispatch(self, request, *args, **kwargs):
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['selected_tab'] = 'view'
+        article_context = ArticleMixin.get_context_data(self, **kwargs)
+        descendants = article_context['urlpath'].root().get_descendants()
+        descendants = [descendant for descendant in descendants if descendant.article.can_read(self.request.user)]
+        article_context['descendants'] = descendants
+        return article_context

--- a/templates/wiki/tree.html
+++ b/templates/wiki/tree.html
@@ -1,0 +1,60 @@
+{% extends 'base.html' %}
+
+{% load static %}
+{% load i18n wiki_tags %}
+{% load render_bundle from webpack_loader %}
+
+{% block title %}
+{% block wiki_pagetitle %}{% endblock %}
+{% endblock title %}
+
+{% block js %}
+    {{ block.super }}
+    <script src="{% static "wiki/js/jquery.min.js" %}"></script>
+    <script src="{% static "wiki/js/core.js" %}"></script>
+    <script src="{% static "wiki/bootstrap/js/bootstrap.min.js" %}"></script>
+    {% render_bundle 'wiki' 'js' %}
+{% endblock %}
+
+{% block styles %}
+    {{ block.super }}
+     <link href="{{ STATIC_URL }}wiki/bootstrap/css/wiki-bootstrap.min.css" rel="stylesheet">
+    {% render_bundle 'wiki' 'css' %}
+{% endblock %}
+
+{% block content %}
+    <section id="wiki-tree">
+        {% block wiki_body %}
+            <div class="container">
+                <!-- article.html -->
+                <h4>List of articles</h4>
+                <ul>
+                <!-- Need to get the first article (root) -->
+                {% url 'wiki:get' path=urlpath.root.path as rootpath %}
+                <li>
+                    <a href="{{ rootpath }}">
+                    {{ urlpath.root.article.current_revision.title }}
+                    </a>
+                </li>
+
+                <!-- Now get all the descendent articles of the root -->
+                {% for child in descendants %}
+                    <!-- Don't list articles marked for deletion -->
+                    {% if not child.is_deleted %}
+                    {% with ''|center:child.level as range %}
+                        {% for _ in range %}<ul>{% endfor %}
+                        {% url 'wiki:get' path=child.path as childpath %}
+                        <li>
+                        <a href="{{ childpath }}">
+                            {{ child.article.current_revision.title }}
+                        </a>
+                        </li>
+                        {% for _ in range %}</ul>{% endfor %}
+                    {% endwith %}
+                    {% endif %}
+                {% endfor %}
+                </ul>
+            </div>
+        {% endblock %}
+    </section>
+{% endblock %}


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible

## Description of changes

Adds a new view and URL: `/wiki-tree`, which lists all wiki articles the user has access to, in a hierarchical manner.

The view is quite slow, depending on how many articles the user has access to.
Used mainly to let users moderate the wiki in an easier manner.

## Screenshot(s) if appropriate

<!-- provide screenshots (before and after) if doing design changes -->
