### PR TITLE
Change test-runner to Pytest

### DIFF
--- a/onlineweb4/runner.py
+++ b/onlineweb4/runner.py
@@ -1,0 +1,29 @@
+class PytestTestRunner(object):
+    """Runs pytest to discover and run tests."""
+
+    def __init__(self, verbosity=1, failfast=False, keepdb=False, **kwargs):
+        self.verbosity = verbosity
+        self.failfast = failfast
+        self.keepdb = keepdb
+
+    def run_tests(self, test_labels):
+        """Run pytest and return the exitcode.
+
+        It translates some of Django's test command option to pytest's.
+        """
+        import pytest
+
+        argv = []
+        if self.verbosity == 0:
+            argv.append('--quiet')
+        if self.verbosity == 2:
+            argv.append('--verbose')
+        if self.verbosity == 3:
+            argv.append('-vv')
+        if self.failfast:
+            argv.append('--exitfirst')
+        if self.keepdb:
+            argv.append('--reuse-db')
+
+        argv.extend(test_labels)
+        return pytest.main(argv)

--- a/onlineweb4/settings/django.py
+++ b/onlineweb4/settings/django.py
@@ -8,7 +8,7 @@ from django.contrib.messages import constants as messages
 
 from .base import PROJECT_ROOT_DIRECTORY, PROJECT_SETTINGS_DIRECTORY
 
-TEST_RUNNER = config("OW4_DJANGO_TEST_RUNNER", default="django_nose.NoseTestSuiteRunner")
+TEST_RUNNER = config("OW4_DJANGO_TEST_RUNNER", default="onlineweb4.runner.PytestTestRunner")
 
 DEBUG = config("OW4_DJANGO_DEBUG", cast=bool, default=True)
 


### PR DESCRIPTION
- This is the de-facto testrunner we already use, just not updated in Django settings
- Added necessary PyTest test runner

## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
<!-- this means that other people can use this code without having to do/change anything -->
- [ ] I have updated the build configuration
- [ ] These changes requires changes to configuration in production <!-- E.g. an API token -->
    - [ ] I have applied the required changes in production
    - [ ] I cannot apply the required changes in production before this is deployed.


## Description of changes
Change the Django `TEST_RUNNER` setting from Nosetest to Pytest, and add Pytest test runner

I also apparently had a stroke and have no idea how to correctly write test-runner


To be clear: stuff like `make test` already use `pytest` instead of `python manage.py test`, and this changes only the `manage.py` testing, so does basically nothing

## Screenshot(s) if appropriate

<!-- provide screenshots (before and after) if doing design changes -->
