### PR TITLE
Make sure social members are counted as having a membership length

### DIFF
--- a/apps/approval/views.py
+++ b/apps/approval/views.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext as _
 
 from apps.approval.forms import FieldOfStudyApplicationForm
 from apps.approval.models import MembershipApproval
-from apps.authentication.models import AllowedUsername, get_length_of_field_of_study
+from apps.authentication.models import AllowedUsername, get_length_of_membership
 
 
 @login_required
@@ -65,7 +65,7 @@ def create_fos_application(request):
                 documentation=documentation
             )
 
-            length_of_fos = get_length_of_field_of_study(field_of_study)
+            length_of_fos = get_length_of_membership(field_of_study)
             if length_of_fos > 0:
                 application.new_expiry_date = get_expiry_date(
                     started_year, length_of_fos)

--- a/apps/authentication/models.py
+++ b/apps/authentication/models.py
@@ -71,6 +71,13 @@ def get_length_of_field_of_study(field_of_study):
         return 0
 
 
+def get_length_of_membership(field_of_study: str) -> int:
+    if field_of_study == FieldOfStudyType.SOCIAL_MEMBER:
+        return 1
+    else:
+        return get_length_of_field_of_study(field_of_study)
+
+
 def get_start_of_field_of_study(field_of_study):
     """
     Returns start year of a field of study


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible


## Description of changes

Membership applications for social members fail because a previous change made social members count as studying for 0 years.
The previous change was done because it made social members as studying on year 1.
This fucked up event registrations as social members counted as first graders.


## Screenshot(s) if appropriate

<!-- provide screenshots (before and after) if doing design changes -->
