### PR TITLE
downgrade django-rest-framework

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==2.1.11
 Pillow==6.1.0                   # PIL fork (Python Imaging Library)
-djangorestframework==3.10.2      # API v1
+djangorestframework==3.9.4      # API v1
 django-filter==2.2.0           # Filtering for DRF
 # python-memcached==1.57          # Memcache. Used by Mailinglists to fetch from Sympa.
 # Upstream is missing Python 3 patches


### PR DESCRIPTION
## What kind of a pull request is this?
Downgrades the django-rest-framework dependency. 

## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [x] I have added tests for the code I added
- [x] I have provided documentation for the code I added
- [x] The code is ready to be merged

## Description of changes
Downgrades the django-rest-framework dependency. 

It seems markdown2 is not supported by django-rest-framework and swapping it out is too much effort for upgrading to 3.10 drf.
