### PR TITLE
Set proper NTNU Username for employees

### DIFF
--- a/apps/dataporten/settings.py
+++ b/apps/dataporten/settings.py
@@ -8,6 +8,6 @@ DATAPORTEN = {
         'CLIENT_SECRET': config('OW4_DP_STUDY_CLIENT_SECRET', default=''),
         'REDIRECT_URI': config('OW4_DP_STUDY_REDIRECT_URI', default=''),
         'PROVIDER_URL': 'https://auth.dataporten.no/oauth/token',
-        'SCOPES': ['openid', 'userid', 'profile', 'groups', 'email'],
+        'SCOPES': ['openid', 'userid-feide', 'profile', 'groups', 'email'],
     }
 }

--- a/apps/dataporten/views.py
+++ b/apps/dataporten/views.py
@@ -102,7 +102,8 @@ def study_callback(request):
 
     # Do user info request
     userinfo = client.do_user_info_request(state=auth_resp['state'], behavior='use_authorization_header')
-    ntnu_username_dataporten = userinfo.get('email').split('@')[0]
+    # connect-userid_sec format is array with "feide:username@ntnu.no"
+    ntnu_username_dataporten = userinfo.get('connect-userid_sec')[0].split(':')[1].split('@')[0]
     if request.user.ntnu_username and request.user.ntnu_username != ntnu_username_dataporten:
         logger.warning(
             '{} tried to authorize, but the registered ntnu_username and the one received from Dataporten differ.'


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [x] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [ ] The changes are backwards compatible
<!-- this means that other people can use this code without having to do/change anything -->
- [ ] I have updated the build configuration
- [x] These changes requires changes to configuration in production <!-- E.g. an API token -->
    - [ ] I have applied the required changes in production
    - [ ] I cannot apply the required changes in production before this is deployed.


## Description of changes
Resolves  #2334

Removes unused scopes and add the `userid-feide` scope.
Updates the views to set ntnu_username from the new scope, which should properly be `username` and not `firstname.lastname` if you are hired by NTNU.

This will break automatic membership application if the new Dataporten application owned by the Online Linjeforening organization is not set in environment variables due to updated scopes.
`OW4_DP_STUDY_[setting]`

## Screenshot(s) if appropriate

<!-- provide screenshots (before and after) if doing design changes -->
