### PR TITLE
Fixed wrong field in UserUpdateSerializer

### DIFF
--- a/apps/authentication/serializers.py
+++ b/apps/authentication/serializers.py
@@ -74,7 +74,7 @@ class UserUpdateSerializer(serializers.ModelSerializer):
         model = User
         fields = (
             'first_name', 'last_name', 'rfid', 'password', 'email', 'username', 'infomail', 'jobmail', 'nickname',
-            'website', 'github', 'linkedin', 'gender', 'bio', 'ntnu_username', 'password', 'phone', 'id',
+            'website', 'github', 'linkedin', 'gender', 'bio', 'ntnu_username', 'password', 'phone_number', 'id',
         )
         extra_kwargs = {
             'password': {'write_only': True}


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [ ] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
<!-- this means that other people can use this code without having to do/change anything -->
- [ ] I have updated the build configuration
- [ ] These changes requires changes to configuration in production <!-- E.g. an API token -->
    - [ ] I have applied the required changes in production
    - [ ] I cannot apply the required changes in production before this is deployed.


## Description of changes
UserUpdateSerializer tried to retrieve the field "phone", however the model only contains "phone_number". Changed the field from phone to phone_number in userupdateserializer to match the model.

## Screenshot(s) if appropriate

<!-- provide screenshots (before and after) if doing design changes -->
