### PR TITLE
Make it possible for any attending user to see event with restrictions

### DIFF
--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -186,14 +186,14 @@ class Event(models.Model):
 
     def can_display(self, user):
         restriction = GroupRestriction.objects.filter(event=self).first()
+        if not user.is_anonymous and self.is_attendance_event() and self.attendance_event.is_attendee(user):
+            return True
         if not self.visible:
             return False
         if not restriction:
             return True
         if not user:
             return False
-        if self.is_attendance_event() and self.attendance_event.is_attendee(user):
-            return True
         return restriction.has_access(user)
 
     @property

--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -192,6 +192,8 @@ class Event(models.Model):
             return True
         if not user:
             return False
+        if self.is_attendance_event() and self.attendance_event.is_attendee(user):
+            return True
         return restriction.has_access(user)
 
     @property

--- a/apps/events/tests/model_tests.py
+++ b/apps/events/tests/model_tests.py
@@ -16,7 +16,7 @@ from apps.events.models import (AttendanceEvent, Attendee, CompanyEvent, Event, 
 from apps.feedback.models import Feedback, FeedbackRelation
 from apps.marks.models import DURATION, Mark, MarkUser
 
-from .utils import generate_attendance_event, generate_attendee
+from .utils import attend_user_to_event, generate_attendance_event, generate_attendee
 
 
 class EventModelTest(TestCase):
@@ -299,9 +299,10 @@ class AttendanceEventModelTest(TestCase):
         denied_user = G(User, groups=[denied_groups[0], ])
 
         unrestricted_event = G(Event)
+        G(AttendanceEvent, event=unrestricted_event)
         restricted_event = G(Event)
         G(GroupRestriction, event=restricted_event, groups=allowed_groups)
-        # restricted_event.group_restriction.add(allowed_groups)
+        G(AttendanceEvent, event=restricted_event)
 
         self.assertTrue(restricted_event.can_display(allowed_user),
                         "User should be able to view restricted event if in allowed group")
@@ -311,6 +312,10 @@ class AttendanceEventModelTest(TestCase):
                         "Any user should be able to see unrestricted events")
         self.assertTrue(unrestricted_event.can_display(denied_user),
                         "Any user should be able to see unrestricted events")
+
+        attend_user_to_event(restricted_event, denied_user)
+        self.assertTrue(restricted_event.can_display(denied_user),
+                        "User should be able to see event when they are attending even if the event is restricted")
 
 
 class WaitlistAttendanceEventTest(TestCase):


### PR DESCRIPTION

## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible

## Description of changes

Resolves #1351 

How does this differ from the previous provided solution which was denied?
It does a few more things:
- Makes sure the user can view the details of the event
- Makes sure anonymous users are handles correctly by the query (since they do not have an `id`, and are therefore not query-able)

## Screenshot(s) if appropriate

<!-- provide screenshots (before and after) if doing design changes -->
