### PR TITLE
Allow documentation for all manual field of study applications

### DIFF
--- a/apps/approval/forms.py
+++ b/apps/approval/forms.py
@@ -11,6 +11,8 @@ SEMESTER_CHOICES = [
     ("v", _("Vår")),
 ]
 
+VALID_FIELD_OF_STUDY_CHOICES = filter(lambda choice: choice[0] != FieldOfStudyType.GUEST, FieldOfStudyType.ALL_CHOICES)
+
 
 def _year_choices():
     now = timezone.now()
@@ -24,6 +26,6 @@ class FieldOfStudyApplicationForm(forms.Form):
     started_year = forms.ChoiceField(
         label=_("Hvilket år startet du? "), choices=_year_choices())
     field_of_study = forms.ChoiceField(
-        label=_("Studieretning "), choices=FieldOfStudyType.ALL_CHOICES)
+        label=_("Studieretning "), choices=VALID_FIELD_OF_STUDY_CHOICES)
     documentation = forms.ImageField(
         label=_("Dokumentasjon "), required=False)

--- a/assets/profiles/dependent_fields.js
+++ b/assets/profiles/dependent_fields.js
@@ -1,12 +1,12 @@
 import $ from 'jquery';
 
 export default () => {
-  $('#field-of-study-application-documentation').hide();
+  $('#social-membership-application').hide();
   $('#id_field_of_study').on('change', () => {
     if ($('#id_field_of_study').val() === '40') {
-      $('#field-of-study-application-documentation').show();
+      $('#social-membership-application').show();
     } else {
-      $('#field-of-study-application-documentation').hide();
+      $('#social-membership-application').hide();
     }
   });
 

--- a/templates/profiles/membership.html
+++ b/templates/profiles/membership.html
@@ -82,10 +82,15 @@
                         {{ field_of_study_application.started_year|as_crispy_field }}
                         {{ field_of_study_application.field_of_study|as_crispy_field }}
                         <div id="field-of-study-application-documentation">
-                            <p>For å søke sosialt medlemsskap i linjeforeningen, kreves det at du tar over 50% informatikk
+                            <p>
+                                Manuell søknad om studieretning krever at du laster opp f.eks et screenshot av
+                                studentweb for å vise til at du studerer informatikk.
+                            </p>
+                            <p id="social-membership-application">
+                                For å søke sosialt medlemsskap i linjeforeningen, kreves det at du tar over 50% informatikk
                                 emner (15 stp+) ved NTNU per semester og at du planlegger å søke overgang til informatikk.
-                                Dette må dokumenteres ved at du laster opp f.eks et screenshot av din studieplan på
-                                studentweb.</p>
+                                Dette kan du vise ved studieplanen på studentweb.
+                            </p>
                             {{ field_of_study_application.documentation|as_crispy_field }}
                         </div>
                         <button type="submit" class="btn btn-success pull-right">Send søknad</button>


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible

## Description of changes

This allows users to add documentation to all kinds of field of study applications.

This removes the need for _the board_ to email every single person applying manual to send the applicant a manual email asking for them to provide documentation for their field of study.

This comes a little late, but it is better late than never I guess.

## Screenshot(s) if appropriate

<!-- provide screenshots (before and after) if doing design changes -->
