### PR TITLE
Add registration based sorting for front-page events

### DIFF
--- a/assets/frontpage/events/containers/EventsContainer.js
+++ b/assets/frontpage/events/containers/EventsContainer.js
@@ -16,11 +16,22 @@ const mergeEventImages = (eventImage, companyEvent) => {
   return [...eventImages, ...companyImages];
 };
 
+const threeDaysAgo = moment().subtract(3, 'days');
+const inThreeDays = moment().add(3, 'days');
+
+const getRegistrationFiltered = ({ attendance_event: attendance, event_start: startDate }) => {
+  if (attendance && moment(attendance.registration_start).isBetween(threeDaysAgo, inThreeDays)) {
+    return attendance.registration_start;
+  }
+  return startDate;
+};
+
 const apiEventsToEvents = event => ({
   eventUrl: `/events/${event.id}/${event.slug}`,
   ingress: event.ingress_short,
   startDate: event.event_start,
   endDate: event.event_end,
+  registrationFiltered: getRegistrationFiltered(event),
   title: event.title,
   images: mergeEventImages(event.image, event.company_event),
 });
@@ -33,7 +44,7 @@ const sortEvents = (a, b) => {
     }
     return -1;
   }
-  return moment(a.startDate).isBefore(b.startDate) ? -1 : 1;
+  return moment(a.registrationFiltered).isBefore(b.registrationFiltered) ? -1 : 1;
 };
 
 /*

--- a/assets/frontpage/events/containers/EventsContainer.js
+++ b/assets/frontpage/events/containers/EventsContainer.js
@@ -16,11 +16,17 @@ const mergeEventImages = (eventImage, companyEvent) => {
   return [...eventImages, ...companyImages];
 };
 
-const threeDaysAgo = moment().subtract(3, 'days');
-const inThreeDays = moment().add(3, 'days');
+const DAYS_BACK_DELTA = moment().subtract(3, 'days');
+const DAYS_FORWARD_DELTA = moment().add(3, 'days');
 
 const getRegistrationFiltered = ({ attendance_event: attendance, event_start: startDate }) => {
-  if (attendance && moment(attendance.registration_start).isBetween(threeDaysAgo, inThreeDays)) {
+  if (
+    attendance &&
+    moment(attendance.registration_start).isBetween(
+      DAYS_BACK_DELTA,
+      DAYS_FORWARD_DELTA,
+    )
+  ) {
     return attendance.registration_start;
   }
   return startDate;


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [ ] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible

## Description of changes

Sort events on the front page based on `registration_start` date instead of `start_date` when the registration is within a delta of 3 days.

Based on what the back-end did before: https://github.com/dotkom/onlineweb4/blob/develop/apps/events/models.py#L60-L67

## Screenshot(s) if appropriate

<!-- provide screenshots (before and after) if doing design changes -->
