### PR TITLE
Split the inventory dashboard into two parts, live and discontinued wares

### DIFF
--- a/apps/inventory/dashboard/urls.py
+++ b/apps/inventory/dashboard/urls.py
@@ -6,6 +6,7 @@ from apps.inventory.dashboard import views
 
 urlpatterns = [
     url(r"^$", views.index, name="dashboard_inventory_index"),
+    url(r"^discontinued", views.discontinued, name="dashboard_discontinued_index"),
     url(r"^statistics/$", views.statistics, name="dashboard_inventory_statistics"),
     url(
         r"^statistics/orders/$",

--- a/apps/inventory/dashboard/views.py
+++ b/apps/inventory/dashboard/views.py
@@ -33,7 +33,7 @@ def index(request):
     return render(request, "inventory/dashboard/index.html", context)
 
 @login_required
-@permission_required("inventory.view_discontinued", return_403=True)
+@permission_required("inventory.view_item", return_403=True)
 def discontinued(request):
   if not has_access(request):
         raise PermissionDenied

--- a/apps/inventory/dashboard/views.py
+++ b/apps/inventory/dashboard/views.py
@@ -43,7 +43,7 @@ def discontinued(request):
   # Select all items that are not available for purchase
   context["items"] = Item.objects.filter(available=False).order_by("name")
 
-  return render(request, "inventory/dashboard/index.html", context)
+  return render(request, "inventory/dashboard/discontinued.html", context)
 
 @login_required
 @permission_required("inventory.add_item", return_403=True)

--- a/apps/inventory/dashboard/views.py
+++ b/apps/inventory/dashboard/views.py
@@ -27,11 +27,23 @@ def index(request):
 
     # Create the base context needed for the sidebar
     context = get_base_context(request)
-
-    context["items"] = Item.objects.all().order_by("name")
+    # Select all items that are available for purchase
+    context["items"] = Item.objects.filter(available=True).order_by("name")
 
     return render(request, "inventory/dashboard/index.html", context)
 
+@login_required
+@permission_required("inventory.view_discontinued", return_403=True)
+def discontinued(request):
+  if not has_access(request):
+        raise PermissionDenied
+
+  # Create the base context needed for the sidebar
+  context = get_base_context(request)
+  # Select all items that are not available for purchase
+  context["items"] = Item.objects.filter(available=False).order_by("name")
+
+  return render(request, "inventory/dashboard/index.html", context)
 
 @login_required
 @permission_required("inventory.add_item", return_403=True)

--- a/templates/dashboard_base.html
+++ b/templates/dashboard_base.html
@@ -276,6 +276,7 @@
                         </a>
                         <ul class="treeview-menu">
                             <li><a href="{% url 'dashboard_inventory_index' %}"><i class="fa fa-angle-double-right orange"></i> Administrere varelager</a></li>
+                            <li><a href="{% url 'dashboard_discontinued_index' %}"><i class="fa fa-angle-double-right orange"></i> Administrere utgått varelager</a></li>
                             <li><a href="{% url 'dashboard_category_index' %}"><i class="fa fa-angle-double-right orange"></i> Administrere kategorier</a></li>
                             <li><a href="{% url 'dashboard_inventory_statistics' %}"><i class="fa fa-angle-double-right orange"></i> Statistikk</a></li>
                         </ul>

--- a/templates/inventory/dashboard/discontinued.html
+++ b/templates/inventory/dashboard/discontinued.html
@@ -1,0 +1,65 @@
+{% extends "dashboard_base.html" %}
+{% load render_bundle from webpack_loader %}
+
+{% block title %}
+Utgått varelager - Online Dashboard
+{% endblock title %}
+
+{% block styles %}
+    {{ block.super }}
+    {% render_bundle 'dashboardInventory' 'css' %}
+{% endblock %}
+
+{% block js %}
+    {{ block.super }}
+    {% render_bundle 'dashboardInventory' 'js' %}
+{% endblock %}
+
+{% block page-header %}
+Utgått varelager
+{% endblock %}
+
+{% block breadcrumbs %}
+    <li>Utgått varelager</li>
+{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-md-12">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">Vareoversikt</h3>
+            </div>
+            <div class="panel-body">
+                <p>Her finner du en oversikt over utgåtte varer. Varene som er her blir ikke solgt på Nibble.</p>
+                <table class="table table-striped table-condensed tablesorter" id="inventory_item_list">
+                    <thead>
+                        <tr>
+                            <th>Navn</th>
+                            <th>Mengde</th>
+                            <th>Kategori</th>
+                            <th>Pris</th>
+                            <th>Til salgs</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for item in items %}
+                        <tr>
+                            <td><a href="/dashboard/inventory/item/{{ item.id }}/">{{ item.name }}</a></td>
+                            <td>{{ item.total_amount }}</td>
+                            <td>{{ item.category}}</td>
+                            <td>{% if item.available %}{{ item.price }},-{% else %}-{% endif %}</td>
+                            <td>
+                                <a href="#" data-id="{{ item.id }}" class="toggle-inventory-item in-stock">
+                                <i class="checkbox fa fa-lg {% if item.available %} fa-check-square-o checked {% else %} fa-square-o {% endif %}"></i>
+                                </a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock content %}


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review


## Code Checklist

- [ ] The code follows dotkom code style 
- [ ] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged

## Description of changes

* Split 'Varelager' into two components, 'Varelager' and 'Utgått varelager'.

### Reason for pull request
When updating prices or wares in Nibble, all the old items are still there, even if they are not for sale. Deleting the items does not work, and even if it did, it might break some statistics which are based on the kiosk. To make the wares easier to work with which wares are sold, a hack was implemented by prepending [Discontinued] or [Utgått sortiment] to the item names. This also ruins the statistics since it will forever display the prepended word beforehand.

By adding this the discontinued items can get their real names back. Trikom does not have to hassle through an endless amount of wares just to update their price (or anything). And the wares are in general more easier to work with.

### Should these features be added?
1. Remove the delete button. Currently it does not even work, and by adding this feature it is obsolete.
2. Refresh the window whenever a checkbox is checked or unchecked.
3. Use another template besides the default template. Mostly due to the title being "Varelager" and not "Utgått Varelager"


## Screenshot(s) if appropriate

### Ny
![Ny sidebar](https://i.imgur.com/zaQHACR.png "Ny Sidebare" )
![Ny varelager](https://i.imgur.com/tV7tw6H.png "Ny varelager")

### Gammel
![Gammel sidebar](https://i.imgur.com/l9YzKRL.png "Gammel Sidebar")
![Gammel varelager](https://i.imgur.com/xxl3BzT.png "Gammel varelager")