### PR TITLE
Add admin_group for posters

### DIFF
--- a/apps/posters/dashboard/utils.py
+++ b/apps/posters/dashboard/utils.py
@@ -27,13 +27,14 @@ def _handle_poster_add(request, form, order_type):
 
     poster.save()
     ordered_committee = form.cleaned_data["ordered_committee"]
-    poster_admin_group = get_poster_admin_group()
+    poster_admin_groups = get_poster_admin_groups()
 
     # Let this user have permissions to show this order
     UserObjectPermission.objects.assign_perm("view_poster_order", request.user, poster)
-    GroupObjectPermission.objects.assign_perm(
-        "view_poster_order", poster_admin_group, poster
-    )
+    for admin_group in poster_admin_groups:
+        GroupObjectPermission.objects.assign_perm(
+            "view_poster_order", admin_group, poster
+        )
     GroupObjectPermission.objects.assign_perm(
         "view_poster_order", ordered_committee, poster
     )
@@ -96,9 +97,9 @@ def get_poster_admins():
     return users
 
 
-def get_poster_admin_group():
+def get_poster_admin_groups():
     content_type = ContentType.objects.get_for_model(Poster)
     all_permissions = Permission.objects.filter(content_type=content_type)
     change_order_perm = all_permissions.filter(codename="change_poster").first()
-    admin_group = Group.objects.filter(permissions=change_order_perm).distinct()
-    return admin_group
+    admin_groups = Group.objects.filter(permissions=change_order_perm).distinct()
+    return admin_groups

--- a/apps/posters/dashboard/utils.py
+++ b/apps/posters/dashboard/utils.py
@@ -101,3 +101,4 @@ def get_poster_admin_group():
     change_order_perm = all_permissions.filter(codename="change_poster").first()
     admin_group = Group.objects.filter(permissions=change_order_perm).distinct()
     return admin_group
+

--- a/apps/posters/dashboard/utils.py
+++ b/apps/posters/dashboard/utils.py
@@ -95,10 +95,10 @@ def get_poster_admins():
     ).distinct()
     return users
 
+
 def get_poster_admin_group():
     content_type = ContentType.objects.get_for_model(Poster)
     all_permissions = Permission.objects.filter(content_type=content_type)
     change_order_perm = all_permissions.filter(codename="change_poster").first()
     admin_group = Group.objects.filter(permissions=change_order_perm).distinct()
     return admin_group
-

--- a/apps/posters/dashboard/utils.py
+++ b/apps/posters/dashboard/utils.py
@@ -2,7 +2,7 @@ import logging
 
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMessage
@@ -27,9 +27,13 @@ def _handle_poster_add(request, form, order_type):
 
     poster.save()
     ordered_committee = form.cleaned_data["ordered_committee"]
+    poster_admin_group = get_poster_admin_group()
 
     # Let this user have permissions to show this order
     UserObjectPermission.objects.assign_perm("view_poster_order", request.user, poster)
+    GroupObjectPermission.objects.assign_perm(
+        "view_poster_order", poster_admin_group, poster
+    )
     GroupObjectPermission.objects.assign_perm(
         "view_poster_order", ordered_committee, poster
     )
@@ -90,3 +94,10 @@ def get_poster_admins():
         Q(groups__permissions=change_order_perm) | Q(user_permissions=change_order_perm)
     ).distinct()
     return users
+
+def get_poster_admin_group():
+    content_type = ContentType.objects.get_for_model(Poster)
+    all_permissions = Permission.objects.filter(content_type=content_type)
+    change_order_perm = all_permissions.filter(codename="change_poster").first()
+    admin_group = Group.objects.filter(permissions=change_order_perm).distinct()
+    return admin_group


### PR DESCRIPTION
Add admin_group (currently "prokom", just avoid having the name in the code) and give them permissions to view individual poster orders. Resolves an issue lingering from #2384 

## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
<!-- this means that other people can use this code without having to do/change anything -->


## Description of changes
Reintroduce prokoms ability to work with posters, but based on permissions instead of name

## Screenshot(s) if appropriate

<!-- provide screenshots (before and after) if doing design changes -->
