### PR TITLE
Purge the last mention of "Komiteer"

### DIFF
--- a/apps/authentication/signals.py
+++ b/apps/authentication/signals.py
@@ -29,12 +29,10 @@ sync_uuid = uuid.uuid1()
 MAILING_LIST_USER_FIELDS_TO_LIST_NAME = settings.MAILING_LIST_USER_FIELDS_TO_LIST_NAME
 
 
-def run_group_syncer(user):
+def run_group_syncer(user: User) -> None:
     """
     Tasks to run after User is changed.
     :param user: The user instance to sync groups for.
-    :type user: OnlineUser
-    :return: None
     """
     SynchronizeGroups.run()
     if settings.OW4_GSUITE_SYNC.get("ENABLED", False):
@@ -51,7 +49,7 @@ def run_group_syncer(user):
 
 
 @receiver(post_save, sender=Group)
-def trigger_group_syncer(sender, instance, created=False, **kwargs):
+def trigger_group_syncer(sender, instance: Group, created=False, **kwargs):
     """
     :param sender: The model that triggered this hook
     :param instance: The model instance triggering this hook

--- a/apps/authentication/templatetags/group_membership.py
+++ b/apps/authentication/templatetags/group_membership.py
@@ -1,9 +1,0 @@
-# -*- encoding: utf-8 -*-
-from django import template
-
-register = template.Library()
-
-
-@register.simple_tag(takes_context=True)
-def in_group(context, group):
-    return context["request"].user.in_group(group)

--- a/apps/authentication/utils.py
+++ b/apps/authentication/utils.py
@@ -42,9 +42,10 @@ def create_online_mail_alias(user):
 
 
 def create_online_mail_aliases():
-    group = OnlineUser.objects.filter(is_staff=True)
+    # We only sync members who are staff
+    staff_users = OnlineUser.objects.filter(is_staff=True)
     # Fetch all users that do not currently have an alias
-    nomail = group.filter(
+    nomail = staff_users.filter(
         Q(online_mail__isnull=True) | Q(online_mail__exact="")
     ).order_by("id")
     # Find a list of all taken email aliases in the system already
@@ -80,7 +81,7 @@ def create_online_mail_aliases():
                 i = i + 1 if i else 2
 
     # Then produce a list of "alias: email" for all users in Komiteer
-    for user in group:
+    for user in staff_users:
         if user.online_mail and user.email:
             print("%s: %s" % (user.online_mail, user.email))
 

--- a/apps/authentication/utils.py
+++ b/apps/authentication/utils.py
@@ -4,7 +4,6 @@ import uuid
 from smtplib import SMTPException
 
 from django.conf import settings
-from django.contrib.auth.models import Group
 from django.core.mail import send_mail
 from django.db import IntegrityError
 from django.db.models import Q
@@ -43,10 +42,9 @@ def create_online_mail_alias(user):
 
 
 def create_online_mail_aliases():
-    # We only sync in members of the Komiteer group
-    group = Group.objects.get(name="Komiteer")
+    group = OnlineUser.objects.filter(is_staff=True)
     # Fetch all users that do not currently have an alias
-    nomail = group.user_set.filter(
+    nomail = group.filter(
         Q(online_mail__isnull=True) | Q(online_mail__exact="")
     ).order_by("id")
     # Find a list of all taken email aliases in the system already
@@ -82,7 +80,7 @@ def create_online_mail_aliases():
                 i = i + 1 if i else 2
 
     # Then produce a list of "alias: email" for all users in Komiteer
-    for user in group.user_set.all():
+    for user in group:
         if user.online_mail and user.email:
             print("%s: %s" % (user.online_mail, user.email))
 

--- a/scripts/management/commands/online_mail_usernames.py
+++ b/scripts/management/commands/online_mail_usernames.py
@@ -2,7 +2,6 @@
 
 import re
 
-from django.contrib.auth.models import Group
 from django.core.management.base import BaseCommand
 from django.db.models import Q
 from unidecode import unidecode
@@ -13,9 +12,9 @@ from apps.authentication.models import OnlineUser
 class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         # We only sync in members of the Komiteer group
-        group = Group.objects.get(name="Komiteer")
+        group = OnlineUser.objects.filter(is_staff=True)
         # Fetch all users that do not currently have an alias
-        nomail = group.user_set.filter(
+        nomail = group.filter(
             Q(online_mail__isnull=True) | Q(online_mail__exact="")
         ).order_by("id")
         # Find a list of all taken email aliases in the system already

--- a/scripts/management/commands/online_mail_usernames.py
+++ b/scripts/management/commands/online_mail_usernames.py
@@ -50,6 +50,6 @@ class Command(BaseCommand):
                     i = i + 1 if i else 2
 
         # Then produce a list of "alias: email" for all users in Komiteer
-        for user in staff_users.user_set.all():
+        for user in staff_users:
             if user.online_mail and user.email:
                 print("%s: %s" % (user.online_mail, user.email))

--- a/scripts/management/commands/online_mail_usernames.py
+++ b/scripts/management/commands/online_mail_usernames.py
@@ -11,10 +11,10 @@ from apps.authentication.models import OnlineUser
 
 class Command(BaseCommand):
     def handle(self, *args, **kwargs):
-        # We only sync in members of the Komiteer group
-        group = OnlineUser.objects.filter(is_staff=True)
+        # We only sync members who are staff
+        staff_users = OnlineUser.objects.filter(is_staff=True)
         # Fetch all users that do not currently have an alias
-        nomail = group.filter(
+        nomail = staff_users.filter(
             Q(online_mail__isnull=True) | Q(online_mail__exact="")
         ).order_by("id")
         # Find a list of all taken email aliases in the system already
@@ -50,6 +50,6 @@ class Command(BaseCommand):
                     i = i + 1 if i else 2
 
         # Then produce a list of "alias: email" for all users in Komiteer
-        for user in group.user_set.all():
+        for user in staff_users.user_set.all():
             if user.online_mail and user.email:
                 print("%s: %s" % (user.online_mail, user.email))

--- a/templates/article/details.html
+++ b/templates/article/details.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 {% load render_bundle from webpack_loader %}
 {% load markdown_deux_tags %}
-{% load group_membership %}
 
 {% block title %}{{ article.heading }} - Online{% endblock title %}
 
@@ -46,9 +45,7 @@
                         <div class="page-header">
                             <h1>
                                 {{ article.heading }}
-                                {% if user.is_authenticated %}
-                                    {% in_group "Komiteer" as in_komiteer %}
-                                    {% if in_komiteer %}
+                                {% if user.is_authenticated and user.is_staff %}
                                         <div class="btn-group pull-right">
                                             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                                                 <span class="caret"></span>
@@ -57,7 +54,6 @@
                                                 <li><a href="{% url 'dashboard_article_edit' article.id %}">Endre</a></li>
                                             </ul>
                                         </div>
-                                    {% endif %}
                                 {% endif %}
                             </h1>
                         </div>

--- a/templates/events/details.html
+++ b/templates/events/details.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 {% load markdown_deux_tags %}
 {% load crispy_forms_tags %}
-{% load group_membership %}
 {% load calendar_filters %}
 {% load payment_tag %}
 {% load render_bundle from webpack_loader %}
@@ -31,11 +30,8 @@
                 <div class="col-md-12">
                     <div class="page-header">
                         <h2 id="event-details-heading">
-                            {% if user.is_authenticated %}
-                                {% in_group "Komiteer" as in_komiteer %}
-                            {% endif %}
                             {{ event.title }}
-                            <div class="{% if user.is_authenticated and in_komiteer %}btn-group {% endif %}pull-right">
+                            <div class="{% if user.is_authenticated and user.is_staff %}btn-group {% endif %}pull-right">
                                 <div class="btn-group">
                                   <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                                     <span class="glyphicon glyphicon-calendar"></span>
@@ -48,8 +44,7 @@
                                   </ul>
                                 </div>
 
-                            {% if user.is_authenticated %}
-                                {% if in_komiteer %}
+                            {% if user.is_authenticated and user.is_staff%}
                                 <div class="btn-group pull-right">
                                     <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                                         Administrasjon
@@ -65,7 +60,6 @@
                                         {% endif %}
                                     </ul>
                                 </div>
-                                {% endif %}
                             {% endif %}
                             </div>
                         </h2>

--- a/templates/profiles/email.html
+++ b/templates/profiles/email.html
@@ -1,5 +1,4 @@
 {% load crispy_forms_tags %}
-{% load group_membership %}
 
 <div class="row">
     <div class="col-xs-12 col-md-8">
@@ -56,8 +55,7 @@
         <button type="button" class="btn btn-success btn-sm add-new-email">Legg til ny epostadresse</button>
     </div>
 </div>
-{% in_group "Komiteer" as in_komiteer %}
-{% if in_komiteer and user.online_mail %}
+{% if user.is_staff and user.online_mail %}
 <div class="row">
     <div class="col-xs-12 col-sm-12 col-md-10">
         <h3>Online e-postkonto</h3>
@@ -109,23 +107,3 @@
         </form>
     </div>
 </div>
-
-{% comment %}
-This block is redundant as long as mailinglists aren't being synced with onlinwweb4.
-If we want to use this, the form has to be added to the dictionary again in the view.
-This is related to issue #595
-<div class="row-space"></div>
-<div class="row">
-    <div class="col-xs-12 col-sm-12 col-md-8">
-        <h3>Listealternativer</h3>
-    </div>
-</div>
-<div class="row">
-    <div class="col-xs-12">
-        <form method="post" action="{% url 'profile' %}">
-            {{ mail_settings|crispy }}
-            <button type="submit" class="btn btn-success">Lagre</button>
-        </form>
-    </div>
-</div>
-{% endcomment %}


### PR DESCRIPTION
- Remove unneeded `in_komiteer`
- Some type-fixup
- Swap some Online-e-mail-syncing to use is_staff, instead of "Komiteer"

## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible
<!-- this means that other people can use this code without having to do/change anything -->
- [ ] I have updated the build configuration
- [ ] These changes requires changes to configuration in production <!-- E.g. an API token -->
    - [ ] I have applied the required changes in production
    - [ ] I cannot apply the required changes in production before this is deployed.


## Description of changes

Ensures that only `user.is_staff` is used to determine if an user should have an Online-e-mail, more specifically, this allows user that are not in "Komiteer" to have an Online-e-mail

## Screenshot(s) if appropriate

<!-- provide screenshots (before and after) if doing design changes -->
