### PR TITLE
Hotfix guardian get_objects_for_user

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,9 @@ django-oauth-toolkit==1.2.0     # OAuth2 authentication support
 # django-watson==1.5.4            # Indexed model search lib
 git+https://github.com/henrikhorluck/django-watson.git@24c69ff57cc4b840f129f579761b0ac41044e26a#egg=django-watson==1.5.5
 django-reversion==3.0.7         # Model version history with middleware hooks to all post_save signals
-django-guardian==2.2.0          # Per Object permissions framework
+# django-guardian==2.2.0          # Per Object permissions framework
+# Bugfix which has not been released yet: https://github.com/django-guardian/django-guardian/pull/677
+git+https://github.com/django-guardian/django-guardian.git@dba092f5db86808713433388717dcfbaaa928a0b#egg=django-guardian==2.2.1
 django-taggit==1.2.0            # Generic multi-model tagging library
 django-taggit-serializer==0.1.7 # REST Framework serializers for Django-taggit
 APScheduler==3.6.1              # Scheduler


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [x] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible

## Description of changes

Hotfix for the problem where django guardian `get_objects_for_user` breaks for some databases when a model has a non-standard `primary_key`, such as another model in our case (the `primary_key` of `OnlineGroup` is a `ForeignKey/OneToOneField` to `django.contrib.auth.models.Group`).

A simple fix has been applied to Django Guardian here:  https://github.com/django-guardian/django-guardian/pull/677, but it has not been released yet.
