### PR TITLE
Fix double emails for webshop payments (and refactor payment related objects)

### DIFF
--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -4,6 +4,7 @@ import logging
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from random import choice as random_choice
+from typing import List
 
 from django.conf import settings
 from django.contrib.auth.models import Group
@@ -33,6 +34,7 @@ from apps.feedback.models import FeedbackRelation
 from apps.gallery.models import ResponsiveImage
 from apps.marks.models import get_expiration_date
 from apps.payment import status as payment_status
+from apps.payment.mixins import PaymentMixin
 
 User = settings.AUTH_USER_MODEL
 
@@ -536,7 +538,7 @@ class Extras(models.Model):
         default_permissions = ("add", "change", "delete")
 
 
-class AttendanceEvent(models.Model):
+class AttendanceEvent(PaymentMixin, models.Model):
     """
     Events that require special considerations regarding attendance.
     """
@@ -1021,6 +1023,62 @@ class AttendanceEvent(models.Model):
         if extra_capacity > 0:
             # Using old object because waitlist has already been changed in self
             old_attendance_event.bump_waitlist_for_x_users(extra_capacity)
+
+    def get_payment_description(self):
+        return self.event.title
+
+    def get_payment_email(self):
+        organizer = self.event.organizer
+        organizer_group: OnlineGroup = OnlineGroup.objects.filter(
+            group=organizer
+        ).first()
+        if organizer_group and organizer_group.email:
+            return organizer_group.email
+        else:
+            return settings.DEFAULT_FROM_EMAIL
+
+    def is_user_allowed_to_pay(self, user: User):
+        """
+        In the case of attendance events the user should only be allowed to pay if they are attending
+        and has not paid yet.
+        """
+        is_attending = self.is_attendee(user)
+        if is_attending:
+            attendee = Attendee.objects.get(user=user, event=self)
+            return not attendee.has_paid
+        return False
+
+    def can_refund_payment(self, payment_relation) -> (bool, str):
+        if self.unattend_deadline < timezone.now():
+            return False, _("Fristen for å melde seg av har utgått")
+        if len(Attendee.objects.filter(event=self, user=payment_relation.user)) == 0:
+            return False, _("Du er ikke påmeldt dette arrangementet.")
+        if self.event.event_start < timezone.now():
+            return False, _("Dette arrangementet har allerede startet.")
+
+        return True, ""
+
+    def on_payment_done(self, user: User):
+        attendee = Attendee.objects.filter(event=self, user=user)
+
+        if attendee:
+            attendee[0].paid = True
+            attendee[0].save()
+        else:
+            Attendee.objects.create(event=self, user=user, paid=True)
+
+    def on_payment_refunded(self, payment_relation):
+        Attendee.objects.get(event=self, user=payment_relation.user).delete()
+
+    def get_payment_receipt_items(self, payment_relation) -> List[dict]:
+        items = [
+            {
+                "name": self.get_payment_description(),
+                "price": payment_relation.payment_price.price,
+                "quantity": 1,
+            }
+        ]
+        return items
 
     def save(
         self, force_insert=False, force_update=False, using=None, update_fields=None

--- a/apps/payment/mixins.py
+++ b/apps/payment/mixins.py
@@ -1,0 +1,83 @@
+from abc import abstractmethod
+from typing import List
+
+from django.conf import settings
+from django.utils import timezone
+
+from apps.authentication.models import OnlineUser as User
+
+
+class PaymentMixin:
+    """
+    Mixin for models related to the a payment.
+    Each abstract method should be overridden to handle payment correctly from that model type.
+
+    To allow payments for new model, just subclass this mixin in the model and implement all methods.
+    """
+
+    @abstractmethod
+    def get_payment_description(self) -> str:
+        return "No description (unsupported content type)"
+
+    @abstractmethod
+    def get_payment_email(self) -> str:
+        """
+        :return the email of the responsible committee/group/user which created or handles the payment.
+        """
+        return settings.DEFAULT_FROM_EMAIL
+
+    @abstractmethod
+    def is_user_allowed_to_pay(self, user: User) -> bool:
+        """ There are no rules prohibiting user from paying for other types of payments """
+        return True
+
+    @abstractmethod
+    def can_refund_payment(self, payment_relation) -> (bool, str):
+        return (
+            False,
+            "Denne betalingen er koblet til en ikke-støttet objekttype, og kan derfor ikke refunderes",
+        )
+
+    @abstractmethod
+    def on_payment_done(self, user: User):
+        """
+        Handle the effect of a payment being done/completed for a user.
+        """
+        pass
+
+    @abstractmethod
+    def on_payment_refunded(self, payment_relation):
+        """
+        Handle the effects of payment relation being refunded.
+        """
+        pass
+
+    @abstractmethod
+    def get_payment_receipt_items(self, payment_relation) -> List[dict]:
+        return []
+
+
+class ReceiptMixin:
+    @abstractmethod
+    def get_receipt_timestamp(self) -> timezone.datetime:
+        pass
+
+    @abstractmethod
+    def get_receipt_subject(self) -> str:
+        pass
+
+    @abstractmethod
+    def get_receipt_description(self) -> str:
+        pass
+
+    @abstractmethod
+    def get_receipt_items(self) -> List[dict]:
+        pass
+
+    @abstractmethod
+    def get_receipt_from_email(self) -> str:
+        pass
+
+    @abstractmethod
+    def get_receipt_to_email(self) -> str:
+        pass

--- a/apps/payment/models.py
+++ b/apps/payment/models.py
@@ -2,6 +2,7 @@
 
 import logging
 import uuid
+from typing import List
 
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
@@ -13,12 +14,10 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
-from apps.authentication.models import OnlineGroup
-from apps.events.models import AttendanceEvent, Attendee
 from apps.marks.models import Suspension
 from apps.payment import status
-from apps.webshop.models import OrderLine
 
+from .mixins import PaymentMixin, ReceiptMixin
 from .transaction_constants import TransactionSource
 
 User = settings.AUTH_USER_MODEL
@@ -42,7 +41,7 @@ class Payment(models.Model):
     """Which model the payment is created for. For attendance events this should be attendance_event(påmelding)."""
     object_id = models.PositiveIntegerField()
     """Object id for the model chosen in content_type."""
-    content_object = GenericForeignKey()
+    content_object: PaymentMixin = GenericForeignKey()
     """Helper attribute which points to the object select in object_id"""
     stripe_key = models.CharField(
         _("stripe key"), max_length=10, choices=STRIPE_KEY_CHOICES, default="arrkom"
@@ -105,16 +104,7 @@ class Payment(models.Model):
             PaymentDelay.objects.create(payment=self, user=user, valid_to=deadline)
 
     def description(self):
-        if self._is_type(AttendanceEvent):
-            return self.content_object.event.title
-        if self._is_type(OrderLine):
-            order_line: OrderLine = self.content_object
-            return f"{order_line.user} - {order_line.payment_description}"
-        logging.getLogger(__name__).error(
-            f"Trying to get description for payment #{self.pk}, but it's not an AttendanceEvent or a "
-            f"Webshop OrderLine."
-        )
-        return "No description"
+        return self.content_object.get_payment_description()
 
     def get_receipt_description(self):
         receipt_description = ""
@@ -126,43 +116,10 @@ class Payment(models.Model):
         return receipt_description
 
     def responsible_mail(self):
-        if self._is_type(AttendanceEvent):
-            organizer = self.content_object.event.organizer
-            organizer_group: OnlineGroup = OnlineGroup.objects.filter(
-                group=organizer
-            ).first()
-            if organizer_group and organizer_group.email:
-                return organizer_group.email
-            else:
-                return settings.DEFAULT_FROM_EMAIL
-        elif self._is_type(OrderLine):
-            return settings.EMAIL_PROKOM
-        else:
-            return settings.DEFAULT_FROM_EMAIL
+        return self.content_object.get_payment_email()
 
     def is_user_allowed_to_pay(self, user: User) -> bool:
-        """
-        In the case of attendance events the user should only be allowed to pay if they are attending
-        and has not paid yet.
-        """
-        if self._is_type(AttendanceEvent):
-            event: AttendanceEvent = self.content_object
-            is_attending = event.is_attendee(user)
-            if is_attending:
-                attendee = Attendee.objects.get(user=user, event=event)
-                return not attendee.has_paid
-            return False
-
-        """
-        Payments for Webshop orderlines should only be payable for the owner of the orderline
-        """
-        if self._is_type(OrderLine):
-            order_line: OrderLine = self.content_object
-            is_order_line_owner = order_line.user == user
-            return is_order_line_owner
-
-        """ There are no rules prohibiting user from paying for other types of payments """
-        return True
+        return self.content_object.is_user_allowed_to_pay(user)
 
     def handle_payment(self, user: User):
         """
@@ -170,78 +127,25 @@ class Payment(models.Model):
         Deletes any relevant payment delays, suspensions and marks user's attendee object as paid.
 
         :param OnlineUser user: User who paid
-
         """
-        if self._is_type(AttendanceEvent):
-            attendee = Attendee.objects.filter(event=self.content_object, user=user)
+        # Delete payment delay objects for the user if there are any
+        delays = PaymentDelay.objects.filter(payment=self, user=user)
+        for delay in delays:
+            delay.delete()
 
-            # Delete payment delay objects for the user if there are any
-            delays = PaymentDelay.objects.filter(payment=self, user=user)
-            for delay in delays:
-                delay.delete()
+        # If the user is suspended because of a lack of payment the suspension is deactivated.
+        suspensions = Suspension.objects.filter(payment_id=self.id, user=user)
+        for suspension in suspensions:
+            suspension.active = False
+            suspension.save()
 
-            # If the user is suspended because of a lack of payment the suspension is deactivated.
-            suspensions = Suspension.objects.filter(payment_id=self.id, user=user)
-            for suspension in suspensions:
-                suspension.active = False
-                suspension.save()
-
-            if attendee:
-                attendee[0].paid = True
-                attendee[0].save()
-            else:
-                Attendee.objects.create(event=self.content_object, user=user, paid=True)
-
-        elif self._is_type(OrderLine):
-            order_line: OrderLine = self.content_object
-            order_line.pay()
+        self.content_object.on_payment_done(user)
 
     def handle_refund(self, payment_relation):
-        """
-        Method for handling refunds.
-        For events it deletes the Attendee object.
-
-        :param str host: hostname to include in email
-        :param PaymentRelation payment_relation: user payment to refund
-        """
-
-        if self._is_type(AttendanceEvent):
-            Attendee.objects.get(
-                event=self.content_object, user=payment_relation.user
-            ).delete()
-
-        if self._is_type(OrderLine):
-            order_line: OrderLine = self.content_object
-            order_line.paid = False
-            order_line.save()
+        self.content_object.on_payment_refunded(payment_relation)
 
     def check_refund(self, payment_relation) -> (bool, str):
-        """Method for checking if the payment can be refunded"""
-        if self._is_type(AttendanceEvent):
-            attendance_event = self.content_object
-            if attendance_event.unattend_deadline < timezone.now():
-                return False, _("Fristen for å melde seg av har utgått")
-            if (
-                len(
-                    Attendee.objects.filter(
-                        event=attendance_event, user=payment_relation.user
-                    )
-                )
-                == 0
-            ):
-                return False, _("Du er ikke påmeldt dette arrangementet.")
-            if attendance_event.event.event_start < timezone.now():
-                return False, _("Dette arrangementet har allerede startet.")
-
-            return True, ""
-
-        if self._is_type(OrderLine):
-            return (
-                False,
-                "Du kan ikke refundere betalinger i Webshop på dette tidspunktet",
-            )
-
-        return False, "Refund checks not implemented"
+        return self.content_object.can_refund_payment(payment_relation)
 
     def prices(self):
         return self.paymentprice_set.all()
@@ -260,14 +164,11 @@ class Payment(models.Model):
     def stripe_public_key(self):
         return settings.STRIPE_PUBLIC_KEYS[self.stripe_key]
 
-    def _is_type(self, model_type):
-        return ContentType.objects.get_for_model(model_type) == self.content_type
-
     def __str__(self):
         return self.description()
 
     def clean_generic_relation(self):
-        if not self._is_type(AttendanceEvent) and not self._is_type(OrderLine):
+        if not isinstance(self.content_object, PaymentMixin):
             raise ValidationError(
                 {
                     "content_type": _(
@@ -275,12 +176,6 @@ class Payment(models.Model):
                     )
                 }
             )
-        else:
-            if (
-                not self.content_object
-                or not self.content_object.event.is_attendance_event()
-            ):
-                raise ValidationError(_("Dette arrangementet har ikke påmelding."))
 
     def clean(self):
         super().clean()
@@ -332,7 +227,7 @@ class StripeMixin(models.Model):
         abstract = True
 
 
-class PaymentRelation(StripeMixin, models.Model):
+class PaymentRelation(ReceiptMixin, StripeMixin, models.Model):
     """Payment metadata for user"""
 
     payment = models.ForeignKey(Payment, on_delete=models.CASCADE)
@@ -349,29 +244,22 @@ class PaymentRelation(StripeMixin, models.Model):
     unique_id = models.CharField(max_length=128, null=True, blank=True)
     """Unique ID for payment"""
 
-    def get_timestamp(self):
+    def get_receipt_timestamp(self) -> timezone.datetime:
         return self.datetime
 
-    def get_subject(self):
+    def get_receipt_subject(self) -> str:
         return "[Kvittering] " + self.payment.description()
 
-    def get_description(self):
+    def get_receipt_description(self) -> str:
         return self.payment.description()
 
-    def get_items(self):
-        items = [
-            {
-                "name": self.payment.description(),
-                "price": self.payment_price.price,
-                "quantity": 1,
-            }
-        ]
-        return items
+    def get_receipt_items(self) -> List[dict]:
+        return self.payment.content_object.get_payment_receipt_items(self)
 
-    def get_from_mail(self):
+    def get_receipt_from_email(self) -> str:
         return self.payment.responsible_mail()
 
-    def get_to_mail(self):
+    def get_receipt_to_email(self) -> str:
         return self.user.email
 
     def refund(self):
@@ -440,7 +328,7 @@ class TransactionManager(models.Manager):
         return value if value is not None else 0
 
 
-class PaymentTransaction(StripeMixin, models.Model):
+class PaymentTransaction(ReceiptMixin, StripeMixin, models.Model):
     """
     A transaction for a User
     The set of all transactions for a user defines the amount of 'coins' a user has.
@@ -459,13 +347,13 @@ class PaymentTransaction(StripeMixin, models.Model):
     def used_stripe(self):
         return self.source == TransactionSource.STRIPE
 
-    def get_timestamp(self):
+    def get_receipt_timestamp(self) -> timezone.datetime:
         return self.datetime
 
-    def get_subject(self):
-        return f"[Kvittering] {self.get_description()}"
+    def get_receipt_subject(self) -> str:
+        return f"[Kvittering] {self.get_receipt_description()}"
 
-    def get_description(self):
+    def get_receipt_description(self) -> str:
         if self.source == TransactionSource.STRIPE:
             return "Saldoinnskudd på online.ntnu.no"
         elif self.source == TransactionSource.TRANSFER:
@@ -475,7 +363,7 @@ class PaymentTransaction(StripeMixin, models.Model):
         elif self.source == TransactionSource.SHOP:
             return "Kjøp i Onlinekiosken"
 
-    def get_items(self):
+    def get_receipt_items(self):
         if self.source == TransactionSource.STRIPE:
             return [{"name": "Påfyll av saldo", "price": self.amount, "quantity": 1}]
         elif self.source == TransactionSource.TRANSFER:
@@ -494,10 +382,10 @@ class PaymentTransaction(StripeMixin, models.Model):
                     f"Transaction for a shop purchase is not connected to an OrderLine"
                 )
 
-    def get_from_mail(self):
+    def get_receipt_from_email(self):
         return settings.EMAIL_TRIKOM
 
-    def get_to_mail(self):
+    def get_receipt_to_email(self):
         return self.user.primary_email
 
     def __str__(self):
@@ -518,39 +406,32 @@ class PaymentReceipt(models.Model):
     """Which model the receipt is created for"""
     object_id = models.PositiveIntegerField(null=True)
     """Object id for the model chosen in content_type"""
-    content_object = GenericForeignKey()
+    content_object: ReceiptMixin = GenericForeignKey()
     """Helper attribute which points to the object select in object_id"""
 
     def save(self, *args, **kwargs):
-        transaction = self.content_object
-        self.timestamp = transaction.get_timestamp()
-        self.subject = transaction.get_subject()
-        self.description = transaction.get_description()
-        self.items = transaction.get_items()
-        self.from_mail = transaction.get_from_mail()
-        self.to_mail = [transaction.get_to_mail()]
-
         self._send_receipt(
-            self.timestamp,
-            self.subject,
-            self.description,
-            self.receipt_id,
-            self.items,
-            self.to_mail,
-            self.from_mail,
+            payment_id=self.receipt_id,
+            payment_date=self.content_object.get_receipt_timestamp(),
+            subject=self.content_object.get_receipt_subject(),
+            description=self.content_object.get_receipt_description(),
+            items=self.content_object.get_receipt_items(),
+            from_mail=self.content_object.get_receipt_to_email(),
+            to_mail=[self.content_object.get_receipt_to_email()],
         )
         super().save(*args, **kwargs)
 
-    def _is_type(self, model_type):
-        """Function for comparing content types to differentiate payment types"""
-        return ContentType.objects.get_for_model(model_type) == self.content_type
-
     def _send_receipt(
-        self, payment_date, subject, description, payment_id, items, to_mail, from_mail
+        self,
+        payment_date: timezone.datetime,
+        subject: str,
+        description: str,
+        payment_id: str,
+        items: List[dict],
+        to_mail: List[str],
+        from_mail: str,
     ):
-        """Send confirmation email with receipt
-        param receipt: object
-        """
+        """ Send confirmation email with receipt """
 
         # Calculate total item price and ensure correct input to template.
         receipt_items = []


### PR DESCRIPTION
## What kind of a pull request is this?

- QA / Code Review
<!-- Add other options if appropriate -->


## Code Checklist

- [x] The code follows dotkom code style 
- [x] The code passes the defined tests
- [ ] I have added tests for the code I added
- [ ] I have provided documentation for the code I added
- [x] The code is ready to be merged


## (Possible) Breaking Changes

- [x] The changes are backwards compatible

## Description of changes

Payments for webshop have sent two receipt emails previously because the OrderLine sent a receipt and the payment relation sent its own receipt.
This makes payments handle related objects/models with an abstract interface to gather needed information about the payment.

This also solves a lot of problems with circular imports which where a result of the _is_type checking
