### PR TITLE
Fix CommitteeApplicationPeriod bug with overlaps

### DIFF
--- a/apps/approval/api/serializers.py
+++ b/apps/approval/api/serializers.py
@@ -41,11 +41,11 @@ class CommitteeApplicationPeriodSerializer(serializers.ModelSerializer):
             )
 
         actual_deadline = period.deadline + period.deadline_delta
+
         overlapping_periods = CommitteeApplicationPeriod.objects.filter_overlapping(
             period.start, actual_deadline
-        ).filter(pk=period.pk)
+        ).exclude(pk=self.instance.pk)
 
-        # Will always overlap with itself. If we have 2 or more overlapped periods then we have an issue
         if overlapping_periods.exists():
             raise serializers.ValidationError(
                 "Opptaksperioder kan ikke overlappe med hverandre"

--- a/apps/approval/api/serializers.py
+++ b/apps/approval/api/serializers.py
@@ -43,10 +43,10 @@ class CommitteeApplicationPeriodSerializer(serializers.ModelSerializer):
         actual_deadline = period.deadline + period.deadline_delta
         overlapping_periods = CommitteeApplicationPeriod.objects.filter_overlapping(
             period.start, actual_deadline
-        )
+        ).filter(pk=period.pk)
 
         # Will always overlap with itself. If we have 2 or more overlapped periods then we have an issue
-        if len(overlapping_periods) > 1:
+        if overlapping_periods.exists():
             raise serializers.ValidationError(
                 "Opptaksperioder kan ikke overlappe med hverandre"
             )

--- a/apps/approval/api/serializers.py
+++ b/apps/approval/api/serializers.py
@@ -45,6 +45,7 @@ class CommitteeApplicationPeriodSerializer(serializers.ModelSerializer):
             period.start, actual_deadline
         )
 
+        # Will always overlap with itself. If we have 2 or more overlapped periods then we have an issue
         if len(overlapping_periods) > 1:
             raise serializers.ValidationError(
                 "Opptaksperioder kan ikke overlappe med hverandre"

--- a/apps/approval/api/serializers.py
+++ b/apps/approval/api/serializers.py
@@ -45,7 +45,7 @@ class CommitteeApplicationPeriodSerializer(serializers.ModelSerializer):
             period.start, actual_deadline
         )
 
-        if overlapping_periods.exists():
+        if len(overlapping_periods) > 1:
             raise serializers.ValidationError(
                 "Opptaksperioder kan ikke overlappe med hverandre"
             )

--- a/apps/approval/dashboard/forms.py
+++ b/apps/approval/dashboard/forms.py
@@ -19,11 +19,11 @@ class CommitteeApplicationPeriodForm(forms.ModelForm):
             raise ValidationError("En opptaksperiode må vare i minst én dag")
 
         actual_deadline = period.deadline + period.deadline_delta
+
         overlapping_periods = CommitteeApplicationPeriod.objects.filter_overlapping(
             period.start, actual_deadline
-        ).filter(pk=period.pk)
+        ).exclude(pk=self.instance.pk)
 
-        # Will always overlap with itself. If we have 2 or more overlapped periods then we have an issue
         if overlapping_periods.exists():
             raise ValidationError("Opptaksperioder kan ikke overlappe med hverandre")
 

--- a/apps/approval/dashboard/forms.py
+++ b/apps/approval/dashboard/forms.py
@@ -23,9 +23,9 @@ class CommitteeApplicationPeriodForm(forms.ModelForm):
             period.start, actual_deadline
         )
 
+        # Will always overlap with itself. If we have 2 or more overlapped periods then we have an issue
         if len(overlapping_periods) > 1:
-            raise ValidationError(
-                "Opptaksperioder kan ikke overlappe med hverandre")
+            raise ValidationError("Opptaksperioder kan ikke overlappe med hverandre")
 
         return cleaned_data
 

--- a/apps/approval/dashboard/forms.py
+++ b/apps/approval/dashboard/forms.py
@@ -25,8 +25,7 @@ class CommitteeApplicationPeriodForm(forms.ModelForm):
 
         # Will always overlap with itself. If we have 2 or more overlapped periods then we have an issue
         if overlapping_periods.exists():
-            raise ValidationError(
-                "Opptaksperioder kan ikke overlappe med hverandre" + str(overlapping_periods))
+            raise ValidationError("Opptaksperioder kan ikke overlappe med hverandre")
 
         return cleaned_data
 

--- a/apps/approval/dashboard/forms.py
+++ b/apps/approval/dashboard/forms.py
@@ -21,11 +21,12 @@ class CommitteeApplicationPeriodForm(forms.ModelForm):
         actual_deadline = period.deadline + period.deadline_delta
         overlapping_periods = CommitteeApplicationPeriod.objects.filter_overlapping(
             period.start, actual_deadline
-        )
+        ).filter(pk=period.pk)
 
         # Will always overlap with itself. If we have 2 or more overlapped periods then we have an issue
-        if len(overlapping_periods) > 1:
-            raise ValidationError("Opptaksperioder kan ikke overlappe med hverandre")
+        if overlapping_periods.exists():
+            raise ValidationError(
+                "Opptaksperioder kan ikke overlappe med hverandre" + str(overlapping_periods))
 
         return cleaned_data
 

--- a/apps/approval/dashboard/forms.py
+++ b/apps/approval/dashboard/forms.py
@@ -23,8 +23,9 @@ class CommitteeApplicationPeriodForm(forms.ModelForm):
             period.start, actual_deadline
         )
 
-        if overlapping_periods.exists():
-            raise ValidationError("Opptaksperioder kan ikke overlappe med hverandre")
+        if len(overlapping_periods) > 1:
+            raise ValidationError(
+                "Opptaksperioder kan ikke overlappe med hverandre")
 
         return cleaned_data
 

--- a/apps/approval/models.py
+++ b/apps/approval/models.py
@@ -32,10 +32,8 @@ class Approval(models.Model):
         on_delete=models.CASCADE,
     )
     created = models.DateTimeField(_("opprettet"), auto_now_add=True)
-    processed = models.BooleanField(
-        _("behandlet"), default=False, editable=False)
-    processed_date = models.DateTimeField(
-        _("behandlet dato"), blank=True, null=True)
+    processed = models.BooleanField(_("behandlet"), default=False, editable=False)
+    processed_date = models.DateTimeField(_("behandlet dato"), blank=True, null=True)
     approved = models.BooleanField(_("godkjent"), default=False, editable=False)
     message = models.TextField(_("melding"))
 
@@ -44,8 +42,7 @@ class Approval(models.Model):
 
 
 class MembershipApproval(Approval):
-    new_expiry_date = models.DateField(
-        _("ny utløpsdato"), blank=True, null=True)
+    new_expiry_date = models.DateField(_("ny utløpsdato"), blank=True, null=True)
     field_of_study = models.SmallIntegerField(
         _("studieretning"),
         choices=FieldOfStudyType.ALL_CHOICES,
@@ -220,8 +217,7 @@ class CommitteeApplication(models.Model):
 
 
 class CommitteePriority(models.Model):
-    valid_priorities = [(1, "1. prioritet"),
-                        (2, "2. prioritet"), (3, "3. prioritet")]
+    valid_priorities = [(1, "1. prioritet"), (2, "2. prioritet"), (3, "3. prioritet")]
 
     committee_application = models.ForeignKey(
         CommitteeApplication,

--- a/apps/approval/models.py
+++ b/apps/approval/models.py
@@ -32,8 +32,10 @@ class Approval(models.Model):
         on_delete=models.CASCADE,
     )
     created = models.DateTimeField(_("opprettet"), auto_now_add=True)
-    processed = models.BooleanField(_("behandlet"), default=False, editable=False)
-    processed_date = models.DateTimeField(_("behandlet dato"), blank=True, null=True)
+    processed = models.BooleanField(
+        _("behandlet"), default=False, editable=False)
+    processed_date = models.DateTimeField(
+        _("behandlet dato"), blank=True, null=True)
     approved = models.BooleanField(_("godkjent"), default=False, editable=False)
     message = models.TextField(_("melding"))
 
@@ -42,7 +44,8 @@ class Approval(models.Model):
 
 
 class MembershipApproval(Approval):
-    new_expiry_date = models.DateField(_("ny utløpsdato"), blank=True, null=True)
+    new_expiry_date = models.DateField(
+        _("ny utløpsdato"), blank=True, null=True)
     field_of_study = models.SmallIntegerField(
         _("studieretning"),
         choices=FieldOfStudyType.ALL_CHOICES,
@@ -217,7 +220,8 @@ class CommitteeApplication(models.Model):
 
 
 class CommitteePriority(models.Model):
-    valid_priorities = [(1, "1. prioritet"), (2, "2. prioritet"), (3, "3. prioritet")]
+    valid_priorities = [(1, "1. prioritet"),
+                        (2, "2. prioritet"), (3, "3. prioritet")]
 
     committee_application = models.ForeignKey(
         CommitteeApplication,


### PR DESCRIPTION
## Description of changes
When serializing or changing a CommitteePeriod it will check if the period is overlapping with others. The issue here is that it will check all periods if there is any overlap. However since it checks all overlaps the period will always be in conflict with itself. I changed the code to throw error whenever theres 2 or more overlapping issues instead of max 1 overlap. 

I tested this localy and it works.