### PR TITLE
Exclude itself (CommiteeApplicationPeriod) when checking for overlapping periods

### DIFF
--- a/apps/approval/api/serializers.py
+++ b/apps/approval/api/serializers.py
@@ -42,7 +42,7 @@ class CommitteeApplicationPeriodSerializer(serializers.ModelSerializer):
 
         overlapping_periods = CommitteeApplicationPeriod.objects.filter_overlapping(
             period.start, period.actual_deadline_method()
-        )
+        ).exclude(pk=self.instance.pk)
 
         if overlapping_periods.exists():
             raise serializers.ValidationError(

--- a/apps/approval/api/serializers.py
+++ b/apps/approval/api/serializers.py
@@ -42,7 +42,10 @@ class CommitteeApplicationPeriodSerializer(serializers.ModelSerializer):
 
         overlapping_periods = CommitteeApplicationPeriod.objects.filter_overlapping(
             period.start, period.actual_deadline_method()
-        ).exclude(pk=self.instance.pk)
+        )
+
+        if self.instance:
+            overlapping_periods = overlapping_periods.exclude(pk=self.instance.pk)
 
         if overlapping_periods.exists():
             raise serializers.ValidationError(

--- a/apps/approval/dashboard/forms.py
+++ b/apps/approval/dashboard/forms.py
@@ -21,7 +21,7 @@ class CommitteeApplicationPeriodForm(forms.ModelForm):
         actual_deadline = period.deadline + period.deadline_delta
         overlapping_periods = CommitteeApplicationPeriod.objects.filter_overlapping(
             period.start, actual_deadline
-        )
+        ).exclude(pk=self.instance.pk)
 
         if overlapping_periods.exists():
             raise ValidationError("Opptaksperioder kan ikke overlappe med hverandre")

--- a/apps/approval/dashboard/forms.py
+++ b/apps/approval/dashboard/forms.py
@@ -21,7 +21,10 @@ class CommitteeApplicationPeriodForm(forms.ModelForm):
         actual_deadline = period.deadline + period.deadline_delta
         overlapping_periods = CommitteeApplicationPeriod.objects.filter_overlapping(
             period.start, actual_deadline
-        ).exclude(pk=self.instance.pk)
+        )
+
+        if self.instance:
+            overlapping_periods = overlapping_periods.exclude(pk=self.instance.pk)
 
         if overlapping_periods.exists():
             raise ValidationError("Opptaksperioder kan ikke overlappe med hverandre")


### PR DESCRIPTION
Dashboard will have an validationerror everytime you try to update because everytime you update it will check for overlapping periods. Since the Manager checks towards all periods it will always get a conflict with itself. This PR just makes sure to remove themselves from overlapping periods so it doesnt check up against itself