### PR TITLE
fix/user email leftover

### DIFF
--- a/templates/events/dashboard/attendee.html
+++ b/templates/events/dashboard/attendee.html
@@ -37,7 +37,7 @@ Deltakerdetaljer
                 </div>
                 <div class="inline row">
                     <div class="col-md-3"><b>Epost:</b></div>
-                    <div class="col-md-9">{{ attendee.user.email }}</div>
+                    <div class="col-md-9">{{ attendee.user.primary_email }}</div>
                 </div>
                 <div class="inline row">
                     <div class="col-md-3"><b>Studieretn.:</b></div>

--- a/templates/posters/dashboard/details.html
+++ b/templates/posters/dashboard/details.html
@@ -48,7 +48,7 @@
                                 </div>
                                 <div class="col-xs-12 col-sm-3 col-md-3">
                                     <div class="event-hero-title">Bestilt av</div>
-                                    <div class="event-hero-large-text"><a href="mailto:{{poster.ordered_by.email}}">{{poster.ordered_by}}</a> i <a href="mailto:{{poster.ordered_committee}}@online.ntnu.no">{{poster.ordered_committee}}</a></div>
+                                    <div class="event-hero-large-text"><a href="mailto:{{poster.ordered_by.primary_email}}">{{poster.ordered_by}}</a> i <a href="mailto:{{poster.ordered_committee}}@online.ntnu.no">{{poster.ordered_committee}}</a></div>
                                 </div>
                                 <div class="col-xs-12 col-sm-3 col-md-3">
                                     <div class="event-hero-title">Status</div>


### PR DESCRIPTION
## Description of changes
<!-- It is often obvious what changed by looking at the code, so it is more helpful to say _why_ it should be changed -->
<!-- If the Pull Request is not ready to be merged, please use a draft pull request -->
A long time ago in a galaxy far away... there was the issue of having multiple email attached to users, and data related to each email. This was fixed by introducing `user.primary_email`, which is a string. But some places it hasn't been updated! This fixes that
## Code Checklist

- [ ] I have added tests
- [ ] I have provided documentation

<!-- IF THERE ARE ANY BREAKING CHANGES
E.G. IF THERE IS A CHANGE IN AN API OR A NEW API-TOKEN NEEDS TO BE ADDED,
BE SURE TO DOCUMENT THEM, AND INFORM US ABOUT
CHANGES NEEDED TO BE MADE IN OTHER PROJECTS,
OR IN PRODUCTION. 
 -->

