### PR TITLE
Add endpoint to use djangos logout

### DIFF
--- a/apps/authentication/api/views.py
+++ b/apps/authentication/api/views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth import logout
 from django.contrib.auth.models import Group
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
@@ -82,6 +83,11 @@ class UserViewSet(
         user: User = self.get_object()
         serializer = self.get_serializer(user)
         return Response(data=serializer.data, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=["get"], url_path="logout")
+    def remote_logout(self, request):
+        logout(request)
+        return Response(status=status.HTTP_200_OK)
 
 
 class EmailViewSet(MultiSerializerMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
## Description of changes
<!-- It is often obvious what changed by looking at the code, so it is more helpful to say _why_ it should be changed -->
<!-- If the Pull Request is not ready to be merged, please use a draft pull request -->
External systems should be able to log a user out completely and thus require a new login to OW4.
This endpoint uses django's own logout process to remove the session.

## Code Checklist

- [ ] I have added tests
- [ ] I have provided documentation
