### PR TITLE
check if user is unattending themselves and do not send email if that…

### DIFF
--- a/apps/events/models/Attendance.py
+++ b/apps/events/models/Attendance.py
@@ -739,7 +739,7 @@ class Attendee(models.Model):
         )
 
         # Notify responsible group if someone is unattended after deadline
-        if timezone.now() >= self.event.unattend_deadline:
+        if timezone.now() >= self.event.unattend_deadline and not self.user_id == admin_user.id:
             subject = "[%s] %s har blitt avmeldt arrangementet av %s" % (
                 self.event,
                 self.user.get_full_name(),

--- a/apps/events/models/Attendance.py
+++ b/apps/events/models/Attendance.py
@@ -739,7 +739,10 @@ class Attendee(models.Model):
         )
 
         # Notify responsible group if someone is unattended after deadline
-        if timezone.now() >= self.event.unattend_deadline and not self.user_id == admin_user.id:
+        if (
+            timezone.now() >= self.event.unattend_deadline
+            and not self.user_id == admin_user.id
+        ):
             subject = "[%s] %s har blitt avmeldt arrangementet av %s" % (
                 self.event,
                 self.user.get_full_name(),


### PR DESCRIPTION
… is the case

## Description of changes
In #2138 we created an email that is sent to an arranging committee when a person is unregistered from an event after the deadline. The intention was to create accountability for unattending people. However with the move to OWF we use the same unregister endpoint to remove users from the frontend. This creates an issue when people unattend while they are on the waitinglist, which can still happen after the unattend deadline is passed. 

When a user is removed from an event through the /unregister endpoint the unattend function is called with themselves as an admin user. The fix implemented here simply checks if you are not the admin user when you unregister yourself. 

This does introduce a slight weakness in our logging system and an issue will be created shortly and linked here. 

