### PR TITLE
use serializer for event extras

### DIFF
--- a/apps/events/api/serializers.py
+++ b/apps/events/api/serializers.py
@@ -20,6 +20,10 @@ from ..models import (
 from .constants import ANONYMOUS_ATTENDEE_NAMES
 from .fields import SerializerUserMethodField
 
+class ExtrasSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Extras
+        fields = ("id", "choice", "note")
 
 class EventSerializer(serializers.ModelSerializer):
     images = ResponsiveImageSerializer(many=True)
@@ -60,6 +64,7 @@ class EventSerializer(serializers.ModelSerializer):
 
 
 class AttendanceEventSerializer(serializers.ModelSerializer):
+    extras = ExtrasSerializer(many=True)
     feedback = serializers.PrimaryKeyRelatedField(read_only=True, source="get_feedback")
     payment = serializers.PrimaryKeyRelatedField(read_only=True)
     has_postponed_registration = SerializerUserMethodField()
@@ -220,10 +225,6 @@ class PublicAttendeeSerializer(serializers.ModelSerializer):
         )
 
 
-class ExtrasSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Extras
-        fields = ("id", "choice", "note")
 
 
 class RuleBundleSerializer(serializers.ModelSerializer):

--- a/apps/events/api/serializers.py
+++ b/apps/events/api/serializers.py
@@ -20,10 +20,12 @@ from ..models import (
 from .constants import ANONYMOUS_ATTENDEE_NAMES
 from .fields import SerializerUserMethodField
 
+
 class ExtrasSerializer(serializers.ModelSerializer):
     class Meta:
         model = Extras
         fields = ("id", "choice", "note")
+
 
 class EventSerializer(serializers.ModelSerializer):
     images = ResponsiveImageSerializer(many=True)
@@ -223,8 +225,6 @@ class PublicAttendeeSerializer(serializers.ModelSerializer):
             "year_of_study",
             "field_of_study",
         )
-
-
 
 
 class RuleBundleSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
## Description of changes
- Uses the already existing serializer for extras. Event extras are then displayed with description instead of only ID. 

related to https://github.com/dotkom/onlineweb-frontend/issues/446