### PR TITLE
Remove CSRF-requirement for SameSite

### DIFF
--- a/onlineweb4/settings/rest_framework.py
+++ b/onlineweb4/settings/rest_framework.py
@@ -1,7 +1,6 @@
 # Django REST framework
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework.authentication.SessionAuthentication",  # Allows users to be logged in to browsable API
         "apps.online_oidc_provider.authentication.OidcOauth2Auth",  # Allows user to be logged in with open-id
     ),
     "DEFAULT_FILTER_BACKENDS": (


### PR DESCRIPTION
When having OWF on the same domain as OW4, allowing session authentication for DRF requires CSRF which prevents regular API-calls from OWF.

## Code Checklist

- [ ] I have added tests
- [ ] I have provided documentation