### PR TITLE
Add id to serializer

### DIFF
--- a/apps/profiles/serializers.py
+++ b/apps/profiles/serializers.py
@@ -16,6 +16,7 @@ class ProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = (
+            "id",
             "first_name",
             "last_name",
             "username",


### PR DESCRIPTION
## Description of changes
Add ID to profile serializer.
There is no way to get the user's ID. You can get it from `public/profile`, but a user may hide their profile, so it is not a sure fire way to get the ID.
