### PR TITLE
Update fixed error where company id is displayed instead of company name

### DIFF
--- a/apps/events/api/serializers.py
+++ b/apps/events/api/serializers.py
@@ -40,6 +40,7 @@ class EventSerializer(serializers.ModelSerializer):
     number_of_seats_taken = serializers.IntegerField(
         source="attendance_event.number_of_seats_taken"
     )
+    companies = serializers.StringRelatedField(many=True)
 
     class Meta:
         model = Event


### PR DESCRIPTION
This fixes the issue on the statistics page where a company's ID is displayed instead of their name. 
