### PR TITLE
Sort Swagger tag groups alphabetically instead of folder order

### DIFF
--- a/templates/api/swagger-ui.html
+++ b/templates/api/swagger-ui.html
@@ -22,7 +22,8 @@
         requestInterceptor: (request) => {
           request.headers['X-CSRFToken'] = "{{ csrf_token }}"
           return request;
-        }
+        },
+        tagsSorter: 'alpha',
       })
     </script>
   </body>


### PR DESCRIPTION
## Description of changes
<!-- It is often obvious what changed by looking at the code, so it is more helpful to say _why_ it should be changed -->
<!-- If the Pull Request is not ready to be merged, please use a draft pull request -->
Right now, Swagger tag groups are sorted by the name of the folder (inside `apps`) they are found in, which is not visible to the user.

In one way, I kinda like it, as it gives an idea of which folder you can find them in.
Changing the sortation also adds a little pause to the "loading"-screen where the loader freezes as it is finished loading, but the UI is busy sorting it.
However, with no help text which tells you how it's sorted, it looks weird and makes finding things hard. It is also not very necessary for consumers of the API to know the folder name order, if they are not contributing to OW4 as well.

Thus, I propose changing it to alphabetical sort. 

Please feel free to discuss this decision!

**PS**: Swagger UI parameters can be found [here](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/).

<!-- REMOVE FROM HERE AND BELOW IF NO VISUAL CHANGES -->
## Visual changes
<!-- IF DOING ANY DESIGN CHANGE PLEASE ADD BEFORE PICTURES HERE -->

### Option 1: Alphabetical
<details>
<summary>Before</summary>
<!-- PASTE BEFORE IMAGE HERE -->  

![](http://folk.ntnu.no/johannkv/img/firefox_aczaDJHgLq.png)
</details>

<details>
<summary>After</summary>
<!-- PASTE AFTER IMAGE HERE -->  

![](http://folk.ntnu.no/johannkv/img/firefox_um4HuchPQp.png)
</details>

### Option 2: Folder name with description
<details>
<summary>Before</summary>
<!-- PASTE BEFORE IMAGE HERE -->  

![](http://folk.ntnu.no/johannkv/img/firefox_aczaDJHgLq.png)
</details>

<details>
<summary>After</summary>
<!-- PASTE AFTER IMAGE HERE -->  

![](http://folk.ntnu.no/johannkv/img/firefox_eaXsQrP4cq.png)
</details>
