### PR TITLE
Allow users to see own permissions

### DIFF
--- a/apps/authentication/api/views.py
+++ b/apps/authentication/api/views.py
@@ -94,15 +94,10 @@ class UserViewSet(
         If you want to group permissions, you can group on object type and map the ID to the object from the codename string.
         """
         user = self.get_object()
-        permissions = (
-            Permission.objects.filter(group__user=user)
-            .order_by("content_type")
-            .distinct()
-        )
-        page = self.paginate_queryset(permissions)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
+        permissions = Permission.objects.filter(
+            group__user=user
+        ) | Permission.objects.filter(user=user)
+        permissions.order_by("content_type").distinct()
         serializer = self.get_serializer(permissions, many=True)
         return Response(data=serializer.data)
 
@@ -118,9 +113,10 @@ class PermissionsViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        permissions = Permission.objects.filter(group__user=user).order_by(
-            "content_type"
-        )
+        permissions = Permission.objects.filter(
+            group__user=user
+        ) | Permission.objects.filter(user=user)
+        permissions.distinct().order_by("content_type")
         return permissions
 
 

--- a/apps/authentication/api/views.py
+++ b/apps/authentication/api/views.py
@@ -88,6 +88,8 @@ class PermissionsViewSet(viewsets.ViewSet):
     """
     This endpoint returns a dictionary of permissions for the authenticated user.
     This can be used to check whether a user should be able to perform a certain action related to an endpoint.
+
+    The response is a dictionary of permission_name: [permissions]
     """
 
     permission_classes = (IsAuthenticated,)

--- a/apps/authentication/api/views.py
+++ b/apps/authentication/api/views.py
@@ -84,6 +84,26 @@ class UserViewSet(
         return Response(data=serializer.data, status=status.HTTP_200_OK)
 
 
+class PermissionsViewSet(viewsets.ViewSet):
+    """
+    This endpoint returns a dictionary of permissions for the authenticated user.
+    This can be used to check whether a user should be able to perform a certain action related to an endpoint.
+    """
+
+    permission_classes = (IsAuthenticated,)
+
+    def list(self, request):
+        permissions = request.user.get_user_permissions()
+        # Convert from one long list to dictionary.
+        permissions_dict = {}
+        for key, value in [perm.split(".") for perm in permissions]:
+            if key in permissions_dict:
+                permissions_dict[key].append(value)
+            else:
+                permissions_dict[key] = [value]
+        return Response(data=permissions_dict)
+
+
 class EmailViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated,)
     serializer_classes = {

--- a/apps/authentication/api/views.py
+++ b/apps/authentication/api/views.py
@@ -94,10 +94,13 @@ class UserViewSet(
         If you want to group permissions, you can group on object type and map the ID to the object from the codename string.
         """
         user = self.get_object()
-        permissions = Permission.objects.filter(
-            group__user=user
-        ) | Permission.objects.filter(user=user)
-        permissions.order_by("content_type").distinct()
+        if user.is_superuser:
+            permissions = Permission.objects.all().order_by("content_type")
+        else:
+            permissions = Permission.objects.filter(
+                group__user=user
+            ) | Permission.objects.filter(user=user)
+            permissions.order_by("content_type").distinct()
         serializer = self.get_serializer(permissions, many=True)
         return Response(data=serializer.data)
 
@@ -113,10 +116,13 @@ class PermissionsViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        permissions = Permission.objects.filter(
-            group__user=user
-        ) | Permission.objects.filter(user=user)
-        permissions.distinct().order_by("content_type")
+        if user.is_superuser:
+            permissions = Permission.objects.all().order_by("content_type")
+        else:
+            permissions = Permission.objects.filter(
+                group__user=user
+            ) | Permission.objects.filter(user=user)
+            permissions.distinct().order_by("content_type")
         return permissions
 
 

--- a/apps/authentication/serializers.py
+++ b/apps/authentication/serializers.py
@@ -2,7 +2,7 @@ import hashlib
 import random
 import string
 
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.contrib.auth.password_validation import validate_password
 from django.utils.timezone import datetime
 from guardian.shortcuts import get_objects_for_user
@@ -239,6 +239,13 @@ class UserUpdateSerializer(serializers.ModelSerializer):
             "phone_number",
             "id",
         )
+
+
+class PermissionReadOnlySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Permission
+        fields = ("content_type", "codename")
+        read_only = True
 
 
 class PositionReadOnlySerializer(serializers.ModelSerializer):

--- a/apps/authentication/urls.py
+++ b/apps/authentication/urls.py
@@ -21,6 +21,9 @@ urlpatterns = [
 router = SharedAPIRootRouter()
 router.register("users", api_views.UserViewSet, basename="users")
 router.register("user/emails", api_views.EmailViewSet, basename="user_emails")
+router.register(
+    "user/permissions", api_views.PermissionsViewSet, basename="user_permissions"
+)
 router.register("user/positions", api_views.PositionViewSet, basename="user_positions")
 router.register(
     "user/special-positions",


### PR DESCRIPTION
## Description of changes
<!-- It is often obvious what changed by looking at the code, so it is more helpful to say _why_ it should be changed -->
<!-- If the Pull Request is not ready to be merged, please use a draft pull request -->
If external apps wants to limit access to users without registered permissions, one would now have to do this based on group memberships. This change allows for accessing a users permissions and can thus be used for committee-specific applications without limiting to certain groups, but rather the actual permissions that group has.

**Note:** The endpoint is unable to generate a schema as there is no serializer attached to this view (since permissions are serialized by default). This would perhaps need to manually written as [specified in the docs](https://www.django-rest-framework.org/api-guide/schemas/#map_field). I have added the response type in the text as a temporary fix to this.