### PR TITLE
Don't create consent if no user in authorization

### DIFF
--- a/apps/sso/signals.py
+++ b/apps/sso/signals.py
@@ -8,6 +8,8 @@ def handle_app_authorized(sender, request, token, **kwargs):
         pk=token.application.pk, user=token.user
     ).exists():
         return
+    if not token.user:
+        return
     ApplicationConsent.objects.create(
         user=token.user, client=token.application, approved_scopes=token.scopes
     )


### PR DESCRIPTION
If authorization happens through a method which is not connected to a user, do not try to create a consent because none were given. 
E.g. when Nibble logs in a user, it is all through `client_credentials` with no user-approval.