### PR TITLE
Load RSA-key from file instead of env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ webpack-stats-test.json
 .drone-secrets.yml*
 jest/
 venv/
+oidc.key

--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -64,12 +64,22 @@ SLACK_INVITER = {
 }
 
 # SSO / OAuth2 settings
+
+OIDC_RSA_PRIVATE_KEY = "" # Default case
+if not os.path.isfile("oidc.key"):
+    print("Failed to locate OIDC RSA Private key file during setup.")
+else:
+    with open("oidc.key", "r") as f:
+        OIDC_RSA_PRIVATE_KEY = f.read()
+
+print("KEY: ", OIDC_RSA_PRIVATE_KEY)
+
 OAUTH2_PROVIDER_APPLICATION_MODEL = "sso.Client"
 OAUTH2_PROVIDER = {
     "OAUTH2_VALIDATOR_CLASS": "apps.sso.validator.Validator",
     "OIDC_ENABLED": True,
     "PKCE": True,
-    "OIDC_RSA_PRIVATE_KEY": config("OW4_OIDC_RSA_PRIVATE_KEY", default=""),
+    "OIDC_RSA_PRIVATE_KEY": OIDC_RSA_PRIVATE_KEY,
     "SCOPES": OAUTH2_SCOPES,
     "ACCESS_TOKEN_EXPIRE_SECONDS": 3600,
     "AUTHORIZATION_CODE_EXPIRE_SECONDS": 60,

--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -72,8 +72,6 @@ else:
     with open("oidc.key", "r") as f:
         OIDC_RSA_PRIVATE_KEY = f.read()
 
-print("KEY: ", OIDC_RSA_PRIVATE_KEY)
-
 OAUTH2_PROVIDER_APPLICATION_MODEL = "sso.Client"
 OAUTH2_PROVIDER = {
     "OAUTH2_VALIDATOR_CLASS": "apps.sso.validator.Validator",

--- a/onlineweb4/settings/base.py
+++ b/onlineweb4/settings/base.py
@@ -65,7 +65,7 @@ SLACK_INVITER = {
 
 # SSO / OAuth2 settings
 
-OIDC_RSA_PRIVATE_KEY = "" # Default case
+OIDC_RSA_PRIVATE_KEY = ""  # Default case
 if not os.path.isfile("oidc.key"):
     print("Failed to locate OIDC RSA Private key file during setup.")
 else:


### PR DESCRIPTION
OW4-deployment does not execute the `.env`, and as the file is large, it would clutter the file to have the entire content in env. Therefore, we load from file instead.