### PR TITLE
Fix pr-request-target and let dependabot run CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
   pull_request:
-     branches:
-       - main
+    branches:
+      - '*'
   pull_request_target:
     branches:
       - '*'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,13 @@ jobs:
   test-python:
     runs-on: ubuntu-latest
     # Run if the repo is not a fork, or if it is a fork with the label 'safe to test', or if it is dependabot
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || contains(github.event.pull_request.labels.*.name, 'safe to test') || github.actor == 'dependabot[bot]' }}
+    if: github.event.pull_request.head.repo.full_name == github.repository || contains(github.event.pull_request.labels.*.name, 'safe to test') || github.actor == 'dependabot[bot]'
     steps:
       - name: checkout-if-pr
         uses: actions/checkout@v2
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
-          # when using pull_requ
+          # when using pull_requst, by default the code that is checked-out is actually the base of the PR, not the code of it.
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: checkout-if-push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,20 +4,24 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   pull_request_target:
-    types: [labeled]
 
 jobs:
   test-python:
     runs-on: ubuntu-latest
-    # Run if the repo is not a fork, or if it is a fork with the label 'safe to test'
-    if: github.event.pull_request.head.repo.full_name == github.repository || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    # Run if the repo is not a fork, or if it is a fork with the label 'safe to test', or if it is dependabot
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || contains(github.event.pull_request.labels.*.name, 'safe to test') || github.actor == 'dependabot[bot]' }}
     steps:
-      - name: checkout
+      - name: checkout-if-pr
         uses: actions/checkout@v2
+        if: ${{ github.event_name == 'pull_request_target' }}
+        with:
+          # when using pull_requ
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: checkout-if-push
+        uses: actions/checkout@v2
+        if: ${{ github.event_name == 'push' }}
 
       - name: Set up Python 3.7
         uses: actions/setup-python@v2.2.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+     branches:
+       - main
   pull_request_target:
     branches:
       - '*'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request_target:
+    branches:
+      - '*'
 
 jobs:
   test-python:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: checkout-if-push
         uses: actions/checkout@v2
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
 
       - name: Set up Python 3.7
         uses: actions/setup-python@v2.2.2


### PR DESCRIPTION
- pull_request_target does not checkout the same code as with pr, it runs against the base branch of the code, not the changes, this fixes that
- Allows dependabot to always run

## Description of changes
<!-- It is often obvious what changed by looking at the code, so it is more helpful to say _why_ it should be changed -->
<!-- If the Pull Request is not ready to be merged, please use a draft pull request -->

## Code Checklist

- [ ] I have added tests
- [ ] I have provided documentation

<!-- IF THERE ARE ANY BREAKING CHANGES
E.G. IF THERE IS A CHANGE IN AN API OR A NEW API-TOKEN NEEDS TO BE ADDED,
BE SURE TO DOCUMENT THEM, AND INFORM US ABOUT
CHANGES NEEDED TO BE MADE IN OTHER PROJECTS,
OR IN PRODUCTION. 
 -->

<!-- REMOVE FROM HERE AND BELOW IF NO VISUAL CHANGES -->
## Visual changes
<!-- IF DOING ANY DESIGN CHANGE PLEASE ADD BEFORE PICTURES HERE -->

<details>
<summary>Before</summary>
<!-- PASTE BEFORE IMAGE HERE -->

</details>

<details>
<summary>After</summary>
<!-- PASTE AFTER IMAGE HERE -->

</details>
