### PR TITLE
Fix slow user orders

### DIFF
--- a/apps/shop/views.py
+++ b/apps/shop/views.py
@@ -52,7 +52,9 @@ class OrderLineViewSet(viewsets.GenericViewSet, mixins.CreateModelMixin):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         user = get_object_or_404(User, pk=pk)
-        orders = OrderLine.objects.filter(user=user)
+        # Only include the latest purchases
+        amount = 50
+        orders = OrderLine.objects.filter(user=user).order_by("-datetime")[:amount]
         serializer = UserOrderLineSerializer(orders, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
## Description of changes
Nibble is very slow at the moment due to heavy calculations on both front- and backend which was an unpredicted side effect of the favourites feature. 
This reduces the backends workload, limiting the response to the 50 latests purchases (a quick fix of sorts).

## Code Checklist

- [ ] I have added tests
- [x] I have provided documentation

Unfortunately I have no way of testing whether this is a sufficiently small number, hope thats ok. 50 is just an educated guess.