### PR TITLE
fix: remove check for enabled dataporten application

### DIFF
--- a/templates/profiles/membership.html
+++ b/templates/profiles/membership.html
@@ -15,7 +15,6 @@
     </div>
 </div>
 {% if not has_active_approvals %}
-    {% if enable_dataporten_application %}
     <div class="row">
         <div class="col-xs-12 col-sm-6 col-md-5">
             <a href="{% url 'dataporten:study' %}" class="btn btn-success membership-button">
@@ -35,7 +34,6 @@
             </div>
         </div>
     </div>
-    {% endif %}
     <div class="row">
         <div class="col-md-12">
             <p><strong>NB! Godkjente og avslåtte søknader havner nederst på siden, sjekk her før du sender inn nye søknader!</strong></p>


### PR DESCRIPTION
## Description of changes
<!-- It is often obvious what changed by looking at the code, so it is more helpful to say _why_ it should be changed -->
<!-- If the Pull Request is not ready to be merged, please use a draft pull request -->
Out in production, there is no longer buttons for applying for membership.
Removed the line which removes those buttons from production as it should be enabled by default.