### PR TITLE
add the search bar to the wiki again

### DIFF
--- a/templates/wiki/base.html
+++ b/templates/wiki/base.html
@@ -32,7 +32,6 @@
                         {% block wiki_breadcrumbs %}{% endblock %}
                     </div>
                     <div class="col-xs-4">
-<!-- TEMPORARLY REMOVE SEARCH FUNCTIONALITY
                       <form method="GET" action="{% spaceless %}
                         {% if article or urlpath %}
                             {% url 'wiki:search' article_id=article.id path=urlpath.path %}
@@ -55,7 +54,6 @@
                             </span>
                         </div>
                       </form>
--->
                     </div>
                 </div>
                 {% block wiki_contents %}{% endblock %}


### PR DESCRIPTION
## Description of changes

The searchbar in the wiki was removed during December for a christmas calendar. This PR just removes the changes made in [this](https://github.com/dotkom/onlineweb4/commit/959ac658800c83add3ba42ebdf8901d78d12328c) commit. 
