### PR TITLE
fix: read documentation from s3

### DIFF
--- a/templates/approval/dashboard/index.html
+++ b/templates/approval/dashboard/index.html
@@ -64,7 +64,7 @@ Søknadsgodkjenning
         </div>
         <div class="col-md-2 cell">
             {% if app.has_documentation %}
-                <div class="visible-xs visible-sm">1. </div><a href="/media/{{app.documentation}}" target="_blank">Dokumentasjon</a>
+                <div class="visible-xs visible-sm">1. </div><a href="{{ MEDIA_URL }}{{app.documentation}}" target="_blank">Dokumentasjon</a>
             {% else %}
                 -
             {% endif %}


### PR DESCRIPTION
## Description of changes
- Tell dashboard view to find documentation files on S3, not locally 
