### PR TITLE
Fix envfiles and move venv to named volumes

### DIFF
--- a/.devcontainer/.dockerignore
+++ b/.devcontainer/.dockerignore
@@ -1,2 +1,0 @@
-.venv
-node_modules

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,23 +7,22 @@ LABEL org.opencontainers.image.source=https://github.com/dotkom/onlineweb4
 LABEL org.opencontainers.image.authors=dotkom
 
 WORKDIR /workspace
-ENV PYTHONUNBUFFERED=1 POETRY_VIRTUALENVS_IN_PROJECT=true
+ENV PYTHONUNBUFFERED=1 POETRY_VIRTUALENVS_CREATE=false
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
-RUN pip install poetry==1.1
-
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-     && apt-get -y install --no-install-recommends \
+RUN pipx install poetry==1.1.13 \
+    && apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
         libjpeg-dev \
         git
 
 FROM base AS with-dependencies
 
 COPY pyproject.toml poetry.lock ./
-RUN poetry install --no-interaction --no-root --no-ansi && rm poetry.lock pyproject.toml
+RUN poetry install --no-interaction --no-root --no-ansi
 
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --non-interactive && rm package.json yarn.lock
+RUN yarn install --frozen-lockfile --non-interactive

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.source=https://github.com/dotkom/onlineweb4
 LABEL org.opencontainers.image.authors=dotkom
 
 WORKDIR /workspace
-ENV PYTHONUNBUFFERED=1 POETRY_VIRTUALENVS_CREATE=false
+ENV PYTHONUNBUFFERED=1 POETRY_VIRTUALENVS_IN_PROJECT=true
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"

--- a/.devcontainer/devcontainer.env
+++ b/.devcontainer/devcontainer.env
@@ -3,7 +3,7 @@ DATABASE_URL=postgres://postgres:postgres@db:5432/onlineweb4
 DJANGO_SETTINGS_MODULE=onlineweb4.settings
 LOG_LEVEL=DEBUG
 
-# To run stripe tests locally: copy these to a `.env` file in the same directory, and add the actual values
+# To run stripe tests locally: copy these to .env in project root and fill them in.
 # OW4_DJANGO_STRIPE_PUBLIC_KEY_ARRKOM
 # OW4_DJANGO_STRIPE_PUBLIC_KEY_PROKOM
 # OW4_DJANGO_STRIPE_PUBLIC_KEY_TRIKOM

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,20 +9,20 @@
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
-		"python.defaultInterpreterPath": "${containerWorkspaceFolder}/.venv/bin/python",
+		"python.defaultInterpreterPath": "/usr/local/py-utils/bin/python",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
 		"python.testing.cwd": "/workspace",
-		"python.formatting.autopep8Path": "${containerWorkspaceFolder}/.venv/bin/autopep8",
-		"python.formatting.blackPath": "${containerWorkspaceFolder}/.venv/bin/black",
-		"python.formatting.yapfPath": "${containerWorkspaceFolder}/.venv/bin/yapf",
-		"python.linting.banditPath": "${containerWorkspaceFolder}/.venv/bin/bandit",
-		"python.linting.flake8Path": "${containerWorkspaceFolder}/.venv/bin/flake8",
-		"python.linting.mypyPath": "${containerWorkspaceFolder}/.venv/bin/mypy",
-		"python.linting.pycodestylePath": "${containerWorkspaceFolder}/.venv/bin/pycodestyle",
-		"python.linting.pydocstylePath": "${containerWorkspaceFolder}/.venv/bin/pydocstyle",
-		"python.linting.pylintPath": "${containerWorkspaceFolder}/.venv/bin/pylint",
-		"python.testing.pytestPath": "${containerWorkspaceFolder}/.venv/bin/pytest"
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+		"python.testing.pytestPath": "/usr/local/py-utils/bin/pytest"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
@@ -40,7 +40,7 @@
 	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "poetry run pre-commit install",
+	"postCreateCommand": "pre-commit install",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,20 +9,20 @@
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
-		"python.defaultInterpreterPath": "/usr/local/py-utils/bin/python",
+		"python.defaultInterpreterPath": "${containerWorkspaceFolder}/.venv/bin/python",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
 		"python.testing.cwd": "/workspace",
-		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/bin/autopep8",
-		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
-		"python.testing.pytestPath": "/usr/local/py-utils/bin/pytest"
+		"python.formatting.autopep8Path": "${containerWorkspaceFolder}/.venv/bin/autopep8",
+		"python.formatting.blackPath": "${containerWorkspaceFolder}/.venv/bin/black",
+		"python.formatting.yapfPath": "${containerWorkspaceFolder}/.venv/bin/yapf",
+		"python.linting.banditPath": "${containerWorkspaceFolder}/.venv/bin/bandit",
+		"python.linting.flake8Path": "${containerWorkspaceFolder}/.venv/bin/flake8",
+		"python.linting.mypyPath": "${containerWorkspaceFolder}/.venv/bin/mypy",
+		"python.linting.pycodestylePath": "${containerWorkspaceFolder}/.venv/bin/pycodestyle",
+		"python.linting.pydocstylePath": "${containerWorkspaceFolder}/.venv/bin/pydocstyle",
+		"python.linting.pylintPath": "${containerWorkspaceFolder}/.venv/bin/pylint",
+		"python.testing.pytestPath": "${containerWorkspaceFolder}/.venv/bin/pytest"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
@@ -40,7 +40,7 @@
 	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pre-commit install",
+	"postCreateCommand": "poetry run pre-commit install --install-hooks",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,6 +6,12 @@ services:
     image: ghcr.io/dotkom/onlineweb4-devcontainer:latest
     volumes:
       - ..:/workspace:cached
+      # hack?: https://stackoverflow.com/questions/29181032/add-a-volume-to-docker-but-exclude-a-sub-folder
+      # this is to be able to use `.venv` _inside_ the container and ignoring the .venv outside,
+      # basically a facny dockerignore
+      - python-venv:/workspace/.venv/
+      # same as above, ignore outside node_modules
+      - node-modules:/workspace/node_modules/
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
@@ -33,3 +39,5 @@ services:
 
 volumes:
   postgres-data: null
+  node-modules: null
+  python-venv: null

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   app:
     # we do not include the build-definition here, since that prevents us from using the pre-built image.
-    image: ghcr.io/dotkom/onlineweb4-devcontainer
+    image: ghcr.io/dotkom/onlineweb4-devcontainer:latest
     volumes:
       - ..:/workspace:cached
     # Overrides default command so things don't shut down after the process ends.
@@ -11,8 +11,8 @@ services:
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
     network_mode: service:db
     env_file:
-      - .ow4.env
-      - .env
+      - devcontainer.env
+    # vscode also automatically adds .env from root
     # Uncomment the next line to use a non-root user for all processes.
     # user: vscode
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         python-version: 3.9
 
-    - name: Add Requirements.txt
+    - name: Install dependencies
       if: matrix.language == 'python'
       env:
         POETRY_VIRTUALENVS_CREATE: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,8 +41,8 @@ jobs:
       env:
         POETRY_VIRTUALENVS_CREATE: false
       run: |
-        pip install poetry
-        poetry export -f requirements.txt > requirements.txt --dev -E docs --without-hashes
+        pipx install poetry==1.1.13
+        poetry install
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install Zappa
         run: |
-          pip install poetry
+          pipx install poetry==1.1.13
           poetry install --no-interaction --no-ansi
 
       - name: Configure AWS credentials

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          pip install poetry
+          pipx install poetry==1.1.13
           poetry install --no-interaction --no-ansi
 
       - name: Install node dependencies
@@ -112,7 +112,7 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          pip install poetry
+          pipx install poetry==1.1.13
           poetry install --no-interaction --no-ansi
 
       - name: Python linting
@@ -150,7 +150,7 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          pip install poetry
+          pipx install poetry==1.1.13
           poetry install --no-interaction --no-ansi
 
       - name: Check migrations

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ _tmp
 *.vagrant
 uploaded_media/*
 build/*
-node_modules/*
+node_modules
 .tox
 coverage
 coverage.xml
@@ -51,4 +51,4 @@ oidc.key
 zappa_settings.py
 requirements.txt
 .env
-.devcontainer/.env
+.venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ ENV APP_DIR=/srv/app POETRY_VIRTUALENVS_CREATE=false
 
 WORKDIR $APP_DIR
 
-RUN pip install poetry
+RUN curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.1.13 python3 - \
+    && export PATH="/root/.local/bin:$PATH"
 
 COPY pyproject.toml poetry.lock $APP_DIR
 

--- a/README.md
+++ b/README.md
@@ -189,8 +189,9 @@ You can view the details of these tests by clicking the "detail" link in the pul
 
 > **Important:** We have integration tests with Stripe that require valid test-API-keys, those tests are **not**
 > run by default locally, or when creating a PR from a fork of this repository. To run them, first get ahold of
-> the appropriate testing keys, then add them to an `.devcontainer/.env` file, the name of the environment variables
-> are in [`.devcontainer/.ow4.env`](.devcontainer/.ow4.env).
+> the appropriate testing keys, then add them to an `.env` file in the project root,
+> the name of the environment variables are in
+> [`.devcontainer/devcontainer.env`](.devcontainer/devcontainer.env).
 
 ## API
 


### PR DESCRIPTION
- .venv had a problem with mounting the current working directory,
  removing the file. Also Poetry does not know about it's own virtual
  environments without being in file with pyproject.toml, whic
  negatively affected the postCreateCommand.
- Lock poetry versions, as we might have breaking or changed behaviour
  in the near future with Poetry 1.2
- Use envfile naming that works, previous config had a problem with the
  .env-file in root not existing, and thus crashing

## Description of changes
<!-- It is often obvious what changed by looking at the code, so it is more helpful to say _why_ it should be changed -->
<!-- If the Pull Request is not ready to be merged, please use a draft pull request -->

## Code Checklist

- [ ] I have added tests
- [ ] I have provided documentation

<!-- IF THERE ARE ANY BREAKING CHANGES
E.G. IF THERE IS A CHANGE IN AN API OR A NEW API-TOKEN NEEDS TO BE ADDED,
BE SURE TO DOCUMENT THEM, AND INFORM US ABOUT
CHANGES NEEDED TO BE MADE IN OTHER PROJECTS,
OR IN PRODUCTION. 
 -->

<!-- REMOVE FROM HERE AND BELOW IF NO VISUAL CHANGES -->
## Visual changes
<!-- IF DOING ANY DESIGN CHANGE PLEASE ADD BEFORE PICTURES HERE -->

<details>
<summary>Before</summary>
<!-- PASTE BEFORE IMAGE HERE -->

</details>

<details>
<summary>After</summary>
<!-- PASTE AFTER IMAGE HERE -->

</details>
