### PR TITLE
Fix Sentry config, make it not repeat itself

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Python linting
         run: poetry run tox -e flake8 -e isort -e black
 
-  check-migrations:
+  django-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -126,6 +126,9 @@ jobs:
 
       - name: Check migrations
         run: poetry run python manage.py makemigrations --check
+
+      - name: Django check
+        run: poetry run python manage.py check
 
   lint-js:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,5 +72,6 @@ RUN ZAPPA_HANDLER_PATH=$(python -c "from zappa import handler; print (handler.__
 
 COPY --from=static-files /srv/app/webpack-stats.json ./
 ARG VERSION
-ENV OW4_VERSION=${VERSION}
+# https://docs.sentry.io/platforms/python/guides/logging/configuration/releases/#setting-a-release
+ENV SENTRY_VERSION=${VERSION}
 CMD [ "handler.lambda_handler" ]

--- a/onlineweb4/settings/sentry.py
+++ b/onlineweb4/settings/sentry.py
@@ -1,19 +1,17 @@
+import sentry_sdk
 from decouple import config
+from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
+from sentry_sdk.integrations.django import DjangoIntegration
 
 from .django import DEBUG
 
 OW4_SENTRY_DSN = config("OW4_SENTRY_DSN", default="")
 
-if OW4_SENTRY_DSN:
-    import sentry_sdk
-    from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
-    from sentry_sdk.integrations.django import DjangoIntegration
 
-    sentry_sdk.init(
-        dsn=OW4_SENTRY_DSN,
-        environment=config("OW4_ENVIRONMENT", default="DEVELOP"),
-        debug=DEBUG,
-        release=config("OW4_VERSION"),
-        traces_sample_rate=0.2,
-        integrations=[DjangoIntegration(), AwsLambdaIntegration(timeout_warning=True)],
-    )
+sentry_sdk.init(
+    dsn=OW4_SENTRY_DSN,
+    environment=config("OW4_ENVIRONMENT", default="DEVELOP"),
+    debug=DEBUG,
+    traces_sample_rate=0.2,
+    integrations=[DjangoIntegration(), AwsLambdaIntegration(timeout_warning=True)],
+)

--- a/poetry.lock
+++ b/poetry.lock
@@ -97,14 +97,14 @@ webencodings = "*"
 
 [[package]]
 name = "boto3"
-version = "1.21.28"
+version = "1.21.30"
 description = "The AWS SDK for Python"
 category = "main"
 optional = true
 python-versions = ">= 3.6"
 
 [package.dependencies]
-botocore = ">=1.24.28,<1.25.0"
+botocore = ">=1.24.30,<1.25.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.5.0,<0.6.0"
 
@@ -113,7 +113,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.24.28"
+version = "1.24.30"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = true
@@ -188,7 +188,7 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "8.1.0"
+version = "8.1.1"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = false
@@ -1086,6 +1086,14 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "pip"
+version = "22.0.4"
+description = "The PyPA recommended tool for installing Python packages."
+category = "main"
+optional = true
+python-versions = ">=3.7"
+
+[[package]]
 name = "pip-tools"
 version = "6.5.1"
 description = "pip-tools keeps your pinned dependencies fresh."
@@ -1096,6 +1104,9 @@ python-versions = ">=3.7"
 [package.dependencies]
 click = ">=7"
 pep517 = "*"
+pip = ">=21.2"
+setuptools = "*"
+wheel = "*"
 
 [package.extras]
 coverage = ["pytest-cov"]
@@ -1501,7 +1512,7 @@ name = "sentry-sdk"
 version = "1.5.8"
 description = "Python client for Sentry (https://sentry.io)"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 
 [package.dependencies]
@@ -1526,6 +1537,19 @@ rq = ["rq (>=0.6)"]
 sanic = ["sanic (>=0.8)"]
 sqlalchemy = ["sqlalchemy (>=1.2)"]
 tornado = ["tornado (>=5)"]
+
+[[package]]
+name = "setuptools"
+version = "61.2.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinxcontrib-towncrier", "furo"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-enabler (>=1.0.1)", "pytest-perf", "mock", "flake8-2020", "virtualenv (>=13.0.0)", "wheel", "pip (>=19.1)", "jaraco.envs (>=2.2)", "pytest-xdist", "jaraco.path (>=3.2.0)", "build", "filelock (>=3.4.0)", "pip-run (>=8.8)", "ini2toml[lite] (>=0.9)", "tomli-w (>=1.0.0)", "pytest-black (>=0.3.7)", "pytest-cov", "pytest-mypy (>=0.9.1)"]
+testing-integration = ["pytest", "pytest-xdist", "pytest-enabler", "virtualenv (>=13.0.0)", "tomli", "wheel", "jaraco.path (>=3.2.0)", "jaraco.envs (>=2.2)", "build", "filelock (>=3.4.0)"]
 
 [[package]]
 name = "six"
@@ -1713,6 +1737,17 @@ python-versions = ">=3.7"
 watchdog = ["watchdog"]
 
 [[package]]
+name = "wheel"
+version = "0.37.1"
+description = "A built-package format for Python"
+category = "main"
+optional = true
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.extras]
+test = ["pytest (>=3.0.0)", "pytest-cov"]
+
+[[package]]
 name = "wiki"
 version = "0.8"
 description = "A wiki system written for the Django framework."
@@ -1768,6 +1803,7 @@ future = "*"
 hjson = "*"
 jmespath = "*"
 kappa = "0.6.0"
+pip = ">=9.0.1"
 pip-tools = "*"
 python-dateutil = "*"
 python-slugify = "*"
@@ -1778,6 +1814,7 @@ toml = "*"
 tqdm = "*"
 troposphere = ">=3.0"
 Werkzeug = "*"
+wheel = "*"
 wsgi-request-logger = "*"
 
 [extras]
@@ -1787,7 +1824,7 @@ prod = ["psycopg2-binary", "boto3", "django-ses", "zappa", "django-storages"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.9"
-content-hash = "9dcf06049e9a34697b8e45a32284a5e70024b622fca5e960f80155a504abdc58"
+content-hash = "93cb7d2a97e4ceefe0c40fd35df4dc4d00f2ec56d45c7288e79649980f39e07f"
 
 [metadata.files]
 argcomplete = [
@@ -1839,12 +1876,12 @@ bleach = [
     {file = "bleach-3.3.1.tar.gz", hash = "sha256:306483a5a9795474160ad57fce3ddd1b50551e981eed8e15a582d34cef28aafa"},
 ]
 boto3 = [
-    {file = "boto3-1.21.28-py3-none-any.whl", hash = "sha256:ca37b9b4ade72f6d4fa2b7bee584dd5b1c7585f07f22ff1edbc9ecc0c4173b1f"},
-    {file = "boto3-1.21.28.tar.gz", hash = "sha256:788aa3281e91413bc201268a251c9d4ca2e9deb3a4af74daea2389cf66e5132e"},
+    {file = "boto3-1.21.30-py3-none-any.whl", hash = "sha256:ef210f8e85cdb6d26a38ebad1cfe9cefdef2ab269207e5987653555375a7ef6b"},
+    {file = "boto3-1.21.30.tar.gz", hash = "sha256:f0af8f4ef5fe6353c794cd3cce627d469a618b58ace7ca75a63cfd719df615ce"},
 ]
 botocore = [
-    {file = "botocore-1.24.28-py3-none-any.whl", hash = "sha256:03c41d26d1e765380b8175d4b136d3144aa051f17a86eebfdf9a885a5a9a6a72"},
-    {file = "botocore-1.24.28.tar.gz", hash = "sha256:102eb24b44d473adea6bb8728b20fb9547fa5858c3293df7cad67ef17ea736a7"},
+    {file = "botocore-1.24.30-py3-none-any.whl", hash = "sha256:c622751093e3d0bf61343e66d6d06190ef30bf42b1557d5070ca84e9efa06d4b"},
+    {file = "botocore-1.24.30.tar.gz", hash = "sha256:af4bdc51eeecbe9fdcdadbed9ad58c5c91380ef30f3560022bbc2ee1d78f0ad6"},
 ]
 cachetools = [
     {file = "cachetools-5.0.0-py3-none-any.whl", hash = "sha256:8fecd4203a38af17928be7b90689d8083603073622229ca7077b72d8e5a976e4"},
@@ -1919,8 +1956,8 @@ charset-normalizer = [
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 click = [
-    {file = "click-8.1.0-py3-none-any.whl", hash = "sha256:19a4baa64da924c5e0cd889aba8e947f280309f1a2ce0947a3e3a7bcb7cc72d6"},
-    {file = "click-8.1.0.tar.gz", hash = "sha256:977c213473c7665d3aa092b41ff12063227751c41d7b17165013e10069cc5cd2"},
+    {file = "click-8.1.1-py3-none-any.whl", hash = "sha256:5e0d195c2067da3136efb897449ec1e9e6c98282fbf30d7f9e164af9be901a6b"},
+    {file = "click-8.1.1.tar.gz", hash = "sha256:7ab900e38149c9872376e8f9b5986ddcaf68c0f413cf73678a0bca5547e6f976"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
@@ -2342,6 +2379,10 @@ pillow = [
     {file = "Pillow-9.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:a9f44cd7e162ac6191491d7249cceb02b8116b0f7e847ee33f739d7cb1ea1f70"},
     {file = "Pillow-9.0.1.tar.gz", hash = "sha256:6c8bc8238a7dfdaf7a75f5ec5a663f4173f8c367e5a39f87e720495e1eed75fa"},
 ]
+pip = [
+    {file = "pip-22.0.4-py3-none-any.whl", hash = "sha256:c6aca0f2f081363f689f041d90dab2a07a9a07fb840284db2218117a52da800b"},
+    {file = "pip-22.0.4.tar.gz", hash = "sha256:b3a9de2c6ef801e9247d1527a4b16f92f2cc141cd1489f3fffaf6a9e96729764"},
+]
 pip-tools = [
     {file = "pip-tools-6.5.1.tar.gz", hash = "sha256:80f562aa699fc76a424539697e0bef41e490a050e57a6a21468531981a9d419e"},
     {file = "pip_tools-6.5.1-py3-none-any.whl", hash = "sha256:80f1cfc7156e4a4465b1a46a6bb3599587909537db1a149cf3a6b73eed979ee4"},
@@ -2688,6 +2729,10 @@ sentry-sdk = [
     {file = "sentry-sdk-1.5.8.tar.gz", hash = "sha256:38fd16a92b5ef94203db3ece10e03bdaa291481dd7e00e77a148aa0302267d47"},
     {file = "sentry_sdk-1.5.8-py2.py3-none-any.whl", hash = "sha256:32af1a57954576709242beb8c373b3dbde346ac6bd616921def29d68846fb8c3"},
 ]
+setuptools = [
+    {file = "setuptools-61.2.0-py3-none-any.whl", hash = "sha256:8f4813dd6a4d6cc17bde85fb2e635fe19763f96efbb0ddf5575562e5ee0bc47a"},
+    {file = "setuptools-61.2.0.tar.gz", hash = "sha256:c3d4e2ab578fbf83775755cd76dae73627915a22832cf4ea5de895978767833b"},
+]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -2755,6 +2800,10 @@ webencodings = [
 werkzeug = [
     {file = "Werkzeug-2.1.0-py3-none-any.whl", hash = "sha256:094ecfc981948f228b30ee09dbfe250e474823b69b9b1292658301b5894bbf08"},
     {file = "Werkzeug-2.1.0.tar.gz", hash = "sha256:9b55466a3e99e13b1f0686a66117d39bda85a992166e0a79aedfcf3586328f7a"},
+]
+wheel = [
+    {file = "wheel-0.37.1-py2.py3-none-any.whl", hash = "sha256:4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a"},
+    {file = "wheel-0.37.1.tar.gz", hash = "sha256:e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4"},
 ]
 wiki = [
     {file = "wiki-0.8-py3-none-any.whl", hash = "sha256:9617492a090538cf7e61c9560bed3f5320ab07ba33b6e6880fcb260a5d363777"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ pyyaml = "^6.0"
 pywebpush = "^1.11.0"
 
 # Monitoring
-sentry-sdk = { version = "~1.5", extras = [ "django" ], optional = true }
+sentry-sdk = { version = "~1.5", extras = [ "django" ] }
 # AWS
 boto3 =  { version = "~1.21", optional = true }
 django-ses = { version = "~2.3", optional = true }
@@ -83,7 +83,6 @@ prod = [
     "django-ses",
     "zappa",
     "django-storages",
-    "sentry",
 ]
 postgresql = ["psycopg2-binary"]
 


### PR DESCRIPTION
- Revert 372e49754609a97aecf602dcc1061fef23818657 to make Sentry
required again. The current setup was crashing due to a typo in the
prod-extras (`sentry` instead of `sentry-sdk`), meaning Sentry was never
installed, but you would'nt notice until you actually start to run.
- Add `python manage.py check` to CI to ensure this does not happen
again.
- Use documented `SENTRY_RELEASE` env-variable instead of a custom one,
mostly due to it having sane defaults normally, and that also crashed
upon startup.

Co-authored-by: Henrik Skog <henrikskog@users.noreply.github.com>

## Description of changes
<!-- It is often obvious what changed by looking at the code, so it is more helpful to say _why_ it should be changed -->
<!-- If the Pull Request is not ready to be merged, please use a draft pull request -->

## Code Checklist

- [ ] I have added tests
- [ ] I have provided documentation

<!-- IF THERE ARE ANY BREAKING CHANGES
E.G. IF THERE IS A CHANGE IN AN API OR A NEW API-TOKEN NEEDS TO BE ADDED,
BE SURE TO DOCUMENT THEM, AND INFORM US ABOUT
CHANGES NEEDED TO BE MADE IN OTHER PROJECTS,
OR IN PRODUCTION. 
 -->

<!-- REMOVE FROM HERE AND BELOW IF NO VISUAL CHANGES -->
## Visual changes
<!-- IF DOING ANY DESIGN CHANGE PLEASE ADD BEFORE PICTURES HERE -->

<details>
<summary>Before</summary>
<!-- PASTE BEFORE IMAGE HERE -->

</details>

<details>
<summary>After</summary>
<!-- PASTE AFTER IMAGE HERE -->

</details>
