### PR TITLE
Fix Dataporten config

### DIFF
--- a/apps/dataporten/urls.py
+++ b/apps/dataporten/urls.py
@@ -1,18 +1,10 @@
-from django.conf import settings
 from django.urls import re_path
 
 from apps.dataporten import views
 
 app_name = "dataporten"
 
-study_urls = [
+urlpatterns = [
     re_path(r"^study/$", views.study, name="study"),
     re_path(r"^study/callback/$", views.study_callback, name="study-callback"),
 ]
-
-urlpatterns = []
-
-if settings.DATAPORTEN.get("STUDY").get("ENABLED") or settings.DATAPORTEN.get(
-    "STUDY"
-).get("TESTING"):
-    urlpatterns += study_urls

--- a/apps/dataporten/views.py
+++ b/apps/dataporten/views.py
@@ -31,7 +31,7 @@ def study(request):
     user's groups membership, which can be used to verify eligibility for membership of Online."""
 
     # If the user already is a member we can return early. However, if we're in testing, we want to skip the check.
-    if settings.DATAPORTEN.get("STUDY").get("ENABLED") and request.user.is_member:
+    if request.user.is_member and not settings.DATAPORTEN.get("STUDY").get("TESTING"):
         messages.info(request, "Du er allerede registrert som medlem.")
         return redirect("profiles_active", active_tab="membership")
 

--- a/apps/profiles/views.py
+++ b/apps/profiles/views.py
@@ -80,6 +80,7 @@ def _create_profile_context(request):
     The code is refactored to use Django signals, so whenever a user is created, a privacy-property is set up.
     """
 
+    # TODO: this should be invoked as a signal upon user receiving is_staff, causes crashes when testing locally
     if request.user.is_staff and not request.user.online_mail:
         create_online_mail_alias(request.user)
 
@@ -169,8 +170,7 @@ def _create_profile_context(request):
         ],
         "internal_services_form": InternalServicesForm(),
         "in_comittee": has_access(request),
-        "enable_dataporten_application": settings.DATAPORTEN.get("STUDY").get("ENABLED")
-        or settings.DATAPORTEN.get("STUDY").get("TESTING"),
+        "DATAPORTEN_ENABLED": "apps.dataporten" in settings.INSTALLED_APPS,
     }
 
     return context

--- a/onlineweb4/settings/dataporten.py
+++ b/onlineweb4/settings/dataporten.py
@@ -2,7 +2,6 @@ from decouple import config
 
 DATAPORTEN = {
     "STUDY": {
-        "ENABLED": config("OW4_DP_STUDY_ENABLED", cast=bool, default=False),
         "TESTING": config("OW4_DP_STUDY_TESTING", cast=bool, default=True),
         "CLIENT_ID": config("OW4_DP_STUDY_CLIENT_ID", default=""),
         "CLIENT_SECRET": config("OW4_DP_STUDY_CLIENT_SECRET", default=""),

--- a/onlineweb4/settings/zappa.py
+++ b/onlineweb4/settings/zappa.py
@@ -30,7 +30,6 @@ SECRET_KEY = env["SECRET_KEY"]
 
 DATAPORTEN = {
     "STUDY": {
-        "ENABLED": config("OW4_DP_STUDY_ENABLED", cast=bool, default=False),
         "TESTING": config("OW4_DP_STUDY_TESTING", cast=bool, default=True),
         "CLIENT_ID": env["DP_STUDY_CLIENT_ID"],
         "CLIENT_SECRET": env["DP_STUDY_CLIENT_SECRET"],

--- a/onlineweb4/urls.py
+++ b/onlineweb4/urls.py
@@ -116,10 +116,10 @@ if "apps.dashboard" in settings.INSTALLED_APPS:
     ]
 
 if "apps.dataporten" in settings.INSTALLED_APPS:
-    from apps.dataporten import urls as dataporten_urls
-
     urlpatterns += [
-        re_path(r"^dataporten/", include(dataporten_urls, namespace="dataporten"))
+        re_path(
+            r"^dataporten/", include("apps.dataporten.urls", namespace="dataporten")
+        )
     ]
 
 if "apps.events" in settings.INSTALLED_APPS:

--- a/templates/profiles/index.html
+++ b/templates/profiles/index.html
@@ -57,9 +57,11 @@ Min side - Online
                         <li class="{% if 'email' == active_tab %}active{% endif %}">
                             <a href="{% url 'profiles_active' 'email' %}" data-section="email">Epost-innstillinger</a>
                         </li>
+                        {% if DATAPORTEN_ENABLED %}
                         <li class="{%if 'membership' == active_tab %}active{% endif %}">
                             <a href="{% url 'profiles_active' 'membership' %}" data-section="membership">Medlemskap</a>
                         </li>
+                        {% endif %}
                         <li class="{% if 'payments' == active_tab %}active{% endif %}">
                             <a href="{% url 'profiles_active' 'payments' %}" data-section="payments">Betalinger</a>
                         </li>
@@ -97,9 +99,11 @@ Min side - Online
                         <section id="email">
                             {% include "profiles/email.html" %}
                         </section>
+                        {% if DATAPORTEN_ENABLED %}
                         <section id="membership">
                             {% include "profiles/membership.html" %}
                         </section>
+                        {% endif %}
                         <section id="payments">
                             {% include "profiles/payments.html" %}
                         </section>


### PR DESCRIPTION
- Activation is not triggered based upon "apps.dataporten" being
  installed, not a separate env-variable.
- Guard the relevant templates on dataporten being enabled, which was
  causing errors (as a bi-effect of misconfiguration)

## Description of changes
<!-- It is often obvious what changed by looking at the code, so it is more helpful to say _why_ it should be changed -->
<!-- If the Pull Request is not ready to be merged, please use a draft pull request -->

## Code Checklist

- [ ] I have added tests
- [ ] I have provided documentation

<!-- IF THERE ARE ANY BREAKING CHANGES
E.G. IF THERE IS A CHANGE IN AN API OR A NEW API-TOKEN NEEDS TO BE ADDED,
BE SURE TO DOCUMENT THEM, AND INFORM US ABOUT
CHANGES NEEDED TO BE MADE IN OTHER PROJECTS,
OR IN PRODUCTION. 
 -->

<!-- REMOVE FROM HERE AND BELOW IF NO VISUAL CHANGES -->
## Visual changes
<!-- IF DOING ANY DESIGN CHANGE PLEASE ADD BEFORE PICTURES HERE -->

<details>
<summary>Before</summary>
<!-- PASTE BEFORE IMAGE HERE -->

</details>

<details>
<summary>After</summary>
<!-- PASTE AFTER IMAGE HERE -->

</details>
