### PR TITLE
Add auth requirement for access to user info

### DIFF
--- a/apps/authentication/api/views.py
+++ b/apps/authentication/api/views.py
@@ -29,7 +29,10 @@ from apps.authentication.serializers import (
     UserUpdateSerializer,
 )
 from apps.common.rest_framework.mixins import MultiSerializerMixin
-from apps.permissions.drf_permissions import DjangoObjectPermissions, DjangoObjectPermissionOrAnonReadOnly
+from apps.permissions.drf_permissions import (
+    DjangoObjectPermissionOrAnonReadOnly,
+    DjangoObjectPermissionOrAuthReadOnly, 
+)
 
 from .filters import OnlineGroupFilter, UserFilter
 from .permissions import IsSelfOrSuperUser
@@ -197,7 +200,7 @@ class OnlineGroupViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
 
 
 class GroupMemberViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
-    permission_classes = (DjangoObjectPermissions,)
+    permission_classes = (DjangoObjectPermissionOrAuthReadOnly,)
     queryset = GroupMember.objects.all()
     serializer_classes = {
         "create": GroupMemberCreateSerializer,

--- a/apps/authentication/api/views.py
+++ b/apps/authentication/api/views.py
@@ -197,7 +197,7 @@ class OnlineGroupViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
 
 
 class GroupMemberViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
-    permission_classes = (DjangoObjectPermissionOrAnonReadOnly,)
+    permission_classes = (IsAuthenticated,)
     queryset = GroupMember.objects.all()
     serializer_classes = {
         "create": GroupMemberCreateSerializer,

--- a/apps/authentication/api/views.py
+++ b/apps/authentication/api/views.py
@@ -31,7 +31,7 @@ from apps.authentication.serializers import (
 from apps.common.rest_framework.mixins import MultiSerializerMixin
 from apps.permissions.drf_permissions import (
     DjangoObjectPermissionOrAnonReadOnly,
-    DjangoObjectPermissionOrAuthReadOnly, 
+    DjangoObjectPermissionOrAuthReadOnly,
 )
 
 from .filters import OnlineGroupFilter, UserFilter

--- a/apps/authentication/api/views.py
+++ b/apps/authentication/api/views.py
@@ -29,7 +29,7 @@ from apps.authentication.serializers import (
     UserUpdateSerializer,
 )
 from apps.common.rest_framework.mixins import MultiSerializerMixin
-from apps.permissions.drf_permissions import DjangoObjectPermissionOrAnonReadOnly
+from apps.permissions.drf_permissions import DjangoObjectPermissions, DjangoObjectPermissionOrAnonReadOnly
 
 from .filters import OnlineGroupFilter, UserFilter
 from .permissions import IsSelfOrSuperUser
@@ -197,7 +197,7 @@ class OnlineGroupViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
 
 
 class GroupMemberViewSet(MultiSerializerMixin, viewsets.ModelViewSet):
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (DjangoObjectPermissions,)
     queryset = GroupMember.objects.all()
     serializer_classes = {
         "create": GroupMemberCreateSerializer,

--- a/apps/permissions/drf_permissions.py
+++ b/apps/permissions/drf_permissions.py
@@ -9,7 +9,8 @@ class DjangoObjectPermissionOrAnonReadOnly(permissions.DjangoObjectPermissions):
             return super().has_permission(request, view)
         # The rest are handled by object permissions
         return True
-    
+
+
 class DjangoObjectPermissionOrAuthReadOnly(permissions.DjangoObjectPermissions):
     authenticated_users_only = True
 

--- a/apps/permissions/drf_permissions.py
+++ b/apps/permissions/drf_permissions.py
@@ -10,7 +10,7 @@ class DjangoObjectPermissionOrAnonReadOnly(permissions.DjangoObjectPermissions):
         # The rest are handled by object permissions
         return True
     
-class DjangoObjectPermissions(permissions.DjangoObjectPermissions):
+class DjangoObjectPermissionOrAuthReadOnly(permissions.DjangoObjectPermissions):
     authenticated_users_only = True
 
     def has_permission(self, request, view):

--- a/apps/permissions/drf_permissions.py
+++ b/apps/permissions/drf_permissions.py
@@ -9,3 +9,12 @@ class DjangoObjectPermissionOrAnonReadOnly(permissions.DjangoObjectPermissions):
             return super().has_permission(request, view)
         # The rest are handled by object permissions
         return True
+    
+class DjangoObjectPermissions(permissions.DjangoObjectPermissions):
+    authenticated_users_only = True
+
+    def has_permission(self, request, view):
+        if request.method == "POST":
+            return super().has_permission(request, view)
+        # The rest are handled by object permissions
+        return True


### PR DESCRIPTION
Currently, anyone can access the private email address of all Online members who are part of a group (committee etc.) For GDPR reasons, this should be changed so that only authenticated users can access this information