### PR TITLE
Remove email field from UserNameSerializer

### DIFF
--- a/apps/authentication/serializers.py
+++ b/apps/authentication/serializers.py
@@ -27,7 +27,7 @@ from onlineweb4.fields.recaptcha import RecaptchaField
 class UserNameSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ("first_name", "last_name", "email", "username")
+        fields = ("first_name", "last_name", "username")
 
 
 class UserReadOnlySerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Having this here allowed anyone to access private emails of users.
Should be removed for GDPR reasons
