### PR TITLE
Exclude email in UserNameSerializer

### DIFF
--- a/apps/authentication/serializers.py
+++ b/apps/authentication/serializers.py
@@ -28,6 +28,7 @@ class UserNameSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ("first_name", "last_name", "username")
+        exclude = ("email")
 
 
 class UserReadOnlySerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Exludes the email field from userSerializer as this info can be read by anyone.
Private emails should be kept behind authentication