### PR TITLE
show id in username serializer for group members

### DIFF
--- a/apps/authentication/serializers.py
+++ b/apps/authentication/serializers.py
@@ -29,6 +29,7 @@ class UserNameSerializer(serializers.ModelSerializer):
         model = User
         fields = ("id", "first_name", "last_name", "email", "username")
 
+
 class UserReadOnlySerializer(serializers.ModelSerializer):
     rfid = serializers.HiddenField(default="")
 

--- a/apps/authentication/serializers.py
+++ b/apps/authentication/serializers.py
@@ -27,7 +27,7 @@ from onlineweb4.fields.recaptcha import RecaptchaField
 class UserNameSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ("first_name", "last_name", "email", "username")
+        fields = ("id", "first_name", "last_name", "email", "username")
 
 
 class UserReadOnlySerializer(serializers.ModelSerializer):

--- a/apps/authentication/serializers.py
+++ b/apps/authentication/serializers.py
@@ -29,8 +29,6 @@ class UserNameSerializer(serializers.ModelSerializer):
         model = User
         fields = ("id", "first_name", "last_name", "email", "username")
 
-
-
 class UserReadOnlySerializer(serializers.ModelSerializer):
     rfid = serializers.HiddenField(default="")
 


### PR DESCRIPTION
## Description of changes

Adds an ID field on a user serializer, that's used by the online-groups/{group}/group-users/ api

## Code Checklist

- [ ] I have added tests
- [ ] I have provided documentation
