### PR TITLE
:sparkles: Add text to placeholder for kommentarer in plakatbestilling"

### DIFF
--- a/apps/posters/forms.py
+++ b/apps/posters/forms.py
@@ -24,7 +24,7 @@ class AddForm(forms.ModelForm):
         required=False,
         widget=forms.Textarea(
             attrs={
-                "placeholder": "Eventuell informasjon, kommentarer, lenker til bilder, osv..."
+                "placeholder": "Skriv her om du vil bestille plakat og banner eller bare banner. Fyll også inn eventuell informasjon, kommentarer, lenker til bilder, osv..."
             }
         ),
     )


### PR DESCRIPTION
## Description of changes
Closes: #2956 

<!-- It is often obvious what changed by looking at the code, so it is more helpful to say _why_ it should be changed -->
<!-- If the Pull Request is not ready to be merged, please use a draft pull request -->

Adds more text to kommentarer placeholder to let users know that they can order only a banner if the event does not require a poster.

This feature has been checked with Henrik Moe from Prokom and they think that it is sufficient! 

