### PR TITLE
make payment price sync on order delete DOT-263

### DIFF
--- a/apps/webshop/signals.py
+++ b/apps/webshop/signals.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db.models.signals import post_save
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
 from apps.payment.models import Payment, PaymentPrice
@@ -10,6 +10,7 @@ from utils.disable_for_loaddata import disable_for_loaddata
 logger = logging.getLogger(__name__)
 
 
+@receiver(post_delete, sender=Order)
 @receiver(post_save, sender=Order)
 @disable_for_loaddata
 def sync_order_line_subtotal_to_payment_price(sender, instance: Order, **kwargs):


### PR DESCRIPTION
## Description of changes
Fix of #2887 

Added decorator to make price sync function also when order is deleted, and not only when new order is created.
Otherwise the price shown in UI and price sent to Stripe diverge after order is deleted

## Code Checklist

- [ ] I have added tests
- [ ] I have provided documentation
