### PR TITLE
Show allergies on attendees list

### DIFF
--- a/templates/events/dashboard/details/attendees.html
+++ b/templates/events/dashboard/details/attendees.html
@@ -34,9 +34,8 @@
                                     <th>Møtt</th>
                                 {% if event.attendance_event.has_extras %}
                                     <th>Extra</th>
-                                {% else %}
-                                    <th>Allergier</th>
                                 {% endif %}
+                                <th>Allergier</th>
                                 <th>Fjern</th>
                             </tr>
                         </thead>
@@ -72,11 +71,10 @@
                                 <td>
                                     {% if attendee.extras %}{{ attendee.extras }}{% else %}-{% endif %}
                                 </td>
-                                {% else %}
+                                {% endif %}
                                 <td>
                                     {% if attendee.user.allergies %}{{ attendee.user.allergies }}{% else %}-{% endif %}
                                 </td>
-                                {% endif %}
                                 <td>
                                     <a href="#modal-delete-attendee" data-toggle="modal" data-id="{{ attendee.id }}" data-name="{{ attendee.user.get_full_name }}" class="remove-user">
                                         <i class="fa fa-times fa-lg red"></i>


### PR DESCRIPTION
## Description of changes
We removed the if statement that was hiding the attendees allergies for events with extras. Kushkom pointed this out to me.

## Code Checklist

- [👎] I have added tests
- [👎] I have provided documentation

How it looked before:

<img width="637" alt="Screenshot 2023-01-24 at 13 28 53" src="https://user-images.githubusercontent.com/42111513/214292115-9a2b8acc-d541-4856-a974-d91a8eaabe87.png">


