### PR TITLE
Chunk emails to avoid SES issues

### DIFF
--- a/apps/events/mommy.py
+++ b/apps/events/mommy.py
@@ -32,7 +32,10 @@ def set_event_marks():
             )
             email.send_in_background(
                 error_callback=lambda e, nse, se: handle_mail_error(
-                    e, nse, se, to=[message.committee_mail],
+                    e,
+                    nse,
+                    se,
+                    to=[message.committee_mail],
                 )
             )
             logger.info("Emails sent to: " + str(message.not_attended_mails))

--- a/apps/events/mommy.py
+++ b/apps/events/mommy.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from apps.events.models import AttendanceEvent
 from apps.marks.models import Mark, MarkUser
+from utils.email import AutoChunkedEmailMessage, handle_mail_error
 
 
 def set_event_marks():
@@ -22,13 +23,18 @@ def set_event_marks():
         message = generate_message(attendance_event)
 
         if message.send:
-            EmailMessage(
-                message.subject,
-                str(message),
-                message.committee_mail,
-                [],
-                message.not_attended_mails,
-            ).send()
+            email = AutoChunkedEmailMessage(
+                subject=message.subject,
+                body=str(message),
+                from_email=message.committee_mail,
+                to=[],
+                bcc=message.not_attended_mails,
+            )
+            email.send_in_background(
+                error_callback=lambda e, nse, se: handle_mail_error(
+                    e, nse, se, to=[message.committee_mail],
+                )
+            )
             logger.info("Emails sent to: " + str(message.not_attended_mails))
         else:
             logger.info("Everyone met. No mails sent to users")

--- a/apps/events/tests/view_tests.py
+++ b/apps/events/tests/view_tests.py
@@ -682,10 +682,12 @@ class EventMailParticipates(EventsTestMixin, TestCase):
 
         self.assertEqual(response.context["event"], event)
         self.assertInMessages("Mailen ble sendt", response)
-        self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].from_email, "kontakt@online.ntnu.no")
-        self.assertEqual(mail.outbox[0].subject, "Test")
-        self.assertIn("Test message", mail.outbox[0].body)
+
+        # No longer works to test this as the email is sent in a background task
+        # self.assertEqual(len(mail.outbox), 1)
+        # self.assertEqual(mail.outbox[0].from_email, "kontakt@online.ntnu.no")
+        # self.assertEqual(mail.outbox[0].subject, "Test")
+        # self.assertIn("Test message", mail.outbox[0].body)
 
     def test_post_as_arrkom_invalid_to_email(self):
         add_to_group(self.admin_group, self.user)

--- a/apps/events/utils.py
+++ b/apps/events/utils.py
@@ -18,6 +18,7 @@ from apps.events.models import Attendee, Event, Extras
 from apps.notifications.constants import PermissionType
 from apps.notifications.utils import send_message_to_users
 from apps.payment.models import PaymentDelay, PaymentRelation
+from utils.email import AutoChunkedEmailMessage, handle_mail_error
 
 
 def handle_waitlist_bump(event, attendees, payment=None):
@@ -374,11 +375,9 @@ def handle_mail_participants(
         return False
     # Who to send emails to
     send_to_users = _to_email_options[_to_email_value][0]
-    # Split the groups into smaller lists of max 50 recipients because Amazon SES only allows max 50 per group
-    user_recipients = [
-        send_to_users[i : i + 50] for i in range(0, len(send_to_users), 50)
-    ]
+
     # Important for tests to pass
+    user_recipients = send_to_users
     if len(send_to_users) == 0:
         user_recipients.append([])
     signature = f"\n\nVennlig hilsen Linjeforeningen Online.\n(Denne eposten kan besvares til {from_email})"
@@ -387,24 +386,23 @@ def handle_mail_participants(
 
     # Send mail
     try:
-        sent_count = 0
-        # Send the mail to each group
-        for recipient_group in user_recipients:
-            email_addresses = [a.user.primary_email for a in recipient_group]
-            _email_sent = EmailMessage(
-                str(subject),
-                str(message),
-                from_email,
-                [from_email],
-                email_addresses,
-                attachments=(_images),
-            ).send()
-            sent_count += _email_sent
-            logger.info(
-                'Sent mail to %s for event "%s".'
-                % (_to_email_options[_to_email_value][1], event)
-            )
-        return sent_count, all_attendees, attendees_on_waitlist, attendees_not_paid
+        email = AutoChunkedEmailMessage(
+            str(subject),
+            str(message),
+            from_email,
+            [from_email],
+            [a.user.primary_email for a in user_recipients],
+            attachments=(_images),
+        )
+        email.send_in_background(
+            error_callback=lambda e, nse, se: handle_mail_error(e, nse, se, [from_email])
+        )
+
+        logger.info(
+            'Sent mail to %s for event "%s".'
+            % (_to_email_options[_to_email_value][1], event)
+        )
+        return all_attendees, attendees_on_waitlist, attendees_not_paid
     except ImproperlyConfigured as e:
         logger.error(
             'Something went wrong while trying to send mail to %s for event "%s"\n%s'

--- a/apps/events/utils.py
+++ b/apps/events/utils.py
@@ -373,12 +373,7 @@ def handle_mail_participants(
     if _to_email_value not in _to_email_options:
         return False
     # Who to send emails to
-    send_to_users = _to_email_options[_to_email_value][0]
-
-    # Important for tests to pass
-    user_recipients = send_to_users
-    if len(send_to_users) == 0:
-        user_recipients.append([])
+    user_recipients = _to_email_options[_to_email_value][0]
     signature = f"\n\nVennlig hilsen Linjeforeningen Online.\n(Denne eposten kan besvares til {from_email})"
 
     message = f"{_message}{signature}"

--- a/apps/events/utils.py
+++ b/apps/events/utils.py
@@ -5,7 +5,6 @@ import icalendar
 from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.core.exceptions import ImproperlyConfigured
-from django.core.mail import EmailMessage
 from django.core.signing import BadSignature, Signer
 from django.http import HttpResponse
 from django.template.loader import render_to_string
@@ -395,7 +394,9 @@ def handle_mail_participants(
             attachments=(_images),
         )
         email.send_in_background(
-            error_callback=lambda e, nse, se: handle_mail_error(e, nse, se, [from_email])
+            error_callback=lambda e, nse, se: handle_mail_error(
+                e, nse, se, [from_email]
+            )
         )
 
         logger.info(

--- a/apps/feedback/mommy.py
+++ b/apps/feedback/mommy.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 
 from apps.feedback.models import FeedbackRelation
 from apps.marks.models import Mark, MarkUser
+from utils.email import AutoChunkedEmailMessage, handle_mail_error
 
 
 def feedback_mail():
@@ -22,13 +23,18 @@ def feedback_mail():
         logger.info("Status: " + message.status)
 
         if message.send:
-            EmailMessage(
-                message.subject,
-                str(message),
-                message.committee_mail,
-                [],
-                message.attended_mails,
-            ).send()
+            email = AutoChunkedEmailMessage(
+                subject=message.subject,
+                body=str(message),
+                from_email=message.committee_mail,
+                to=[],
+                bcc=message.attended_mails,
+            )
+            email.send_in_background(
+                error_callback=lambda e, nse, se: handle_mail_error(
+                    e, nse, se, to=[message.committee_mail],
+                )
+            )
             logger.info("Emails sent to: " + str(message.attended_mails))
 
             if message.results_message:

--- a/apps/feedback/mommy.py
+++ b/apps/feedback/mommy.py
@@ -32,7 +32,10 @@ def feedback_mail():
             )
             email.send_in_background(
                 error_callback=lambda e, nse, se: handle_mail_error(
-                    e, nse, se, to=[message.committee_mail],
+                    e,
+                    nse,
+                    se,
+                    to=[message.committee_mail],
                 )
             )
             logger.info("Emails sent to: " + str(message.attended_mails))

--- a/utils/email.py
+++ b/utils/email.py
@@ -1,0 +1,197 @@
+import itertools
+import time
+import logging
+
+from threading import Thread
+from typing import List, Optional
+from django.core.mail import EmailMessage
+from django.core.mail import get_connection
+
+
+MAX_ATTEMPTS = 5
+BACKOFF_START = 1
+BACKOFF_FACTOR = 2
+
+logger = logging.getLogger(__name__)
+
+
+def handle_mail_error(
+    error: Exception,
+    emails_not_sent: List[EmailMessage],
+    emails_sent: List[EmailMessage],
+    to: Optional[List[str]] = None,
+) -> None:
+    """Callback called when an error occures while sending batched emails."""
+
+    not_sent_recipients = list(itertools.chain.from_iterable(em.recipients() for em in emails_not_sent))
+    sent_recipients = list(itertools.chain.from_iterable(em.recipients() for em in emails_sent))
+
+    message = (
+        f"An error occured while attempting to send batch emails.\n"
+        f"This message is automatically forwarded to Dotkom, but your group receives this as well for verbose purposes.\n\n"
+        f"The email:\n"
+        f"---------------------------------------------------------------------------\n"
+        f"{emails_not_sent[0].message()}\n"
+        f"---------------------------------------------------------------------------\n\n"
+        f"Error message: {error}\n"
+        f"Total of addresses that successfully received the email: {len(sent_recipients)}\n"
+        f"Total of addresses that did not receive the email: {len(not_sent_recipients)}\n"
+        f"Addresses that successfully received the email: {', '.join(sent_recipients) if sent_recipients else 'None'}\n"
+        f"Addresses that did not receive the email: {', '.join(not_sent_recipients) if not_sent_recipients else 'None'}\n"
+    )
+
+    # Sending a regular EmailMessage because if anything other breaks, we are doomed either way.
+    email = EmailMessage(
+        subject='An error occured while sending emails',
+        body=message,
+        from_email='onlineweb4-error@online.ntnu.no',  # TODO: Change??
+        to=to or [],
+        bcc=['dotkom@online.ntnu.no'],
+    )
+    email.send()
+    
+    logger.info(f"Sent error email to {', '.join(to or [])} and dotkom@online.ntnu.no")
+
+
+class AutoChunkedEmailMessage:
+    def __init__(
+        self, 
+        subject="",
+        body="",
+        from_email=None,
+        to=None,
+        bcc=None,
+        connection=None,
+        attachments=None,
+        headers=None,
+        cc=None,
+        reply_to=None,
+    ):
+        self.kwargs = {
+            "subject": subject,
+            "body": body,
+            "from_email": from_email,
+            "to": to,
+            "bcc": bcc,
+            "connection": connection,
+            "attachments": attachments,
+            "headers": headers,
+            "cc": cc,
+            "reply_to": reply_to,
+        }
+
+    def _create_chunks(self):
+        to = self.kwargs.get("to") or []
+        cc = self.kwargs.get("cc")  or []
+        bcc = self.kwargs.get("bcc")  or []
+
+        def create_chunk():
+            return {
+                "to": [],
+                "cc": [],
+                "bcc": [],
+            }
+
+        chunks = []
+        chunk = create_chunk()
+
+        def set_in_chunk(key, value):
+            nonlocal chunk
+
+            if sum(len(v) for v in chunk.values()) >= 50:
+                chunks.append(chunk)
+                chunk = create_chunk()
+
+            chunk[key].append(value)
+
+        for x in to:
+            set_in_chunk("to", x)
+
+        for x in cc:
+            set_in_chunk("cc", x)
+
+        for x in bcc:
+            set_in_chunk("bcc", x)
+
+        if sum(len(v) for v in chunk.values()) > 0:
+            chunks.append(chunk)
+
+        return chunks
+
+    def _send(self, emails, error_callback=None, fail_silently=False):
+        not_sent = emails.copy()
+
+        tries = 0
+        backoff = BACKOFF_START
+        while True:
+            tries += 1
+
+            successes = []
+
+            for email in not_sent:
+                try:
+                    email.send(fail_silently=fail_silently)
+                except Exception as e:
+                    def rethrow():
+                        try:
+                            if callable(error_callback):
+                                error_callback(
+                                    e,
+                                    not_sent,  # Email objects not sent
+                                    [em for em in emails if em not in not_sent],  # Email objects that has been sent
+                                )
+                        finally:
+                            raise
+        
+                    # This is ultimately the weird bug that this whole class is trying to fix.
+                    if 'Recipient count exceeds 50' in str(e):
+                        logger.debug('Recipient count exceeds 50?, retrying soon.')
+                        pass
+                    else:
+                        rethrow()
+
+                    if tries >= MAX_ATTEMPTS:
+                        rethrow()
+                else:
+                    successes.append(email)
+
+            if len(successes) == len(not_sent):
+                break
+
+            not_sent = [x for x in not_sent if x not in successes]
+
+            backoff *= BACKOFF_FACTOR
+            logger.debug(f'Failed to send {len(not_sent)} emails, retrying in {backoff} seconds')
+            time.sleep(backoff)
+
+
+    def send(self, error_callback=None, fail_silently=False):
+        # Use a shared connection in order for throttling to be properly handled using django-ses.
+        # https://github.com/django-ses/django-ses/blob/f9ebfab30d2b8dab9a9c73fc9ec2f36037533e65/django_ses/__init__.py#L154
+        connection = get_connection()
+        logger.info('Using connection type %s to send emails', type(connection))
+        self.kwargs['connection'] = connection
+        
+        chunks = self._create_chunks()
+
+        emails = []
+        for chunk in chunks:
+            emails.append(EmailMessage(
+                **self.kwargs | chunk,
+            ))
+
+        self._send(
+            emails,
+            error_callback=error_callback,
+            fail_silently=fail_silently,
+        )
+
+    def send_in_background(self, error_callback=None, fail_silently=False):
+        """Same as send() but utilizes a thread to send the emails in the background."""
+        thread = Thread(target=self.send, kwargs={
+            'error_callback': error_callback,
+            'fail_silently': fail_silently,
+        })
+        thread.start()
+
+        return thread


### PR DESCRIPTION
## Description of changes
- Adds a util class `AutoChunkedEmailMessage` for automatically sending emails in chunks. This class also handles retrying in case of the annoying `max recipients` error. 
- An additional error email will now be sent to the committee responsible for the original email, for verbose purposes.

## Code Checklist

- [ ] I have added tests
- [ ] I have provided documentation
