### PR TITLE
Re-add code splitting, fix global jquery, fix N+1 query

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
       if: matrix.language == 'python'
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version-file: '.python-version'
 
     - name: Install dependencies
       if: matrix.language == 'python'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version-file: '.python-version'
 
       - name: Install Zappa
         run: pip install zappa==0.58

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,6 @@ on:
 env:
   POETRY_VERSION: "1.6.1"
   NODE_VERSION: "18"
-  PYTHON_VERSION: "3.11"
 
 jobs:
   test-python:
@@ -43,7 +42,7 @@ jobs:
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version-file: '.python-version'
 
       - name: Install Poetry
         run: pip install poetry==${{ env.POETRY_VERSION }}
@@ -85,10 +84,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-poetry-
 
-      - name: Set up Python ${{ env.PYTHON_VERSION }}
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version-file: '.python-version'
 
       - name: Install Poetry
         run: pip install poetry==${{ env.POETRY_VERSION }}
@@ -113,10 +112,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-poetry-
 
-      - name: Set up Python ${{ env.PYTHON_VERSION }}
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version-file: '.python-version'
 
       - name: Install Poetry
         run: pip install poetry==${{ env.POETRY_VERSION }}

--- a/apps/dashboard/templates/chunks/chunk_form.html
+++ b/apps/dashboard/templates/chunks/chunk_form.html
@@ -17,7 +17,7 @@
 
 {% block js %}
   {{ block.super }}
-  {% render_bundle 'dashboardChunks' 'js' %}
+  {% render_bundle 'dashboardChunks' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/assets/article/archive/Article-archive.js
+++ b/assets/article/archive/Article-archive.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+/// import $ from 'jquery';
 import ArticleArchiveWidget from './ArticleArchiveWidget';
 
 let isLoadingNewContent = false; // Indicating if we are currently loading something

--- a/assets/article/archive/ArticleArchiveWidget.js
+++ b/assets/article/archive/ArticleArchiveWidget.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import $ from 'jquery';
+// import $ from 'jquery';
 import { makeApiRequest } from 'common/utils';
 
 function ArticleArchiveWidget() {

--- a/assets/article/archive/TagCloud.js
+++ b/assets/article/archive/TagCloud.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 
 $('div.tagcloud span').each(function tagCloud() {
   const max = $('div.tagcloud').data('max_frequency');

--- a/assets/article/details/articleRelated.js
+++ b/assets/article/details/articleRelated.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 
 const addRelatedArticles = (data) => {
   let output = '';

--- a/assets/authentication/login.js
+++ b/assets/authentication/login.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 
 export default () => {
   // Setting focus on either username or password if errortext is presented

--- a/assets/common/utils/alert.js
+++ b/assets/common/utils/alert.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 
 // Fadeout alerts if they have the data-dismiss property
 export const timeOutAlerts = () => {

--- a/assets/common/utils/dom.js
+++ b/assets/common/utils/dom.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 import { template } from 'underscore';
 import { cityFromZipCode } from './request';
 

--- a/assets/common/utils/request.js
+++ b/assets/common/utils/request.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 import Cookies from 'js-cookie';
 
 /**

--- a/assets/core/init.js
+++ b/assets/core/init.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 
 const addAnimation = () => {
   const svg = document.querySelectorAll('.mn-svg');

--- a/assets/dashboard/approval/index.js
+++ b/assets/dashboard/approval/index.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 import { showStatusMessage } from 'common/utils';
 import './less/approval.less';
 

--- a/assets/dashboard/article/article.js
+++ b/assets/dashboard/article/article.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import jQuery from 'jquery';
+// import jQuery from 'jquery';
 import { ajax, showStatusMessage } from 'common/utils';
 /**
  * Created by myth on 10/18/15.

--- a/assets/dashboard/chunks/index.js
+++ b/assets/dashboard/chunks/index.js
@@ -1,5 +1,5 @@
 import showdown from 'showdown';
-import $ from 'jquery';
+// import $ from 'jquery';
 
 let sourceText = '';
 let previousSourceText;

--- a/assets/dashboard/core/Gallery.js
+++ b/assets/dashboard/core/Gallery.js
@@ -1,4 +1,4 @@
-import jQuery from 'jquery';
+// import jQuery from 'jquery';
 import MicroEvent from 'common/utils/MicroEvent';
 import { ajaxEnableCSRF, format, render } from 'common/utils';
 import moment from 'moment';

--- a/assets/dashboard/core/GalleryCrop.js
+++ b/assets/dashboard/core/GalleryCrop.js
@@ -1,4 +1,4 @@
-import jQuery from 'jquery';
+// import jQuery from 'jquery';
 import Cropper from 'cropperjs';
 import 'cropperjs/dist/cropper.css';
 import { format, render } from 'common/utils';

--- a/assets/dashboard/core/GalleryUpload.js
+++ b/assets/dashboard/core/GalleryUpload.js
@@ -1,4 +1,4 @@
-import jQuery from 'jquery';
+// import jQuery from 'jquery';
 import Dropzone from 'dropzone';
 import 'dropzone/dist/dropzone.css';
 import './less/dropzone.less';

--- a/assets/dashboard/core/dashboard.js
+++ b/assets/dashboard/core/dashboard.js
@@ -1,4 +1,4 @@
-import jQuery from 'jquery';
+// import jQuery from 'jquery';
 import 'common/datetimepicker';
 import 'common/tablesorter';
 import { ajaxEnableCSRF } from 'common/utils';

--- a/assets/dashboard/events/events.js
+++ b/assets/dashboard/events/events.js
@@ -1,4 +1,4 @@
-import jQuery from 'jquery';
+// import jQuery from 'jquery';
 import { plainUserTypeahead } from 'common/typeahead';
 import { ajax, showStatusMessage, toggleChecked } from 'common/utils';
 

--- a/assets/dashboard/gallery/galleryDashboard.js
+++ b/assets/dashboard/gallery/galleryDashboard.js
@@ -1,4 +1,4 @@
-import jQuery from 'jquery';
+// import jQuery from 'jquery';
 import moment from 'moment';
 import { ajax, showStatusMessage } from 'common/utils';
 

--- a/assets/dashboard/groups/group.js
+++ b/assets/dashboard/groups/group.js
@@ -1,4 +1,4 @@
-import jQuery from 'jquery';
+// import jQuery from 'jquery';
 import { plainUserTypeahead } from 'common/typeahead';
 import { ajax, showStatusMessage } from 'common/utils';
 

--- a/assets/dashboard/inventory/Inventory.js
+++ b/assets/dashboard/inventory/Inventory.js
@@ -1,4 +1,4 @@
-import jQuery from 'jquery';
+// import jQuery from 'jquery';
 import { ajax, showStatusMessage, toggleChecked } from 'common/utils';
 import './index.less';
 

--- a/assets/dashboard/inventory/InventoryStats.js
+++ b/assets/dashboard/inventory/InventoryStats.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 
 const google = window.google;
 

--- a/assets/dashboard/marks/marks.js
+++ b/assets/dashboard/marks/marks.js
@@ -1,4 +1,4 @@
-import jQuery from 'jquery';
+// import jQuery from 'jquery';
 import { plainUserTypeahead } from 'common/typeahead';
 import { ajax, showStatusMessage } from 'common/utils';
 

--- a/assets/dashboard/photoalbum/index.js
+++ b/assets/dashboard/photoalbum/index.js
@@ -1,5 +1,5 @@
 import Urls from 'common/utils/django_reverse';
-import $ from 'jquery';
+// import $ from 'jquery';
 import { plainUserTypeahead } from 'common/typeahead';
 import Cookies from 'js-cookie';
 

--- a/assets/dashboard/posters/assignToJob.js
+++ b/assets/dashboard/posters/assignToJob.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 import { setStatusMessage } from 'common/utils/';
 
 const assignToJob = (orderId, row) => {

--- a/assets/dashboard/posters/index.js
+++ b/assets/dashboard/posters/index.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 import assignToJob from './assignToJob';
 import './less/posters.less';
 

--- a/assets/dashboard/webshop/Webshop.js
+++ b/assets/dashboard/webshop/Webshop.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 
 const postDeleteForm = (url) => {
   $(`<form method="POST" action="${url}">` +

--- a/assets/dashboard/webshop/WebshopGallery.js
+++ b/assets/dashboard/webshop/WebshopGallery.js
@@ -1,4 +1,4 @@
-import jQuery from 'jquery';
+// import jQuery from 'jquery';
 
 const WebshopGallery = (function PrivateWebshopGallery($) {
   const images = [];

--- a/assets/dashboard/webshop/index.js
+++ b/assets/dashboard/webshop/index.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 import Webshop from './Webshop';
 import WebshopGallery from './WebshopGallery';
 

--- a/assets/events/archive/filters.js
+++ b/assets/events/archive/filters.js
@@ -1,5 +1,5 @@
 import Urls from 'common/utils/django_reverse';
-import $ from 'jquery';
+// import $ from 'jquery';
 
 class Filters {
   constructor() {

--- a/assets/events/details/events.js
+++ b/assets/events/details/events.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 import Cookies from 'js-cookie';
 import { makeApiRequest, showFlashMessage } from 'common/utils/';
 

--- a/assets/feedback/answerRating.js
+++ b/assets/feedback/answerRating.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 import 'jquery-bar-rating';
 
 export default () => {

--- a/assets/feedback/feedbackResults.js
+++ b/assets/feedback/feedbackResults.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 import 'common/jqplot';
 import { ajaxEnableCSRF, debouncedResize, setStatusMessage } from 'common/utils/';
 

--- a/assets/frontpage/initFrontpage.js
+++ b/assets/frontpage/initFrontpage.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// // import $ from 'jquery';
 
 const TOP_OFFSET_ADJUST = 65;
 

--- a/assets/profiles/dependent_fields.js
+++ b/assets/profiles/dependent_fields.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 
 export default () => {
   $('#social-membership-application').hide();

--- a/assets/profiles/profiles.js
+++ b/assets/profiles/profiles.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 import { ajaxEnableCSRF, setStatusMessage } from 'common/utils/';
 
 ajaxEnableCSRF($);

--- a/assets/profiles/userSearch.js
+++ b/assets/profiles/userSearch.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+// import $ from 'jquery';
 import { userTypeahead } from 'common/typeahead';
 import Spinner from 'spin.js';
 import './less/typeahead.less';

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -62,7 +62,8 @@ let result = await esbuild.build({
     plugins: [lessLoader()],
     platform: "browser",
     // we could use https://github.com/marcofugaro/browserslist-to-esbuild
-    target: ['chrome109', 'firefox72', 'safari16', 'edge109'],
+    target: ['chrome109', 'firefox109', 'safari16', 'edge109'],
+    splitting: true,
     minify: process.env.NODE_ENV === "production" || false,
     sourcemap: process.env.NODE_ENV === "production" || false,
     metafile: true

--- a/onlineweb4/urls.py
+++ b/onlineweb4/urls.py
@@ -1,3 +1,4 @@
+from chunks.models import Chunk
 from django.conf import settings
 from django.conf.urls import include, re_path
 from django.conf.urls.static import static
@@ -9,33 +10,43 @@ from django_js_reverse.views import urls_js
 # URL config
 admin.autodiscover()
 
+
+class HomePageView(TemplateView):
+    template_name = "frontpage.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["chunks"] = Chunk.objects.filter(key__startswith="om_")[:21]
+        return context
+
+
 urlpatterns = [
     # Admin urls
     re_path(r"^admin/doc/", include("django.contrib.admindocs.urls")),
     re_path(r"^admin/", admin.site.urls),
     # Onlineweb front page
-    re_path(r"^$", TemplateView.as_view(template_name="frontpage.html"), name="home"),
+    re_path(r"^$", HomePageView.as_view(), name="home"),
     # Django-js-reverse used to get django urls to react
     re_path(r"^jsreverse/$", urls_js, name="js_reverse"),
     # nav-bar menu urls
     re_path(
         r"^#events$",
-        TemplateView.as_view(template_name="frontpage.html"),
+        HomePageView.as_view(template_name="frontpage.html"),
         name="events-link",
     ),
     re_path(
         r"^#articles$",
-        TemplateView.as_view(template_name="frontpage.html"),
+        HomePageView.as_view(template_name="frontpage.html"),
         name="articles-link",
     ),
     re_path(
         r"^#about$",
-        TemplateView.as_view(template_name="frontpage.html"),
+        HomePageView.as_view(template_name="frontpage.html"),
         name="about-link",
     ),
     re_path(
         r"^#business$",
-        TemplateView.as_view(template_name="frontpage.html"),
+        HomePageView.as_view(template_name="frontpage.html"),
         name="business-link",
     ),
     # Online Notifier Owner Verification (checked yearly or so by Google)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "cropperjs": "^1.6.1",
     "dropzone": "^4.3.0",
     "eonasdan-bootstrap-datetimepicker": "^4.17.43",
+    "esbuild": "0.19.4",
+    "esbuild-plugin-less": "1.3.1",
     "font-awesome": "^4.7.0",
     "fuse.js": "^2.7.3",
     "jquery": "2",
@@ -30,9 +32,7 @@
     "showdown": "^1.9.1",
     "spin.js": "^2.3.2",
     "tablesorter": "^2.28.3",
-    "underscore": "^1.12.1",
-    "esbuild": "0.19.4",
-    "esbuild-plugin-less": "1.3.1"
+    "underscore": "^1.12.1"
   },
   "devDependencies": {
     "eslint": "^8.50.0",

--- a/templates/approval/dashboard/index.html
+++ b/templates/approval/dashboard/index.html
@@ -12,7 +12,7 @@ Søknadsgodkjenning - Online
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardApproval' 'js' %}
+    {% render_bundle 'dashboardApproval' 'js' attrs='async type="module"' %}
 {% endblock js %}
 
 {% block page-header %}

--- a/templates/article/archive.html
+++ b/templates/article/archive.html
@@ -13,7 +13,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'articleArchive' 'js' %}
+    {% render_bundle 'articleArchive' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 

--- a/templates/article/dashboard/article_create.html
+++ b/templates/article/dashboard/article_create.html
@@ -17,7 +17,7 @@ Artikler
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardArticle' 'js' %}
+    {% render_bundle 'dashboardArticle' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block styles %}

--- a/templates/article/dashboard/article_index.html
+++ b/templates/article/dashboard/article_index.html
@@ -11,7 +11,7 @@ Artikler
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardArticle' 'js' %}
+    {% render_bundle 'dashboardArticle' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block styles %}

--- a/templates/article/details.html
+++ b/templates/article/details.html
@@ -11,7 +11,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'articleDetails' 'js' %}
+    {% render_bundle 'articleDetails' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/auth/dashboard/groups_create.html
+++ b/templates/auth/dashboard/groups_create.html
@@ -11,7 +11,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardGroups' 'js' %}
+    {% render_bundle 'dashboardGroups' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/auth/dashboard/groups_detail.html
+++ b/templates/auth/dashboard/groups_detail.html
@@ -11,7 +11,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardGroups' 'js' %}
+    {% render_bundle 'dashboardGroups' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/auth/dashboard/user_detail.html
+++ b/templates/auth/dashboard/user_detail.html
@@ -20,7 +20,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardAuthentication' 'js' %}
+    {% render_bundle 'dashboardAuthentication' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -13,7 +13,7 @@ Logg inn - Online
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'authentication' 'js' %}
+    {% render_bundle 'authentication' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,7 +18,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {% block styles %}
     {% endblock %}
-    {% render_bundle 'core' 'css' %}
+    {% render_bundle 'core' 'css' attrs='async' %}
     {% block scripts %}
     {% endblock %}
     {% render_block "css" %}
@@ -237,7 +237,7 @@
             window.jQuery || document.write('<script src="{{ STATIC_URL }}js/libs/jquery-2.2.4.min.js"><\/script>');
         </script>
         <script src="{% url 'js_reverse' %}" type="text/javascript"></script>
-        {% render_bundle 'core' 'js' %}
+        {% render_bundle 'core' 'js' attrs='async type="module"' %}
     {% endblock %}
     {% render_block "js" %}
 

--- a/templates/careeropportunity/dashboard/index.html
+++ b/templates/careeropportunity/dashboard/index.html
@@ -12,7 +12,7 @@ Karrieremuligheter - Online
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardCareeropportunity' 'js' %}
+    {% render_bundle 'dashboardCareeropportunity' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/careeropportunity/index.html
+++ b/templates/careeropportunity/index.html
@@ -5,9 +5,14 @@
 Karrieremuligheter - Online
 {% endblock title %}
 
+{% block styles %}
+	{{ block.super }}
+  {% render_bundle 'careeropportunity' 'css' %}
+{% endblock %}
+
 {% block js %}
   {{ block.super }}
-  {% render_bundle 'careeropportunity' %}
+  {% render_bundle 'careeropportunity' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/contact/index.html
+++ b/templates/contact/index.html
@@ -14,7 +14,7 @@ Kontakt oss - Online
 
 {% block js %}
 	{{ block.super }}
-	{% render_bundle 'contact' 'js' %}
+	{% render_bundle 'contact' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/dashboard_base.html
+++ b/templates/dashboard_base.html
@@ -363,7 +363,7 @@
             window.jQuery || document.write('<script src="{{ STATIC_URL }}js/libs/jquery-2.2.4.min.js"><\/script>');
         </script>
 
-        {% render_bundle 'dashboard' 'js' %}
+        {% render_bundle 'dashboard' 'js' attrs='async type="module"' %}
     {% endblock %}
 
     {% if GOOGLE_ANALYTICS_KEY %}

--- a/templates/events/dashboard/details.html
+++ b/templates/events/dashboard/details.html
@@ -152,7 +152,7 @@ Arrangementsdetaljer
 {% block js %}
     <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
     {{ block.super }}
-    {% render_bundle 'dashboardEvents' 'js' %}
+    {% render_bundle 'dashboardEvents' 'js' attrs='async type="module"' %}
     <script>
         // Update details view form with action attribute
         $('#create-event-form').attr('action', "{% url 'dashboard_events_edit' event.id %}")

--- a/templates/events/dashboard/index.html
+++ b/templates/events/dashboard/index.html
@@ -16,7 +16,7 @@ Arrangementsoversikt
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardEvents' 'js' %}
+    {% render_bundle 'dashboardEvents' 'js' attrs='async type="module"' %}
 {% endblock js %}
 
 {% block breadcrumbs %}

--- a/templates/events/details.html
+++ b/templates/events/details.html
@@ -20,7 +20,7 @@
         var selected_extra = "{{ attendee.extras }}";
         var all_extras = [{% for e in attendance_event.extras.all %}"{{e}}", {%endfor%}];
     </script>
-    {% render_bundle 'eventsDetails' 'js' %}
+    {% render_bundle 'eventsDetails' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/events/index.html
+++ b/templates/events/index.html
@@ -99,5 +99,5 @@ Arrangementsarkiv - Online
 
 {% block js %}
   {{ block.super }}
-  {% render_bundle 'eventsArchive' 'js' %}
+  {% render_bundle 'eventsArchive' 'js' attrs='async type="module"' %}
 {% endblock %}

--- a/templates/feedback/answer.html
+++ b/templates/feedback/answer.html
@@ -13,7 +13,7 @@ Tilbakemeldinger - Svar - Online
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'feedback' 'js' %}
+    {% render_bundle 'feedback' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/feedback/results.html
+++ b/templates/feedback/results.html
@@ -13,7 +13,7 @@ Tilbakemeldinger - Resultater - Online
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'feedback' 'js' %}
+    {% render_bundle 'feedback' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 

--- a/templates/frontpage.html
+++ b/templates/frontpage.html
@@ -11,7 +11,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'frontpage' 'js' %}
+    {% render_bundle 'frontpage' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block apple-webapp %}

--- a/templates/frontpage.html
+++ b/templates/frontpage.html
@@ -5,7 +5,7 @@
 
 
 {% block styles %}
-    {{ block.super }}
+    {{ block.super }}
     {% render_bundle 'frontpage' 'css' %}
 {% endblock %}
 
@@ -186,86 +186,13 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="tab-pane" id="about-hovedstyret">
+                        {% for chunk in chunks %}
+                        <div class="tab-pane" id="about-{{ chunk.key | slice:'3:' }}"">
 {% filter markdown %}
-{% chunk 'om_hovedstyret' %}
+{{ chunk.content }}
 {% endfilter %}
                         </div>
-                        <div class="tab-pane" id="about-hovedsamarbeidspartner">
-{% filter markdown %}
-{% chunk 'om_hovedsamarbeidspartner' %}
-{% endfilter %}
-                        </div>
-                        <div class="tab-pane" id="about-arrkom">
-{% filter markdown %}
-{% chunk 'om_arrkom' %}
-{% endfilter %}
-                        </div>
-                        <div class="tab-pane" id="about-bankom">
-{% filter markdown %}
-{% chunk 'om_bankom' %}
-{% endfilter %}
-                        </div>
-                        <div class="tab-pane" id="about-bedkom">
-{% filter markdown %}
-{% chunk 'om_bedkom' %}
-{% endfilter %}
-                        </div>
-                        <div class="tab-pane" id="about-dotkom">
-{% filter markdown %}
-{% chunk 'om_dotkom' %}
-{% endfilter %}
-                        </div>
-                        <div class="tab-pane" id="about-fagkom">
-{% filter markdown %}
-{% chunk 'om_fagkom' %}
-{% endfilter %}
-                        </div>
-                        <div class="tab-pane" id="about-prokom">
-{% filter markdown %}
-{% chunk 'om_prokom' %}
-{% endfilter %}
-                        </div>
-                        <div class="tab-pane" id="about-senkom">
-{% filter markdown %}
-{% chunk 'om_senkom' %}
-{% endfilter %}
-                        </div>
-                        <div class="tab-pane" id="about-trikom">
-{% filter markdown %}
-{% chunk 'om_trikom' %}
-{% endfilter %}
-                        </div>
-                        <div class="tab-pane" id="about-noder">
-{% filter markdown %}
-{% chunk 'om_noder' %}
-{% endfilter %}
-                        </div>
-                        <div class="tab-pane" id="about-interessegrupper">
-{% filter markdown %}
-{% chunk 'om_interessegrupper' %}
-{% endfilter %}
-                        </div>
-                        <div class="tab-pane" id="about-kjelleren">
-{% filter markdown %}
-{% chunk 'om_kjelleren' %}
-{% endfilter %}
-                        </div>
-                        <div class="tab-pane" id="about-datakameratene">
-{% filter markdown %}
-{% chunk 'om_datakameratene' %}
-{% endfilter %}
-                        </div>
-                        <div class="tab-pane" id="about-cag">
-{% filter markdown %}
-{% chunk 'om_casual_gaming' %}
-{% endfilter %}
-                        </div>
-                        <div class="tab-pane" id="about-output">
-{% filter markdown %}
-{% chunk 'om_output' %}
-{% endfilter %}
-                        </div>
+                        {% endfor %}
                     </div>
                 </div>
                 <div class="col-sm-4 col-md-3">
@@ -288,7 +215,7 @@
                         <li><a href="#about-interessegrupper">Interessegrupper</a></li>
                         <li><a href="#about-kjelleren">Realfagskjelleren</a></li>
                         <li><a href="#about-datakameratene">Datakameratene FK</a></li>
-                        <li><a href="#about-cag">Casual Gaming</a></li>
+                        <li><a href="#about-casual_gaming">Casual Gaming</a></li>
                         <li><a href="#about-output">Output</a></li>
                     </ul>
                 </div>

--- a/templates/gallery/dashboard/detail.html
+++ b/templates/gallery/dashboard/detail.html
@@ -17,7 +17,7 @@ Bilder
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardGallery' 'js' %}
+    {% render_bundle 'dashboardGallery' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/templates/gallery/dashboard/index.html
+++ b/templates/gallery/dashboard/index.html
@@ -16,7 +16,7 @@ Bilder
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardGallery' 'js' %}
+    {% render_bundle 'dashboardGallery' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/templates/hobbygroups/dashboard/index.html
+++ b/templates/hobbygroups/dashboard/index.html
@@ -12,7 +12,7 @@ Interessegrupper - Online
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardHobbies' 'js' %}
+    {% render_bundle 'dashboardHobbies' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/hobbygroups/index.html
+++ b/templates/hobbygroups/index.html
@@ -12,7 +12,7 @@ Interessegrupper - Online
 
 {% block js %}
 	{{ block.super }}
-	{% render_bundle 'hobbygroups' 'js' %}
+	{% render_bundle 'hobbygroups' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/inventory/dashboard/details.html
+++ b/templates/inventory/dashboard/details.html
@@ -14,7 +14,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardInventory' 'js' %}
+    {% render_bundle 'dashboardInventory' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/inventory/dashboard/discontinued.html
+++ b/templates/inventory/dashboard/discontinued.html
@@ -12,7 +12,7 @@ Utgått varelager - Online Dashboard
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardInventory' 'js' %}
+    {% render_bundle 'dashboardInventory' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/inventory/dashboard/index.html
+++ b/templates/inventory/dashboard/index.html
@@ -12,7 +12,7 @@ Varelager - Online Dashboard
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardInventory' 'js' %}
+    {% render_bundle 'dashboardInventory' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/inventory/dashboard/new.html
+++ b/templates/inventory/dashboard/new.html
@@ -14,7 +14,7 @@ Ny vare - Online Dashboard
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardInventory' 'js' %}
+    {% render_bundle 'dashboardInventory' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/inventory/dashboard/statistics.html
+++ b/templates/inventory/dashboard/statistics.html
@@ -17,7 +17,7 @@ Varelager statistikk
 {% block js %}
     {{ block.super }}
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-    {% render_bundle 'dashboardInventory' 'js' %}
+    {% render_bundle 'dashboardInventory' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/mailinglists/index.html
+++ b/templates/mailinglists/index.html
@@ -12,7 +12,7 @@ Epostlister - Online
 
 {% block js %}
 	{{ block.super }}
-	{% render_bundle 'mailinglists' 'js' %}
+	{% render_bundle 'mailinglists' 'js' attrs='async type="module"' %}
 {% endblock js %}
 
 

--- a/templates/marks/dashboard/index.html
+++ b/templates/marks/dashboard/index.html
@@ -9,7 +9,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardMarks' 'js' %}
+    {% render_bundle 'dashboardMarks' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/marks/dashboard/marks_details.html
+++ b/templates/marks/dashboard/marks_details.html
@@ -9,7 +9,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardMarks' 'js' %}
+    {% render_bundle 'dashboardMarks' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 

--- a/templates/marks/dashboard/marks_edit.html
+++ b/templates/marks/dashboard/marks_edit.html
@@ -12,7 +12,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardMarks' 'js' %}
+    {% render_bundle 'dashboardMarks' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/marks/dashboard/marks_new.html
+++ b/templates/marks/dashboard/marks_new.html
@@ -12,7 +12,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardMarks' 'js' %}
+    {% render_bundle 'dashboardMarks' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 

--- a/templates/photoalbum/dashboard/album.html
+++ b/templates/photoalbum/dashboard/album.html
@@ -12,7 +12,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardPhotoAlbum' 'js' %}
+    {% render_bundle 'dashboardPhotoAlbum' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/photoalbum/dashboard/album_update.html
+++ b/templates/photoalbum/dashboard/album_update.html
@@ -19,7 +19,7 @@ Nytt album - Online Dashboard
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardPhotoAlbum' 'js' %}
+    {% render_bundle 'dashboardPhotoAlbum' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/photoalbum/dashboard/albums.html
+++ b/templates/photoalbum/dashboard/albums.html
@@ -12,7 +12,7 @@ Fotoalbum - Online Dashboard
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardPhotoAlbum' 'js' %}
+    {% render_bundle 'dashboardPhotoAlbum' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/photoalbum/dashboard/index.html
+++ b/templates/photoalbum/dashboard/index.html
@@ -11,7 +11,7 @@ Fotoalbumer
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'photoalbum' 'js' %}
+    {% render_bundle 'photoalbum' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block styles %}

--- a/templates/photoalbum/dashboard/photo.html
+++ b/templates/photoalbum/dashboard/photo.html
@@ -14,7 +14,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardPhotoAlbum' 'js' %}
+    {% render_bundle 'dashboardPhotoAlbum' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/photoalbum/dashboard/photo_update.html
+++ b/templates/photoalbum/dashboard/photo_update.html
@@ -19,7 +19,7 @@ Nytt bilde - Online Dashboard
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardPhotoAlbum' 'js' %}
+    {% render_bundle 'dashboardPhotoAlbum' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/posters/dashboard/add.html
+++ b/templates/posters/dashboard/add.html
@@ -14,7 +14,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardPosters' 'js' %}
+    {% render_bundle 'dashboardPosters' 'js' attrs='async type="module"' %}
 {% endblock js %}
 
 

--- a/templates/posters/dashboard/details.html
+++ b/templates/posters/dashboard/details.html
@@ -14,7 +14,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardPosters' 'js' %}
+    {% render_bundle 'dashboardPosters' 'js' attrs='async type="module"' %}
 {% endblock js %}
 
 {% block page-header %}

--- a/templates/posters/dashboard/index.html
+++ b/templates/posters/dashboard/index.html
@@ -12,7 +12,7 @@ Plakatbestillinger - Online
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardPosters' 'js' %}
+    {% render_bundle 'dashboardPosters' 'js' attrs='async type="module"' %}
 {% endblock js %}
 
 {% block page-header %}

--- a/templates/profiles/index.html
+++ b/templates/profiles/index.html
@@ -117,5 +117,5 @@ Min side - Online
 {% endblock content %}
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'profiles' 'js' %}
+    {% render_bundle 'profiles' 'js' attrs='async type="module"' %}
 {% endblock %}

--- a/templates/profiles/users.html
+++ b/templates/profiles/users.html
@@ -91,5 +91,5 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'profiles' 'js' %}
+    {% render_bundle 'profiles' 'js' attrs='async type="module"' %}
 {% endblock %}

--- a/templates/profiles/view_profile.html
+++ b/templates/profiles/view_profile.html
@@ -10,7 +10,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'profiles' 'js' %}
+    {% render_bundle 'profiles' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block title %}

--- a/templates/resourcecenter/dashboard/index.html
+++ b/templates/resourcecenter/dashboard/index.html
@@ -12,7 +12,7 @@ Ressurser - Online
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardResources' 'js' %}
+    {% render_bundle 'dashboardResources' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/resourcecenter/index.html
+++ b/templates/resourcecenter/index.html
@@ -13,7 +13,7 @@ Ressurssenter - Online
 
 {% block js %}
 	{{ block.super }}
-	{% render_bundle 'resourcecenter' 'js' %}
+	{% render_bundle 'resourcecenter' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/sso/authorize.html
+++ b/templates/sso/authorize.html
@@ -12,7 +12,7 @@
 
 {% block js %}
   {{ block.super }}
-  {% render_bundle 'sso' 'js' %}
+  {% render_bundle 'sso' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/sso/sso_base.html
+++ b/templates/sso/sso_base.html
@@ -38,7 +38,7 @@
         </script>
         <script>Sentry.init({ dsn: '{{ sentry_dsn }}' })</script>
         <script src="{% url 'js_reverse' %}" type="text/javascript"></script>
-        {% render_bundle 'core' 'js' %}
+        {% render_bundle 'core' 'js' attrs='async type="module"' %}
     {% endblock %}
     {% render_block "js" %}
 

--- a/templates/webshop/dashboard/categories.html
+++ b/templates/webshop/dashboard/categories.html
@@ -12,7 +12,7 @@ Webshop kategorier - Online Dashboard
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardWebshop' 'js' %}
+    {% render_bundle 'dashboardWebshop' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/webshop/dashboard/category.html
+++ b/templates/webshop/dashboard/category.html
@@ -12,7 +12,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardWebshop' 'js' %}
+    {% render_bundle 'dashboardWebshop' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/webshop/dashboard/category_update.html
+++ b/templates/webshop/dashboard/category_update.html
@@ -19,7 +19,7 @@ Ny kategori - Online Dashboard
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardWebshop' 'js' %}
+    {% render_bundle 'dashboardWebshop' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/webshop/dashboard/image.html
+++ b/templates/webshop/dashboard/image.html
@@ -13,7 +13,7 @@ Webshop - Online Dashboard
 {% block js %}
     {{ block.super }}
     <script src="{{ STATIC_URL }}js/dashboard/gallery.js"></script>
-    {% render_bundle 'dashboardWebshop' 'js' %}
+    {% render_bundle 'dashboardWebshop' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/webshop/dashboard/index.html
+++ b/templates/webshop/dashboard/index.html
@@ -12,7 +12,7 @@ Webshop - Online Dashboard
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardWebshop' 'js' %}
+    {% render_bundle 'dashboardWebshop' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/webshop/dashboard/order.html
+++ b/templates/webshop/dashboard/order.html
@@ -14,7 +14,7 @@ Bestilling #{{ order.id }} - Online Dashboard
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardWebshop' 'js' %}
+    {% render_bundle 'dashboardWebshop' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/webshop/dashboard/product.html
+++ b/templates/webshop/dashboard/product.html
@@ -14,7 +14,7 @@
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardWebshop' 'js' %}
+    {% render_bundle 'dashboardWebshop' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/webshop/dashboard/product_update.html
+++ b/templates/webshop/dashboard/product_update.html
@@ -19,7 +19,7 @@ Nytt produkt - Online Dashboard
 
 {% block js %}
     {{ block.super }}
-    {% render_bundle 'dashboardWebshop' 'js' %}
+    {% render_bundle 'dashboardWebshop' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block page-header %}

--- a/templates/wiki/base.html
+++ b/templates/wiki/base.html
@@ -14,7 +14,7 @@
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-    {% render_bundle 'wiki' 'js' %}
+    {% render_bundle 'wiki' 'js' attrs='async type="module"' %}
 {% endblock %}
 
 {% block styles %}


### PR DESCRIPTION
- Re-add code-splitting
- We can't have nice things and bs3
- Fix "N+1" query on frontpage
- Re-order dependencies as `npm i` does
- Only specify Python version in the version-file
