### PR TITLE
show previous events based on time

### DIFF
--- a/apps/events/dashboard/views.py
+++ b/apps/events/dashboard/views.py
@@ -66,7 +66,7 @@ def past(request):
     allowed_events = get_objects_for_user(
         request.user, "events.change_event", accept_global_perms=False
     )
-    events = allowed_events.filter(event_start__lt=timezone.now().date()).order_by(
+    events = allowed_events.filter(event_start__lt=timezone.now()).order_by(
         "-event_start"
     )
 


### PR DESCRIPTION
### Pull Request: Include Events from Earlier Today in Past Events View

#### Summary
This pull request addresses an issue in the event filtering logic within the `past` view function of our events module. Previously, the function only included events that occurred before the current date (day, month, year), excluding events that happened earlier on the same day. 

#### Changes
- Modified the `event_start` filter in the `past` view function.
  - Changed from `event_start__lt=timezone.now().date()` to `event_start__lt=timezone.now()`.
  - This alteration ensures the inclusion of events that occurred earlier on the same day at the time of the request.

#### Rationale
The original filtering logic in the `past` view function did not account for events that occurred earlier on the same day. This was a limitation, as users might need to access recent events from the same day. By including the time in our comparison, we can now present a complete list of past events up to the current moment, enhancing user experience and data accuracy.

#### Impact
- This change will allow users to see events that happened earlier at the same day, which was not possible before
- There are no expected negative impacts on performance or existing functionalities.

Please review the changes and provide any feedback or approval as necessary. Thank you!


copilot:poem (vi er på waitlist, dette vil funke når vi er inne ([les](https://githubnext.com/projects/copilot-for-pull-requests) 😮  )