### PR TITLE
Fix sso consents integrity error

### DIFF
--- a/apps/sso/signals.py
+++ b/apps/sso/signals.py
@@ -10,9 +10,16 @@ def handle_app_authorized(sender, request, token, **kwargs):
         return
     if not token.user:
         return
-    ApplicationConsent.objects.create(
-        user=token.user, client=token.application, approved_scopes=token.scopes
+
+    consent, created = ApplicationConsent.objects.get_or_create(
+        user=token.user,
+        client=token.application,
+        defaults={"approved_scopes": token.scopes},
     )
+
+    if not created:
+        consent.approved_scopes = token.scopes
+        consent.save()
 
 
 app_authorized.connect(handle_app_authorized)

--- a/apps/sso/signals.py
+++ b/apps/sso/signals.py
@@ -4,10 +4,6 @@ from apps.sso.models import ApplicationConsent
 
 
 def handle_app_authorized(sender, request, token, **kwargs):
-    if ApplicationConsent.objects.filter(
-        pk=token.application.pk, user=token.user
-    ).exists():
-        return
     if not token.user:
         return
 


### PR DESCRIPTION
Whenever someone attempted to use the sso authorization endpoint with an authorization code, it would return a 500 error after the first time since it couldn't update the existing sso consents for that client and user.