### PR TITLE
Show documentation for processed membership applications

### DIFF
--- a/templates/approval/dashboard/index.html
+++ b/templates/approval/dashboard/index.html
@@ -110,6 +110,7 @@ Søknadsgodkjenning
                         <th>Behandlet</th>
                         <th>Resultat</th>
                         <th>Behandlet av</th>
+                        <th>Ekstra dokumentasjon</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -119,6 +120,13 @@ Søknadsgodkjenning
                         <td>{{ p.processed_date|date:'Y-m-d H:i:s' }}</td>
                         <td>{% if p.approved %}Godkjent{% else %}Avslått{% endif %}</td>
                         <td>{{ p.approver }}</td>
+                        <td>
+                            {% if p.has_documentation %}
+                                <div class="visible-xs visible-sm">1. </div><a href="{{ MEDIA_URL }}{{p.documentation}}" target="_blank">Dokumentasjon</a>
+                            {% else %}
+                                -
+                            {% endif %}
+                        </td>
                     </tr>
                 {% endfor %}
                 </tbody>


### PR DESCRIPTION
Adds a documentation column to processed applications for the membership applications page on the dashboard.

## Preview
![image](https://github.com/dotkom/onlineweb4/assets/40792825/b21419a2-c063-41ad-a3f3-f4769a538c7b)
