### PR TITLE
Fix pending feedbacks not being shown

### DIFF
--- a/apps/feedback/models.py
+++ b/apps/feedback/models.py
@@ -156,9 +156,9 @@ class FeedbackRelation(models.Model):
                 ~Q(pk__in=self.answered.all())
             )
         else:
-            from apps.events.models import Attendee
+            from apps.authentication.models import OnlineUser
 
-            return Attendee.objects.none()
+            return OnlineUser.objects.none()
 
     def content_email(self):
         if hasattr(self.content_object, "feedback_mail"):

--- a/onlineweb4/context_processors.py
+++ b/onlineweb4/context_processors.py
@@ -44,7 +44,7 @@ def feedback_notifier(request):
         # This method returns both bools and a list for some reason. Python crashes with the expression: x in bool,
         # so we do this to fetch once and test twice
         not_answered = active_feedback.not_answered()
-        if request.user.pk not in not_answered:
+        if request.user not in not_answered:
             continue
 
         context_extras["feedback_pending"].append(active_feedback)


### PR DESCRIPTION
`not_answered` should be a queryset of Users, not attendees

## Description of changes
<!-- It is often obvious what changed by looking at the code, so it is more helpful to say _why_ it should be changed -->
<!-- If the Pull Request is not ready to be merged, please use a draft pull request -->

## Code Checklist

- [ ] I have added tests
- [ ] I have provided documentation

<!-- IF THERE ARE ANY BREAKING CHANGES
E.G. IF THERE IS A CHANGE IN AN API OR A NEW API-TOKEN NEEDS TO BE ADDED,
BE SURE TO DOCUMENT THEM, AND INFORM US ABOUT
CHANGES NEEDED TO BE MADE IN OTHER PROJECTS,
OR IN PRODUCTION. 
 -->

<!-- REMOVE FROM HERE AND BELOW IF NO VISUAL CHANGES -->
## Visual changes
<!-- IF DOING ANY DESIGN CHANGE PLEASE ADD BEFORE PICTURES HERE -->

<details>
<summary>Before</summary>
<!-- PASTE BEFORE IMAGE HERE -->

</details>

<details>
<summary>After</summary>
<!-- PASTE AFTER IMAGE HERE -->

</details>
