### PR TITLE
show allergies on users at waitlist in dashboard events

### DIFF
--- a/templates/events/dashboard/details/waitlist.html
+++ b/templates/events/dashboard/details/waitlist.html
@@ -19,6 +19,7 @@
                                 {% if event.attendance_event.has_extras %}
                                 <th>Extra</th>
                                 {% endif %}
+                                <th>Allergier</th>
                                 <th>Fjern</th>
                             </tr>
                         </thead>
@@ -45,6 +46,9 @@
                                     {% if attendee.extras %}{{ attendee.extras }}{% else %}-{% endif %}
                                 </td>
                                 {% endif %}
+                                <td>
+                                    {% if attendee.user.allergies %}{{ attendee.user.allergies }}{% else %}-{% endif %}
+                                </td>
                                 <td>
                                     <a href="#modal-delete-waitlist-attendee" data-toggle="modal" data-id="{{ attendee.id }}" data-name="{{ attendee.user.get_full_name }}" class="remove-user">
                                         <i class="fa fa-times fa-lg red"></i>


### PR DESCRIPTION
## Description of changes
- Add "allergies" section to users on waitlist in dashboard events
   - **REASON:** Bedkom wants to know allergies of users on waitlist so that they are prepared if the user becomes an attendee

## Code Checklist
- [x] Add allergies to users on waitlist in dashboard events

