### PR TITLE
Revert form asking for userinfo and set name from FEIDE

### DIFF
--- a/apps/approval/urls.py
+++ b/apps/approval/urls.py
@@ -14,11 +14,6 @@ urlpatterns = [
         name="approval_send_membership_application",
     ),
     re_path(
-        r"^update_user_name/$",
-        views.update_user_name,
-        name="update_user_name",
-    ),
-    re_path(
         r"^cancel_application/(?P<application_id>\d+)/$",
         views.cancel_application,
         name="approval_cancel_application",

--- a/apps/approval/views.py
+++ b/apps/approval/views.py
@@ -15,11 +15,11 @@ from apps.authentication.models import get_length_of_membership
 @login_required
 def create_fos_application(request):
     if request.method == "POST":
-        # if not request.user.ntnu_username:
-        # messages.error(
-        #     request, _("Du må knytte et NTNU-brukernavn til kontoen din.")
-        # )
-        # return redirect("profiles_active", active_tab="membership")
+        if not request.user.ntnu_username:
+            messages.error(
+                request, _("Du må knytte et NTNU-brukernavn til kontoen din.")
+            )
+            return redirect("profiles_active", active_tab="membership")
 
         form = FieldOfStudyApplicationForm(request.POST, request.FILES)
         if form.is_valid():
@@ -79,9 +79,6 @@ def create_fos_application(request):
 
             messages.success(request, _("Søknad om bytte av studieretning er sendt."))
 
-        else:
-            messages.error(request, str(form.errors))
-
         return redirect("profiles_active", active_tab="membership")
     raise Http404
 
@@ -111,11 +108,11 @@ def create_membership_application(request):
             messages.error(request, _("Din bruker har ikke et utløpende medlemskap."))
             return redirect("profiles_active", active_tab="membership")
 
-        # if not request.user.ntnu_username:
-        #     messages.error(
-        #         request, _("Du må knytte et NTNU-brukernavn til kontoen din.")
-        #     )
-        #     return redirect("profiles_active", active_tab="membership")
+        if not request.user.ntnu_username:
+            messages.error(
+                request, _("Du må knytte et NTNU-brukernavn til kontoen din.")
+            )
+            return redirect("profiles_active", active_tab="membership")
 
         # Grant membership until 16th of September this year if the request was sent previous to 1st of July,
         # or until 16th of September next year if the request was sent after 1st of July
@@ -135,26 +132,6 @@ def create_membership_application(request):
 
         messages.success(request, _("Søknad om ett års forlenget medlemskap er sendt."))
 
-        return redirect("profiles_active", active_tab="membership")
-    raise Http404
-
-
-@login_required
-def update_user_name(request):
-    if request.method == "POST":
-        first_name = request.POST.get("first_name")
-        last_name = request.POST.get("last_name")
-
-        if not first_name or not last_name:
-            messages.error(request, _("Både fornavn og etternavn må fylles ut."))
-            return redirect("profiles_active", active_tab="membership")
-
-        # Update the user's first and last name
-        request.user.first_name = first_name
-        request.user.last_name = last_name
-        request.user.save()
-
-        messages.success(request, _("Ditt navn har blitt oppdatert."))
         return redirect("profiles_active", active_tab="membership")
     raise Http404
 

--- a/apps/authentication/models.py
+++ b/apps/authentication/models.py
@@ -149,6 +149,7 @@ class OnlineUser(AbstractUser):
     )
     bio = models.TextField(_("bio"), max_length=2048, blank=True)
     # NTNU credentials
+    # Only set if the user signs in with FEIDE, or by admins
     ntnu_username = models.CharField(
         _("NTNU-brukernavn"), max_length=50, blank=True, null=True, unique=True
     )

--- a/apps/dataporten/study/tasks.py
+++ b/apps/dataporten/study/tasks.py
@@ -112,8 +112,3 @@ def find_user_study_and_update(user, groups):
             membership.save()
 
         return True, study_name, study_year
-
-
-def set_ntnu_username(user, username):
-    user.ntnu_username = username
-    user.save()

--- a/apps/dataporten/study/tests/task_tests.py
+++ b/apps/dataporten/study/tests/task_tests.py
@@ -10,7 +10,6 @@ from apps.authentication.models import OnlineUser
 from apps.dataporten.study.tasks import (
     fetch_groups_information,
     find_user_study_and_update,
-    set_ntnu_username,
 )
 
 from .course_test_data import (
@@ -74,10 +73,3 @@ class StudyUpdatingTestCase(TestCase):
         self.assertTrue(application.processed)
 
         self.assertEqual(len(mail.outbox), 0)
-
-
-class UserUpdatingTestCase(TestCase):
-    def test_set_ntnu_username(self):
-        user = G(OnlineUser)
-        set_ntnu_username(user, "testname")
-        self.assertEqual(user.ntnu_username, "testname")

--- a/onlineweb4/settings/dataporten.py
+++ b/onlineweb4/settings/dataporten.py
@@ -7,6 +7,14 @@ DATAPORTEN = {
         "CLIENT_SECRET": config("OW4_DP_STUDY_CLIENT_SECRET", default=""),
         "REDIRECT_URI": config("OW4_DP_STUDY_REDIRECT_URI", default=""),
         "PROVIDER_URL": "https://auth.dataporten.no/oauth/token",
-        "SCOPES": ["openid", "userid-feide", "profile", "groups", "email"],
+        # userid-name gives access to extended userinfo https://docs.feide.no/reference/apis/extended_userinfo.html#example
+        "SCOPES": [
+            "openid",
+            "userid-feide",
+            "userid-name",
+            "profile",
+            "groups",
+            "email",
+        ],
     }
 }

--- a/onlineweb4/settings/zappa.py
+++ b/onlineweb4/settings/zappa.py
@@ -36,7 +36,14 @@ DATAPORTEN = {
         "CLIENT_SECRET": env["DP_STUDY_CLIENT_SECRET"],
         "REDIRECT_URI": config("OW4_DP_STUDY_REDIRECT_URI", default=""),
         "PROVIDER_URL": "https://auth.dataporten.no/oauth/token",
-        "SCOPES": ["openid", "userid-feide", "profile", "groups", "email"],
+        "SCOPES": [
+            "openid",
+            "userid-feide",
+            "userid-name",
+            "profile",
+            "groups",
+            "email",
+        ],
     }
 }
 

--- a/templates/profiles/membership.html
+++ b/templates/profiles/membership.html
@@ -1,36 +1,10 @@
 {% load crispy_forms_tags %}
 
-
 <div class="row">
     <div class="col-xs-12 col-sm-6 col-md-4">
         <h3>Medlemskap</h3>
     </div>
 </div>
-
-{% if not user.first_name or not user.last_name %}
-<div class="row">
-    <div class="col-xs-12 col-sm-6 col-md-5">
-        <form id="user-name-form" method="post" action="{% url 'update_user_name' %}">
-            {% csrf_token %}
-            <h3>Vi trenger ditt fornavn og etternavn!</h3>
-            <div class="form-group">
-                <label for="first_name">Fornavn</label>
-                <input type="text" class="form-control" id="first_name" name="first_name" required>
-            </div>
-            <div class="form-group">
-                <label for="last_name">Etternavn</label>
-                <input type="text" class="form-control" id="last_name" name="last_name" required>
-            </div>
-            <button type="submit" class="btn btn-primary">Send inn</button>
-        </form>
-    </div>
-</div>
-<hr />
-{% else %}
-
-
-
-
 <div class="row">
     <div class="col-xs-12 membership-text">
             Her kan du administrere dine søknader for medlemskap i Online, Linjeforeningen for Informatikk! <br>
@@ -66,22 +40,23 @@
         </div>
     </div>
     <div class="manual-membership-form">
-        {% if user.has_expiring_membership %}
-            <hr />
-            <div class="row">
-                <div class="col-xs-12 col-sm-6 col-md-6">
-                    <p class="ingress">
-                        Ettersom du har et gammelt medlemskap kan du søke om å få dette forlenget. Forlengelsen er for ett år om gangen.
-                    </p>
+        {% if user.ntnu_username %}
+            {% if user.has_expiring_membership %}
+                <hr />
+                <div class="row">
+                    <div class="col-xs-12 col-sm-6 col-md-6">
+                        <p class="ingress">
+                            Ettersom du har et gammelt medlemskap kan du søke om å få dette forlenget. Forlengelsen er for ett år om gangen.
+                        </p>
+                    </div>
+                    <div class="col-xs-12 col-sm-6 col-md-3">
+                        <form id="membership-application" method="post" action="{% url 'approval_send_membership_application' %}">
+                            {% csrf_token %}
+                            <button type="submit" class="btn btn-success pull-right">Send søknad om forlengelse</button>
+                        </form>
+                    </div>
                 </div>
-                <div class="col-xs-12 col-sm-6 col-md-3">
-                    <form id="membership-application" method="post" action="{% url 'approval_send_membership_application' %}">
-                        {% csrf_token %}
-                        <button type="submit" class="btn btn-success pull-right">Send søknad om forlengelse</button>
-                    </form>
-                </div>
-            </div>
-        {% else %}
+            {% endif %}
             <hr />
             <div class="row">
                 <div class="col-md-12">
@@ -118,6 +93,13 @@
                         </div>
                         <button type="submit" class="btn btn-success pull-right">Send søknad</button>
                     </form>
+                </div>
+            </div>
+        {% else %}
+            <div class="row">
+                <div class="col-xs-12 col-sm-6 col-md-4">
+                    <p>For å aktivere ditt medlemskap kreves det at du har knyttet din studentkonto til din profil.</p>
+                    <p>Gå til Epost-innstillinger og registrer din @stud.ntnu.no epost.</p>
                 </div>
             </div>
         {% endif %}
@@ -207,4 +189,3 @@
         </div>
     </div>
 </div>
-{% endif %}

--- a/templates/profiles/membership.html
+++ b/templates/profiles/membership.html
@@ -40,7 +40,7 @@
         </div>
     </div>
     <div class="manual-membership-form">
-        {% if user.ntnu_username %}
+        {% if user.ntnu_username %} <!-- they have or have had a membership at somepoint, ntnu_username is *only* set after an interaction with FEIDE -->
             {% if user.has_expiring_membership %}
                 <hr />
                 <div class="row">
@@ -99,7 +99,7 @@
             <div class="row">
                 <div class="col-xs-12 col-sm-6 col-md-4">
                     <p>For å aktivere ditt medlemskap kreves det at du har knyttet din studentkonto til din profil.</p>
-                    <p>Gå til Epost-innstillinger og registrer din @stud.ntnu.no epost.</p>
+                    <p>Dette kan gjøres ved å søke om automatisk medlemskap, uavhengig av om du får innvilget det automatisk.</p>
                 </div>
             </div>
         {% endif %}


### PR DESCRIPTION
Review commit by commit

This fixes the issue of being unable to apply for master if you previously have a bacheor-membership, which was a bug introduced in #3205 

End resultat: user needs to authenticate against FEIDE, before a manual approval, and we then get the information we need.

Not supported: new master members (from non-NTNU) signing up for ITEX before they get a NTNU-account. I don't think we should support that.