### PR TITLE
Expose `ENVIRONMENT` env var to Docker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: VERSION=${{ steps.meta.outputs.version }}
+          build-args: |
+            ENVIRONMENT=${{ inputs.environment }}
+            VERSION=${{ steps.meta.outputs.version }}
 
       - name: Create Sentry release
         uses: getsentry/action-release@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 
 FROM node:20-alpine AS js-static
 
+ARG ENVIRONMENT
+ENV ENVIRONMENT=$ENVIRONMENT
 ENV APP_DIR=/srv/app
 ENV NODE_ENV=production
 


### PR DESCRIPTION
This PR fixes production builds being treated as developer builds