### PR TITLE
fix(feedback): correct the permission requirement for removing feedback relation

### DIFF
--- a/apps/events/dashboard/tests.py
+++ b/apps/events/dashboard/tests.py
@@ -69,13 +69,9 @@ class DashboardEventsURLTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_dashboard_remove_feedback_from_event(self):
-        # self.committee = G(Group, name="Arrkom")
         add_permissions(self.user)
 
         event = create_generic_attendance_event()
-        # event = G(Event, event_type=EventType.BEDPRES, organizer=self.committee)
-        # G(AttendanceEvent, event=event)
-
         feedback = Feedback.objects.create(author=self.user)
         TextQuestion.objects.create(feedback=feedback)
         deadline = timezone.now().date() + timedelta(days=4)
@@ -85,17 +81,12 @@ class DashboardEventsURLTestCase(TestCase):
         )
 
         assign_perm("delete_feedbackrelation", self.user, feedbackrelation)
-        # self.user.groups.add(self.committee)
         self.assertTrue(self.user.has_perm("feedback.delete_feedbackrelation"))
 
         url = reverse(
             "dashboard_events_remove_feedback",
             kwargs={"event_id": event.id, "pk": feedback.id},
         )
-        response = self.client.get(url)
+        response = self.client.post(url)
 
-        """
-        django.template.exceptions.TemplateDoesNotExist: feedback/feedbackrelation_confirm_delete.html
-        """
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)

--- a/apps/events/dashboard/tests.py
+++ b/apps/events/dashboard/tests.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 from django_dynamic_fixture import G
+from guardian.shortcuts import assign_perm
 from rest_framework import status
 
 from apps.authentication.models import OnlineUser as User
@@ -68,21 +69,33 @@ class DashboardEventsURLTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_dashboard_remove_feedback_from_event(self):
+        # self.committee = G(Group, name="Arrkom")
         add_permissions(self.user)
-        # Is staff, view_event and add_event, delete_feedbackrelation permissions
+
         event = create_generic_attendance_event()
+        # event = G(Event, event_type=EventType.BEDPRES, organizer=self.committee)
+        # G(AttendanceEvent, event=event)
 
         feedback = Feedback.objects.create(author=self.user)
         TextQuestion.objects.create(feedback=feedback)
         deadline = timezone.now().date() + timedelta(days=4)
 
-        FeedbackRelation.objects.create(
+        feedbackrelation = FeedbackRelation.objects.create(
             feedback=feedback, content_object=event, deadline=deadline, active=True
         )
+
+        assign_perm("delete_feedbackrelation", self.user, feedbackrelation)
+        # self.user.groups.add(self.committee)
+        self.assertTrue(self.user.has_perm("feedback.delete_feedbackrelation"))
 
         url = reverse(
             "dashboard_events_remove_feedback",
             kwargs={"event_id": event.id, "pk": feedback.id},
         )
         response = self.client.get(url)
+
+        """
+        django.template.exceptions.TemplateDoesNotExist: feedback/feedbackrelation_confirm_delete.html
+        """
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/apps/events/dashboard/views.py
+++ b/apps/events/dashboard/views.py
@@ -185,7 +185,9 @@ class AddFeedbackRelationView(DashboardCreatePermissionMixin, CreateView):
 
 class RemoveFeedbackRelationView(DashboardObjectPermissionMixin, DeleteView):
     model = FeedbackRelation
+
     permission_required = "feedback.delete_feedbackrelation"
+    # permission_required = "events.add_attendanceevent"
 
     def get_success_url(self):
         return reverse(

--- a/apps/events/dashboard/views.py
+++ b/apps/events/dashboard/views.py
@@ -185,7 +185,7 @@ class AddFeedbackRelationView(DashboardCreatePermissionMixin, CreateView):
 
 class RemoveFeedbackRelationView(DashboardObjectPermissionMixin, DeleteView):
     model = FeedbackRelation
-    permission_required = "events.add_attendanceevent"
+    permission_required = "feedback.delete_feedbackrelation"
 
     def get_success_url(self):
         return reverse(

--- a/apps/events/dashboard/views.py
+++ b/apps/events/dashboard/views.py
@@ -187,7 +187,6 @@ class RemoveFeedbackRelationView(DashboardObjectPermissionMixin, DeleteView):
     model = FeedbackRelation
 
     permission_required = "feedback.delete_feedbackrelation"
-    # permission_required = "events.add_attendanceevent"
 
     def get_success_url(self):
         return reverse(


### PR DESCRIPTION
### Changes:
- Updated the RemoveFeedbackRelationView which used a permission from the events app, to use the feedback.delete_feedbackrelation permission - This fixes the WrongAppError
- Added a test for removing a feedback from an event
