### PR TITLE
Make dashboard attendance work in parallell

### DIFF
--- a/apps/events/dashboard/utils.py
+++ b/apps/events/dashboard/utils.py
@@ -17,6 +17,7 @@ def event_ajax_handler(event: Event, request):
     administrating_user = request.user
     attendee_id = request.POST.get("attendee_id")
     user_id = request.POST.get("user_id")
+    value = request.POST.get("value") == "true"
 
     if action == "attended":
         attendee = _get_attendee(attendee_id)
@@ -25,7 +26,7 @@ def event_ajax_handler(event: Event, request):
                 "message": f"Fant ingen påmeldte med oppgitt ID ({attendee_id}).",
                 "status": 400,
             }
-        return handle_attended(attendee)
+        return handle_attended(attendee, value)
     elif action == "paid":
         attendee = _get_attendee(attendee_id)
         if not attendee:
@@ -33,7 +34,7 @@ def event_ajax_handler(event: Event, request):
                 "message": f"Fant ingen påmeldte med oppgitt ID ({attendee_id}).",
                 "status": 400,
             }
-        return handle_paid(attendee)
+        return handle_paid(attendee, value)
     elif action == "add_attendee":
         return handle_add_attendee(event, user_id)
     elif action == "remove_attendee":
@@ -42,24 +43,24 @@ def event_ajax_handler(event: Event, request):
         raise NotImplementedError
 
 
-def handle_attended(attendee: Attendee):
+def handle_attended(attendee: Attendee, value: bool):
     """
     Toggle attending-status of an attendee between attending and not attending
     """
-    attendee.attended = not attendee.attended
+    attendee.attended = value
     attendee.save()
 
-    return {"message": "OK", "status": 200}
+    return _get_event_context(attendee.event.event)
 
 
-def handle_paid(attendee: Attendee):
+def handle_paid(attendee: Attendee, value: bool):
     """
     Toggle paid status of an attendee between paid and not paid
     """
-    attendee.paid = not attendee.paid
+    attendee.paid = value
     attendee.save()
 
-    return {"message": "OK", "status": 200}
+    return _get_event_context(attendee.event.event)
 
 
 def _get_attendee_data(attendee_qs):

--- a/apps/events/dashboard/utils.py
+++ b/apps/events/dashboard/utils.py
@@ -45,7 +45,7 @@ def event_ajax_handler(event: Event, request):
 
 def handle_attended(attendee: Attendee, value: bool):
     """
-    Toggle attending-status of an attendee between attending and not attending
+    Set attending-status of an attendee to attending or not attending
     """
     attendee.attended = value
     attendee.save()
@@ -55,7 +55,7 @@ def handle_attended(attendee: Attendee, value: bool):
 
 def handle_paid(attendee: Attendee, value: bool):
     """
-    Toggle paid status of an attendee between paid and not paid
+    Set paid status of an attendee to paid or not paid
     """
     attendee.paid = value
     attendee.save()

--- a/assets/common/utils/dom.js
+++ b/assets/common/utils/dom.js
@@ -43,3 +43,20 @@ export const toggleChecked = (element) => {
     }
   }
 };
+
+export const setChecked = (element, checked) => {
+  const checkedIcon = 'fa-check-square-o';
+  const uncheckedIcon = 'fa-square-o';
+  const allITags = $(element).find('i');
+  const ilen = allITags.length;
+
+  let icon;
+  for (let m = 0; m < ilen; m += 1) {
+    icon = allITags[m];
+    if (checked) {
+      $(icon).addClass('checked').removeClass(uncheckedIcon).addClass(checkedIcon);
+    } else {
+      $(icon).removeClass('checked').removeClass(checkedIcon).addClass(uncheckedIcon);
+    }
+  }
+}

--- a/assets/dashboard/events/events.js
+++ b/assets/dashboard/events/events.js
@@ -1,6 +1,6 @@
 import jQuery from 'jquery';
 import { plainUserTypeahead } from 'common/typeahead';
-import { ajax, showStatusMessage, toggleChecked } from 'common/utils';
+import { ajax, showStatusMessage } from 'common/utils';
 
 /*
   The event module provides dynamic functions to event objects
@@ -87,13 +87,16 @@ const Event = (function PrivateEvent($) {
     });
 
     // Toggle paid and attended
-    $('.toggle-attendee').each(function toggleAttendee() {
-      $(this).on('click', function toggleAttendeeClick() {
+    $('.toggle-attendee').each(function toggleAttendee(_, elem) {
+      let checked = Boolean(elem.querySelector(".checked"));
+      $(this).on('click', function toggleAttendeeClick(e) {
+        e.preventDefault();
+        checked = !checked;
         if ($(this).hasClass('attended')) {
-          Event.attendee.toggle(this, 'attended');
+          Event.attendee.setChecked(this, 'attended', checked);
         }
         if ($(this).hasClass('paid')) {
-          Event.attendee.toggle(this, 'paid');
+          Event.attendee.setChecked(this, 'paid', checked);
         }
       });
     });
@@ -149,14 +152,14 @@ const Event = (function PrivateEvent($) {
 
     // Attendee module, toggles and adding
     attendee: {
-      toggle(cell, action) {
+      setChecked(cell, action, checked) {
         const data = {
           attendee_id: $(cell).data('id'),
           action,
+          value: checked,
         };
-        const success = () => {
-          // var line = $('#' + attendee_id > i)
-          toggleChecked(cell);
+        const success = (eventData) => {
+          drawTable('attendeelist', eventData.attendees, eventData.is_payment_event, eventData.has_extras);
         };
         const error = (xhr, txt, errorMessage) => {
           showStatusMessage(errorMessage, 'alert-danger');


### PR DESCRIPTION
## Description of changes
Changes the attendance taking page on the dashboard to work better when multiple people are on it at the same time (as requested by ArrKom). This works by switching the attended ajax method from toggling to setting the value, and updating the client with new data for all the attendees whenever the user checks or unchecks one attendee.

